### PR TITLE
Phase 66: constraint solver gaps G11/G15/G17/G18/G20

### DIFF
--- a/PExpr.cc
+++ b/PExpr.cc
@@ -626,6 +626,44 @@ bool PEUnary::has_aa_term(Design*des, NetScope*scope) const
       return expr_->has_aa_term(des, scope);
 }
 
+PEConstraintIf::PEConstraintIf(PExpr* cond, std::list<PExpr*>* then_l,
+                               std::list<PExpr*>* else_l)
+: cond_(cond), then_(then_l), else_(else_l)
+{
+}
+
+PEConstraintIf::~PEConstraintIf()
+{
+      delete cond_;
+      if (then_) {
+	    for (auto* e : *then_) delete e;
+	    delete then_;
+      }
+      if (else_) {
+	    for (auto* e : *else_) delete e;
+	    delete else_;
+      }
+}
+
+void PEConstraintIf::dump(std::ostream& out) const
+{
+      out << "(constraint-if ";
+      cond_->dump(out);
+      out << " ...)";
+}
+
+NetExpr* PEConstraintIf::elaborate_expr(Design*, NetScope*,
+                                        ivl_type_t, unsigned) const
+{
+      return nullptr;
+}
+
+NetExpr* PEConstraintIf::elaborate_expr(Design*, NetScope*,
+                                        unsigned, unsigned) const
+{
+      return nullptr;
+}
+
 PEVoid::PEVoid()
 {
 }

--- a/PExpr.h
+++ b/PExpr.h
@@ -1283,6 +1283,32 @@ class PEInside : public PExpr {
 };
 
 /*
+ * G17 (Phase 66): if-block constraint.  Carries (cond, then_list, else_list)
+ * for `if(cond) { A; B; } else { C; }` in a constraint body.
+ * Lowered to (implies cond AND(then)) and (implies !cond AND(else)) in IR.
+ */
+class PEConstraintIf : public PExpr {
+    public:
+      PEConstraintIf(PExpr* cond, std::list<PExpr*>* then_l,
+                     std::list<PExpr*>* else_l);
+      ~PEConstraintIf() override;
+
+      PExpr* get_cond() const { return cond_; }
+      const std::list<PExpr*>* get_then() const { return then_; }
+      const std::list<PExpr*>* get_else() const { return else_; }
+
+      void dump(std::ostream& out) const override;
+      NetExpr* elaborate_expr(Design* des, NetScope* scope,
+                              ivl_type_t type, unsigned flags) const override;
+      NetExpr* elaborate_expr(Design* des, NetScope* scope,
+                              unsigned expr_wid, unsigned flags) const override;
+    private:
+      PExpr* cond_;
+      std::list<PExpr*>* then_;
+      std::list<PExpr*>* else_;  // may be null
+};
+
+/*
  * This class is used for error recovery. All methods do nothing and return
  * null or default values.
  */

--- a/docs/claude/uvm_gap_plan.md
+++ b/docs/claude/uvm_gap_plan.md
@@ -265,7 +265,7 @@ Then:
 |---|---|---|
 | 64 chunk-boundary RC | **COMPLETED** | see claude/phase-64; fix in vvp/vthread.cc of_FORK/of_FORK_V |
 | 65 quick-wins | **COMPLETED** | see claude/phase-65; G38/G44/G47/G48/G49 fixed; G19/G45 RESOLVED-BY-PRIOR; 98/98 PASS |
-| 66 constraint solver | not started | |
+| 66 constraint solver | **COMPLETED** | see claude/phase-66; G11/G15/G17/G18/G20 fixed; G16/G21 deferred; 102/102 PASS |
 | 67 UVM core flows | not started | |
 | 68 SVA expansion | not started | |
 | 69 streaming/structs | not started | |
@@ -279,6 +279,35 @@ Then:
 # Working notes (agent appends)
 
 Each session appends ONE entry at the TOP of this section (newest first). Format below — copy-paste the template, fill in the fields, then add your entry above any prior ones.
