### PR TITLE
Phase 70: COMPLETED — modport + interface arrays (G26/G27/G28/G29/G55)

### DIFF
--- a/docs/claude/uvm_gap_plan.md
+++ b/docs/claude/uvm_gap_plan.md
@@ -280,6 +280,22 @@ Then:
 
 Each session appends ONE entry at the TOP of this section (newest first). Format below — copy-paste the template, fill in the fields, then add your entry above any prior ones.
 
+## 2026-05-06 (session 5) — Phase 70 — re-marker (merge commits buried COMPLETED invariant)
+
+**Branch**: `claude/phase-70`
+**Regression**: 110/110 passed, 0 failed, 0 skipped
+
+### What I did
+- Phase 70 was already fully completed in the prior session (commit `a20565c`).
+- A subsequent merge commit (`a9cb11a` — Merge branch 'development' into claude/phase-70) landed on top of the COMPLETED commit, so the branch tip no longer matched the `Phase 70: COMPLETED ...` invariant that the phase-detection state machine relies on.
+- No code changes needed; this commit is a pure re-marker to restore the invariant.
+
+### Root cause
+Same pattern as phases 68 and 69: a development-branch merge was applied after the COMPLETED commit, burying the done marker.
+
+### What I left undone
+Nothing — Phase 70 work was fully done in the prior session.
+
 ## 2026-05-06 (session 4) — Phase 70 — COMPLETED modport + interface arrays
 
 **Branch**: `claude/phase-70`


### PR DESCRIPTION
## Summary

- Removes unnecessary `sorry:` barriers for modport task/function ports (G26/G55) in `parse.y`
- G27/G28 probed and confirmed RESOLVED-BY-PRIOR (scope-based elaboration already handles these)
- G29: Fixed `elaborate_lnet_common_` in `elab_net.cc` to synthesize a typed WIRE for interface instances with explicit port connections when `symbol_search` resolves to a modport scope
- Re-marker commit added to restore the `Phase NN: COMPLETED` branch-tip invariant after a development-merge buried it

## Regression

110/110 passed, 0 failed, 0 skipped

## Test plan

- [ ] `tests/p55_modport_func_test.sv` — G26 modport import task/function
- [ ] `tests/p99_iface_modport_bind_test.sv` — G27 interface modport bind (RESOLVED-BY-PRIOR)
- [ ] `tests/p21_iface_array_test.sv` — G28 interface arrays (RESOLVED-BY-PRIOR)
- [ ] `tests/p43_iface_inh_test.sv` — G29 interface with explicit port connections
- [ ] Full regression: 110/110 PASS

https://claude.ai/code/session_01Qz4kULKY5g41h2jw4Ly78x

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz4kULKY5g41h2jw4Ly78x)_