+
+## 2026-05-05 — Phase 66 — COMPLETED constraint solver gaps
+
+**Branch**: `claude/phase-66`
+**Regression**: 102/102 passed, 0 failed, 0 skipped (up from 98; 4 new tests added)
+
+### What I did
+- **G15/G11** — Implication `A -> B` constraint: added `'q'` case to `pexpr_to_constraint_ir` (elaborate.cc) and `"implies"` handler in `vvp/vvp_z3.cc` using `Z3_mk_implies`. Also added `"mul"`, `"add"`, `"sub"` arithmetic ops to Z3 backend (needed for G20).
+- **G18** — `inside {enum_set}` excluded values: in `pexpr_to_constraint_ir`, detect when the inside subject is an enum-typed class property and resolve unresolved identifiers (PEIdent) against that enum's name table (`netenum_t::find_name`). ~20 lines in elaborate.cc.
+- **G17** — if-block constraint: added new `PEConstraintIf` class (PExpr.h/PExpr.cc) carrying (cond, then_list, else_list). Added `%type <exprs>` grammar types for `constraint_set` and `constraint_expression_list` in parse.y; K_if rules now create PEConstraintIf nodes instead of returning nullptr. Lowered to `(implies cond AND(then))` and `(implies (not cond) AND(else))` IR in `pexpr_to_constraint_ir`.
+- **G20** — cross-class constraint (child refs parent property): changed `of_RANDOMIZE` and `of_RANDOMIZE_WITH` in `vvp/vthread.cc` to gather ancestor constraint IRs into `extra_ir` for a single joint `vvp_z3_randomize` call instead of independent calls per class in the chain.
+- **G19** — already passes (was fixed by Phase 65 or works with existing Z3 soft-weight machinery).
+- **Tests added**: `g11_g15_implication_test.sv`, `g17_if_constraint_test.sv`, `g18_enum_inside_test.sv`, `g20_cross_class_constraint_test.sv`.
+
+### Root causes
+- G15/G11: `PEBLogic('q')` (op for `->`) fell through to `default: return ""` in `pexpr_to_constraint_ir`; Z3 IR had no implies op.
+- G18: enum literal names (RED, BLUE, etc.) are PEIdent nodes not matching any class property → returned "" → range silently dropped from inside constraint.
+- G17: K_if rules in constraint_expression returned nullptr, dropping the entire if-block.
+- G20: Independent Z3 calls per class in the hierarchy meant child constraint `y==x*2` was solved without P's `x inside {[1:50]}` — two Z3 contexts couldn't share property solutions.
+
+### What I left undone
+- **G16** — `foreach(arr[i]) arr[i] inside {[i*10:...]}`: requires runtime expansion of foreach over array indices before Z3. Deferred; parser rule still drops foreach constraint.
+- **G21** — `arr.size() == sz` randomize for dynamic arrays: requires runtime resize hook before Z3. Deferred.
+
+### Deferred / new follow-ups discovered
+None.
+
+### Next session pointer
+Phase 67 (UVM core flows: G22 factory.create_object_by_name, G24 config_db class obj, G25 field_sarray, G23 register_cb).
 
 ## 2026-05-03 (session 3) — Phase 65 — COMPLETED quick-wins
 

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -10062,6 +10062,19 @@ string pexpr_to_constraint_ir(const PExpr*expr,
 	    // `(dist <expr> (b W <range>) ...)` where W is the literal
 	    // weight integer.  Plain inside emits the existing form.
 	    bool is_dist = ins->is_dist();
+
+	    // G18: if subject is an enum-typed class property, resolve enum
+	    // name identifiers in the range list to their numeric values.
+	    const netenum_t* subj_enum = nullptr;
+	    if (const PEIdent*sid = dynamic_cast<const PEIdent*>(ins->get_expr())) {
+		  perm_string sname = sid->path().back().name;
+		  int sidx = cls->property_idx_from_name(sname);
+		  if (sidx >= 0) {
+			ivl_type_t stype = cls->get_prop_type((size_t)sidx);
+			subj_enum = dynamic_cast<const netenum_t*>(stype);
+		  }
+	    }
+
 	    string result = is_dist ? "(dist " : "(inside ";
 	    result += s;
 	    for (auto& r : ins->get_ranges()) {
@@ -10073,6 +10086,16 @@ string pexpr_to_constraint_ir(const PExpr*expr,
 			range_ir = "[" + lo + "," + hi + "]";
 		  } else {
 			string v = pexpr_to_constraint_ir(r.hi, cls, value_slots);
+			// G18: if v is empty and subject is enum-typed, try to
+			// resolve the identifier as an enum literal name.
+			if (v.empty() && subj_enum) {
+			      if (const PEIdent*eid = dynamic_cast<const PEIdent*>(r.hi)) {
+				    perm_string ename = eid->path().back().name;
+				    netenum_t::iterator it = subj_enum->find_name(ename);
+				    if (it != subj_enum->end_name())
+					  v = "c:" + std::to_string(it->second.as_unsigned());
+			      }
+			}
 			if (v.empty()) continue;
 			range_ir = v;
 		  }
@@ -10109,6 +10132,8 @@ string pexpr_to_constraint_ir(const PExpr*expr,
 		case 'o': op = "or";  break;  // || (K_LOR)
 		case '+': op = "add"; break;
 		case '-': op = "sub"; break;
+		case '*': op = "mul"; break;
+		case 'q': op = "implies"; break;  // -> (K_TRIGGER, implication)
 		default:  return "";
 	    }
 	    return "(" + op + " " + left + " " + right + ")";
@@ -10119,6 +10144,45 @@ string pexpr_to_constraint_ir(const PExpr*expr,
 	    if (sub.empty()) return "";
 	    if (un->get_op() == '!') return "(not " + sub + ")";
 	    return "";
+      }
+
+      // G17 (Phase 66): if-block constraint → (implies cond then) [&& (implies !cond else)]
+      if (const PEConstraintIf*cif = dynamic_cast<const PEConstraintIf*>(expr)) {
+	    string cond_s = pexpr_to_constraint_ir(cif->get_cond(), cls, value_slots);
+	    if (cond_s.empty()) return "";
+
+	    // Build AND of then-branch items: each item implies cond
+	    string then_ir;
+	    if (cif->get_then()) {
+		  for (auto* item : *cif->get_then()) {
+			if (!item) continue;
+			string s = pexpr_to_constraint_ir(item, cls, value_slots);
+			if (s.empty()) continue;
+			then_ir = then_ir.empty() ? s
+			        : "(and " + then_ir + " " + s + ")";
+		  }
+	    }
+	    string result = then_ir.empty() ? ""
+	                  : "(implies " + cond_s + " " + then_ir + ")";
+
+	    // Build AND of else-branch items: each item implies !cond
+	    if (cif->get_else() && !cif->get_else()->empty()) {
+		  string else_ir;
+		  for (auto* item : *cif->get_else()) {
+			if (!item) continue;
+			string s = pexpr_to_constraint_ir(item, cls, value_slots);
+			if (s.empty()) continue;
+			else_ir = else_ir.empty() ? s
+			        : "(and " + else_ir + " " + s + ")";
+		  }
+		  if (!else_ir.empty()) {
+			string not_cond = "(not " + cond_s + ")";
+			string else_clause = "(implies " + not_cond + " " + else_ir + ")";
+			result = result.empty() ? else_clause
+			       : "(and " + result + " " + else_clause + ")";
+		  }
+	    }
+	    return result;
       }
 
       return "";

--- a/parse.y
+++ b/parse.y
@@ -1204,6 +1204,7 @@ Module::port_t *module_declare_port(const YYLTYPE&loc, char *id,
 
 %type <expr>  constraint_expression constraint_block_item
 %type <exprs> constraint_block_item_list constraint_block_item_list_opt
+%type <exprs> constraint_set constraint_expression_list
 
 %type <decl_assignment> variable_decl_assignment
 %type <decl_assignments> list_of_variable_decl_assignments
@@ -2580,12 +2581,17 @@ constraint_expression /* IEEE1800-2005 A.1.9 */
       }
   | expression constraint_trigger
       { $$ = $1; }
+  /* G17 (Phase 66): if-block constraint — lower to PEConstraintIf so
+     pexpr_to_constraint_ir can emit (implies cond ...) in the Z3 IR. */
   | K_if '(' expression ')' constraint_set %prec less_than_K_else
-      { $$ = nullptr; }
+      { PEConstraintIf*tmp = new PEConstraintIf($3, $5, nullptr);
+        FILE_NAME(tmp, @1); $$ = tmp; }
   | K_if '(' expression ')' constraint_set K_else constraint_set
-      { $$ = nullptr; }
+      { PEConstraintIf*tmp = new PEConstraintIf($3, $5, $7);
+        FILE_NAME(tmp, @1); $$ = tmp; }
   | K_foreach '(' IDENTIFIER '[' loop_variables ']' ')' constraint_set
-      { $$ = nullptr; delete[] $3; }
+      { $$ = nullptr; delete[] $3;
+        if ($8) { for (auto*e : *$8) delete e; delete $8; } }
   /* I4 (Phase 62c): soft constraint — wrap in PESoft so the IR emitter
      marks it for Z3_optimize_assert_soft (default weight 1).  Other
      contexts (non-constraint elaboration) delegate through to the inner
@@ -2663,11 +2669,19 @@ dist_item
 
 constraint_trigger
   : K_CONSTRAINT_IMPL '{' constraint_expression_list '}'
+      { /* Trigger consequent: ignore the list for now (semantics TBD). */
+        if ($3) {
+              for (auto*e : *$3) delete e;
+              delete $3;
+        }
+      }
   ;
 
-constraint_expression_list /* */
+constraint_expression_list /* G17: typed so K_if can use it */
   : constraint_expression_list constraint_expression
+      { if ($2) $1->push_back($2); $$ = $1; }
   | constraint_expression
+      { $$ = new std::list<PExpr*>(); if ($1) $$->push_back($1); }
   ;
 
 constraint_prototype /* IEEE1800-2005: A.1.9 */
@@ -2680,9 +2694,11 @@ constraint_prototype /* IEEE1800-2005: A.1.9 */
       { /* silently accept extern static constraint prototype */ delete[] $4; }
   ;
 
-constraint_set /* IEEE1800-2005 A.1.9 */
+constraint_set /* G17: typed, returns list of constraint expressions */
   : constraint_expression
+      { $$ = new std::list<PExpr*>(); if ($1) $$->push_back($1); }
   | '{' constraint_expression_list '}'
+      { $$ = $2; }
   ;
 
 /* ========= Covergroup grammar (functional coverage) ========= */

--- a/tests/g11_g15_implication_test.sv
+++ b/tests/g11_g15_implication_test.sv
@@ -1,0 +1,31 @@
+// G11/G15 (Phase 66): implication constraint A -> B
+// Tests `(cond) -> (consequence)` in class constraint blocks.
+class Foo;
+  rand int x;
+  rand int y;
+  constraint c {
+    x inside {[0:1]};
+    (x == 0) -> (y == 99);
+    (x == 1) -> (y inside {[200:300]});
+  }
+endclass
+
+module top;
+  Foo f;
+  int ok, fail;
+  initial begin
+    f = new;
+    ok = 0; fail = 0;
+    repeat (20) begin
+      void'(f.randomize());
+      if (f.x == 0 && f.y != 99) fail++;
+      else if (f.x == 1 && (f.y < 200 || f.y > 300)) fail++;
+      else ok++;
+    end
+    if (fail == 0)
+      $display("PASS: implication constraints hold (%0d iterations)", ok);
+    else
+      $display("FAIL: %0d implication violations (last x=%0d y=%0d)", fail, f.x, f.y);
+    $finish;
+  end
+endmodule

--- a/tests/g17_if_constraint_test.sv
+++ b/tests/g17_if_constraint_test.sv
@@ -1,0 +1,40 @@
+// G17 (Phase 66): if-block constraint
+// Tests `if(cond) { A; B; } else { C; }` in constraint blocks.
+class Foo;
+  rand int x;
+  rand int y;
+  rand int z;
+  constraint c {
+    x inside {[0:1]};
+    if (x == 0) {
+      y inside {[100:200]};
+      z inside {[10:20]};
+    } else {
+      y inside {[500:600]};
+      z == 99;
+    }
+  }
+endclass
+
+module top;
+  Foo f;
+  int fail;
+  initial begin
+    f = new; fail = 0;
+    repeat (20) begin
+      void'(f.randomize());
+      if (f.x == 0) begin
+        if (f.y < 100 || f.y > 200) fail++;
+        if (f.z < 10  || f.z > 20)  fail++;
+      end else begin
+        if (f.y < 500 || f.y > 600) fail++;
+        if (f.z != 99)               fail++;
+      end
+    end
+    if (fail == 0)
+      $display("PASS: if-block constraint works");
+    else
+      $display("FAIL: %0d violations (x=%0d y=%0d z=%0d)", fail, f.x, f.y, f.z);
+    $finish;
+  end
+endmodule

--- a/tests/g18_enum_inside_test.sv
+++ b/tests/g18_enum_inside_test.sv
@@ -1,0 +1,29 @@
+// G18 (Phase 66): inside {enum_set} constraint — excluded values not picked
+// Tests that `c inside {RED, BLUE, MAGENTA}` rejects GREEN and YELLOW.
+typedef enum int { RED=0, GREEN=1, BLUE=2, YELLOW=3, MAGENTA=4 } color_t;
+
+class Foo;
+  rand color_t c;
+  constraint pick_some { c inside {RED, BLUE, MAGENTA}; }
+endclass
+
+module top;
+  Foo f;
+  int ok, fail;
+  initial begin
+    f = new; ok = 0; fail = 0;
+    repeat (30) begin
+      void'(f.randomize());
+      if (f.c == RED || f.c == BLUE || f.c == MAGENTA) ok++;
+      else begin
+        fail++;
+        $display("  excluded value picked: %s (%0d)", f.c.name(), f.c);
+      end
+    end
+    if (fail == 0)
+      $display("PASS: inside {enum_set} excludes unwanted values (%0d ok)", ok);
+    else
+      $display("FAIL: %0d excluded values picked, %0d correct", fail, ok);
+    $finish;
+  end
+endmodule

--- a/tests/g20_cross_class_constraint_test.sv
+++ b/tests/g20_cross_class_constraint_test.sv
@@ -1,0 +1,30 @@
+// G20 (Phase 66): child class constraint referencing parent rand property
+// Tests that `y == x * 2` (child constraint) is solved jointly with
+// `x inside {[1:50]}` (parent constraint).
+class P;
+  rand int x;
+  constraint cP { x inside {[1:50]}; }
+endclass
+
+class C extends P;
+  rand int y;
+  constraint cC { y == x * 2; }
+endclass
+
+module top;
+  C c;
+  int fail;
+  initial begin
+    c = new; fail = 0;
+    repeat (20) begin
+      void'(c.randomize());
+      if (c.x < 1 || c.x > 50) begin fail++; end
+      if (c.y != c.x * 2)      begin fail++; end
+    end
+    if (fail == 0)
+      $display("PASS: cross-class constraint solved jointly (x=%0d y=%0d)", c.x, c.y);
+    else
+      $display("FAIL: %0d violations (x=%0d y=%0d)", fail, c.x, c.y);
+    $finish;
+  end
+endmodule

--- a/vvp/vthread.cc
+++ b/vvp/vthread.cc
@@ -2154,15 +2154,28 @@ bool of_RANDOMIZE(vthread_t thr, vvp_code_t)
 		  cobj->set_vec4(pid, val);
 	    }
 
-	      // Solve constraints with Z3 for this class AND every base
-	      // class in the inheritance chain. Without walking the chain,
-	      // a constraint declared on a base class's rand property is
-	      // silently dropped when the runtime instance is a derived
-	      // class, leaving those properties with raw rand() values that
-	      // ignore inside-range / equality constraints.
-	    for (const class_type*walker = defn; walker; walker = walker->runtime_super()) {
-		  if (walker->constraint_count() > 0)
-			vvp_z3_randomize(walker, cobj);
+	      // G20 (Phase 66): Solve ALL constraints from the entire class
+	      // hierarchy in a SINGLE Z3 call so cross-class constraints
+	      // (e.g. child's `y == x*2` referencing parent's rand `x`) are
+	      // solved jointly.  Separate calls see independent Z3 contexts and
+	      // can clobber each other's solutions.
+	      // Property indices are absolute (include ancestor offsets), so all
+	      // IRs from the hierarchy share the same "p:N" namespace.
+	    {
+		  bool any_constraints = false;
+		  for (const class_type*w = defn; w; w = w->runtime_super())
+			if (w->constraint_count() > 0) { any_constraints = true; break; }
+		  if (any_constraints) {
+			// Collect ancestor IRs (skip defn — vvp_z3_randomize handles it)
+			vector<string> hier_ir;
+			for (const class_type*w = defn->runtime_super(); w; w = w->runtime_super()) {
+			      for (size_t ci = 0; ci < w->constraint_count(); ++ci) {
+				    const string& ir = w->constraint_ir(ci);
+				    if (!ir.empty()) hier_ir.push_back(ir);
+			      }
+			}
+			vvp_z3_randomize(defn, cobj, hier_ir);
+		  }
 	    }
       }
 
@@ -2247,8 +2260,14 @@ bool of_RANDOMIZE_WITH(vthread_t thr, vvp_code_t code)
 		  cobj->set_vec4(pid, val);
 	    }
 
-	      // Solve with Z3: class constraints + with-constraints.
+	      // G20: Solve with Z3: class constraints + ancestor IRs + with-constraints.
 	    vector<string> extra_ir;
+	    for (const class_type*w = defn->runtime_super(); w; w = w->runtime_super()) {
+		  for (size_t ci = 0; ci < w->constraint_count(); ++ci) {
+			const string& ir = w->constraint_ir(ci);
+			if (!ir.empty()) extra_ir.push_back(ir);
+		  }
+	    }
 	    if (ir_text && *ir_text) extra_ir.push_back(string(ir_text));
 	    vvp_z3_randomize(defn, cobj, extra_ir, slot_vals);
       }

--- a/vvp/vvp_z3.cc
+++ b/vvp/vvp_z3.cc
@@ -385,6 +385,30 @@ static Z3_ast build_z3_expr(IRParser& par, Z3Builder& b)
 	    return Z3_mk_or(b.ctx, (unsigned)hard_clauses.size(), hard_clauses.data());
       }
 
+      // G15/G11: implication A -> B  (cond -> cons)
+      if (op == "implies") {
+	    Z3_ast ant = bv_to_bool(b.ctx, build_z3_atom(par, b));
+	    Z3_ast con = bv_to_bool(b.ctx, build_z3_atom(par, b));
+	    par.skip_ws(); par.expect(')');
+	    return Z3_mk_implies(b.ctx, ant, con);
+      }
+
+      // Arithmetic: add, sub, mul — used in equality constraints like y == x*2.
+      if (op == "add" || op == "sub" || op == "mul") {
+	    Z3_ast left  = build_z3_atom(par, b);
+	    Z3_ast right = build_z3_atom(par, b);
+	    par.skip_ws(); par.expect(')');
+	    unsigned lw = bv_width(b.ctx, left);
+	    unsigned rw = bv_width(b.ctx, right);
+	    if (lw != rw) {
+		  if (rw < lw) right = Z3_mk_zero_ext(b.ctx, lw - rw, right);
+		  else         left  = Z3_mk_zero_ext(b.ctx, rw - lw, left);
+	    }
+	    if (op == "add") return Z3_mk_bvadd(b.ctx, left, right);
+	    if (op == "sub") return Z3_mk_bvsub(b.ctx, left, right);
+	    return Z3_mk_bvmul(b.ctx, left, right);
+      }
+
       // Unknown operator — skip to matching ')' and return true
       int depth = 1;
       while (!par.at_end() && depth > 0) {


### PR DESCRIPTION
## Summary

Closes constraint solver gaps G11, G15, G17, G18, G20 from the gap audit.

- **G15/G11 — Implication `A -> B`**: `pexpr_to_constraint_ir` now emits `(implies left right)` for PEBLogic op `'q'` (K_TRIGGER). Z3 backend handles it with `Z3_mk_implies`. Also adds `mul`/`add`/`sub` arithmetic ops.
- **G18 — `inside {enum_set}` excluded values picked**: When the inside subject is an enum-typed class property, PEIdent range items are resolved against `netenum_t::find_name` to get their numeric values.
- **G17 — if-block constraint silently dropped**: New `PEConstraintIf` AST node; parser K_if rules now create it instead of returning nullptr. Lowered in `pexpr_to_constraint_ir` to `(implies cond AND(then))` / `(implies (not cond) AND(else))`.
- **G20 — child constraint referencing parent rand property**: `of_RANDOMIZE` and `of_RANDOMIZE_WITH` now gather all ancestor constraint IRs into `extra_ir` for a single joint Z3 call.

Deferred: G16 (foreach constraint expansion — deep), G21 (dynamic array size — separate mechanism).

## Test plan

- [ ] `g11_g15_implication_test` — implication `A -> B` in constraints
- [ ] `g17_if_constraint_test` — if/else constraint block
- [ ] `g18_enum_inside_test` — `inside {RED, BLUE, MAGENTA}` excludes GREEN/YELLOW
- [ ] `g20_cross_class_constraint_test` — child `y == x*2` + parent `x inside {[1:50]}`
- [ ] Full regression: 102/102 passed, 0 failed, 0 skipped

https://claude.ai/code/session_01JZagZ5k2LQiZQKaC3Q6gaK

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZagZ5k2LQiZQKaC3Q6gaK)_