### PR TITLE
Phase 75: compile-progress fallback hardening (13 silent fallbacks warned)

### DIFF
--- a/docs/claude/uvm_gap_plan.md
+++ b/docs/claude/uvm_gap_plan.md
@@ -275,11 +275,55 @@ Then:
 | 72 parser sorry cleanup | not started | |
 | 73 DPI open-array | not started | |
 | 74 perf hardening | not started | |
-| 75 fallback hardening | not started | |
+| 75 fallback hardening | **COMPLETED** | see claude/phase-75; 13 silent fallbacks warned; 119/119 PASS |
 
 # Working notes (agent appends)
 
 Each session appends ONE entry at the TOP of this section (newest first). Format below — copy-paste the template, fill in the fields, then add your entry above any prior ones.
+
+## 2026-05-07 — Phase 75 — COMPLETED compile-progress fallback hardening
+
+**Branch**: `claude/phase-75`
+**Regression**: 119/119 passed, 0 failed, 0 skipped (vs baseline 119/0/0)
+
+### What I did
+Audited all 45 compile-progress fallback sites identified in the gap audit. Added `debug_elaborate`-gated warning messages to 13 previously-silent fallback sites across 5 files:
+
+- **net_func_eval.cc:261** `NetProc::evaluate_function` base class — unsupported statement kinds in constant function evaluation silently returned true; added debug warning with type name.
+- **net_func_eval.cc:365** `NetAssign::eval_func_lval_` — non-local l-values in constant function eval silently ignored; added debug warning with variable name.
+- **netmisc.cc:828** `elab_and_eval` — class/null r-value coerced to scalar/null placeholder in non-class context; added debug warning with cast_type.
+- **netmisc.cc:933** `elab_and_eval` — class-typed context received non-class expression; coerced to null; added debug warning.
+- **netmisc.cc:949** `elab_and_eval` — parameterized method lost argument typing; added debug warning with expr/cast types.
+- **netmisc.cc:1094** `elaborate_rval_expr` — class-target expression has non-class type in switch default; added debug warning.
+- **netmisc.cc:1120** `elaborate_rval_expr` — UVM container/helper typing lost (second gn_sv fallback block); added debug warning.
+- **elab_expr.cc:879** `PEAssign::elaborate_expr` — integer constant assigned to enum lvalue without explicit cast; added debug warning.
+- **elab_expr.cc:883** `PEAssign::elaborate_expr` — non-enum vectorable type assigned to enum lvalue; added debug warning.
+- **elab_expr.cc:1124** `PEAssignPattern::elaborate_expr_packed_` — element count mismatch vs 32-bit dimension (UVM macro artefact); added debug warning.
+- **elab_expr.cc:1132** `PEAssignPattern::elaborate_expr_packed_` — flattened multi-dim packed slice pattern; added debug warning with slice width.
+- **vvp/vvp_darray.cc:1033** `vvp_queue_object::set_word` — sparse queue<object> store beyond size; added once-warned runtime warning.
+- **elaborate.cc:4523** `PCondit::elaborate` — condition expression failed to elaborate; empty/else fallback; added debug warning.
+
+Sites already having warnings (no change needed):
+- elab_lval.cc:1393, netmisc.cc:1687, elab_expr.cc:1333/5338/5387 — all already emit cerr warnings.
+- elab_sig.cc:1088 — already emits void-fallback warning.
+- net_link.cc:455 — already has assert+error on null.
+- vvp/vthread.cc:1482/12603/13263/13627/13683 — all already emit cerr warnings.
+- elab_expr.cc compile_progress_expr_method_stub system (3140 etc.) — full warning infrastructure.
+- vvp/vvp_darray.cc pre-1033 queue path — already handled.
+- net_func_eval.cc 1168/1179/1303 — function body comment-only; no silent action path.
+- net_expr.cc:462 — informational fallback, no incorrect value produced.
+
+### Root causes
+The 13 patched sites were silent "degrade-and-continue" paths where UVM's parameterized class hierarchy causes type information to be lost during elaboration. Iverilog substitutes typed placeholders (null/zero/empty-string) to keep compilation moving, but without any diagnostic. Now `debug_elaborate=1` makes all such substitutions visible.
+
+### What I left undone
+None — all 45 sites triaged; acceptance criteria met (45 audited, 13 warnings added ≥ 10 required).
+
+### Deferred / new follow-ups discovered
+None.
+
+### Next session pointer
+Phase 75 complete. Plan range 64-75 exhausted; next agent session should extend the phase list or declare all-complete.
 
 ## 2026-05-06 — Phase 68 — COMPLETED re-marker (merge commits buried prior COMPLETED invariant)
 

--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -879,12 +879,20 @@ NetExpr* elaborate_rval_expr(Design*des, NetScope*scope, ivl_type_t lv_net_type,
 		    // Compile-progress fallback: unresolved UVM enum-producing
 		    // calls/macros often collapse to integral placeholder constants.
 		    // Allow elaboration to continue and surface later semantic issues.
+		    if (debug_elaborate)
+			  cerr << expr->get_fileline() << ": debug: "
+			       << "integer constant assigned to enum lvalue without explicit cast"
+			       << " (compile-progress fallback)." << endl;
 	      } else if (gn_system_verilog()) {
 		    // Compile-progress fallback: enum assignments in complex macro
 		    // expansions (e.g. UVM resource macros) may lose type information
 		    // through intermediate casts. Allow if vectorable.
 		    if (type_is_vectorable(rval->expr_type())) {
 			  // Type-compatible integral value, allow assignment
+			  if (debug_elaborate)
+				cerr << expr->get_fileline() << ": debug: "
+				     << "non-enum vectorable type assigned to enum lvalue without explicit cast"
+				     << " (compile-progress fallback)." << endl;
 		    } else {
 		      cerr << expr->get_fileline() << ": error: "
 				"This assignment requires an explicit cast." << endl;
@@ -1127,6 +1135,11 @@ NetExpr* PEAssignPattern::elaborate_expr_packed_(Design *des, NetScope *scope,
 	    // (expected elements == width of integer), likely a misparse.
 	    if (gn_system_verilog() && dims[cur_dim].width() == 32
 		&& parms_.size() <= 8) {
+		  if (debug_elaborate)
+			cerr << get_fileline() << ": debug: "
+			     << "packed assignment pattern element count (" << parms_.size()
+			     << ") mismatch vs 32-bit dimension; treating as UVM macro artefact"
+			     << " (compile-progress fallback)." << endl;
 	    } else if (parms_.size() != 0
 		       && dims[cur_dim].width() % parms_.size() == 0) {
 	      // Compile-progress fallback for flattened multi-dim packed
@@ -1137,6 +1150,13 @@ NetExpr* PEAssignPattern::elaborate_expr_packed_(Design *des, NetScope *scope,
 	      // and continue. This is incorrect for true assignment-pattern
 	      // semantics (no broadcast / repeat) but is sufficient for
 	      // compile-only consumers such as unused cipher SBOX tables.
+		  if (debug_elaborate)
+			cerr << get_fileline() << ": debug: "
+			     << "packed assignment pattern has " << parms_.size()
+			     << " elements vs " << dims[cur_dim].width()
+			     << "-bit dimension; treating as "
+			     << (dims[cur_dim].width()/parms_.size())
+			     << "-bit slices (compile-progress fallback)." << endl;
 	    } else {
 		  cerr << get_fileline() << ": error: Packed array assignment pattern expects "
 		       << dims[cur_dim].width() << " element(s) in this context.\n"

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -4531,6 +4531,11 @@ NetProc* PCondit::elaborate(Design*des, NetScope*scope) const
 	    // If in SystemVerilog mode and inside a function, assume the
 	    // condition is false and continue elaboration as a no-op.
 	    if (gn_system_verilog()) {
+		  if (debug_elaborate)
+			cerr << get_fileline() << ": debug: "
+			     << "condition expression failed to elaborate; "
+			     << (else_ ? "using else branch" : "using empty block")
+			     << " as fallback (compile-progress fallback)." << endl;
 		  // Elaborate only the else branch (if present) or return empty block
 		  if (else_)
 			return else_->elaborate(des, scope);

--- a/net_func_eval.cc
+++ b/net_func_eval.cc
@@ -255,11 +255,17 @@ NetExpr* NetExpr::evaluate_function(const LineInfo&,
       return 0;
 }
 
-bool NetProc::evaluate_function(const LineInfo&,
+bool NetProc::evaluate_function(const LineInfo&loc,
 				map<perm_string,LocalVar>&) const
 {
       // Compile-progress fallback: unsupported statement kinds in constant
       // function evaluation are treated as no-ops.
+      if (debug_elaborate) {
+	    cerr << loc.get_fileline() << ": debug: "
+		 << "unsupported statement type \"" << typeid(*this).name()
+		 << "\" in constant function evaluation; treated as no-op"
+		 << " (compile-progress fallback)." << endl;
+      }
       return true;
 }
 
@@ -364,6 +370,12 @@ bool NetAssign::eval_func_lval_(const LineInfo&loc,
 	    if (gn_system_verilog()) {
 		  // Compile-progress fallback: unresolved/non-local l-values
 		  // in constant-function evaluation are ignored.
+		  if (debug_elaborate) {
+			cerr << loc.get_fileline() << ": debug: "
+			     << "non-local l-value \"" << lval->name()
+			     << "\" in constant function evaluation ignored"
+			     << " (compile-progress fallback)." << endl;
+		  }
 		  delete rval_result;
 		  return true;
 	    }

--- a/netmisc.cc
+++ b/netmisc.cc
@@ -829,6 +829,11 @@ NetExpr* elab_and_eval(Design*des, NetScope*scope, PExpr*pe,
 		  // class handles through scalar/string/real contexts before full
 		  // type information is available.
 		  if (!need_const) {
+			if (debug_elaborate)
+			      cerr << pe->get_fileline() << ": debug: "
+				   << "class/null r-value coerced to scalar/null placeholder"
+				   << " in cast_type=" << cast_type
+				   << " context (compile-progress fallback)." << endl;
 			if (cast_type == IVL_VT_BOOL || cast_type == IVL_VT_LOGIC) {
 			      NetEConst*tmp = make_const_0(1);
 			      tmp->set_line(*pe);
@@ -934,6 +939,11 @@ NetExpr* elab_and_eval(Design*des, NetScope*scope, PExpr*pe,
 		  // class-typed but expression typing arrived as non-class
 		  // (common with parameterized UVM container wrappers),
 		  // degrade to null and keep elaboration moving.
+		  if (debug_elaborate)
+			cerr << pe->get_fileline() << ": debug: "
+			     << "class-typed context received non-class expression (type="
+			     << tmp->expr_type() << "); coerced to null"
+			     << " (compile-progress fallback)." << endl;
 		  NetENull*stub = new NetENull();
 		  stub->set_line(*tmp);
 		  delete tmp;
@@ -948,6 +958,12 @@ NetExpr* elab_and_eval(Design*des, NetScope*scope, PExpr*pe,
 	    if (gn_system_verilog() && !need_const && !normal_scalar_cast_path) {
 		  // Compile-progress fallback for unresolved parameterized
 		  // helper/container method paths that lose argument typing.
+		  if (debug_elaborate)
+			cerr << pe->get_fileline() << ": debug: "
+			     << "parameterized method lost argument typing (expr_type="
+			     << tmp->expr_type() << ", cast_type=" << cast_type
+			     << "); using typed placeholder"
+			     << " (compile-progress fallback)." << endl;
 		  if (cast_type == IVL_VT_STRING) {
 			if (const PEString*str_pe = dynamic_cast<const PEString*>(pe)) {
 			      NetECString*lit = new NetECString(str_pe->parsed_value());
@@ -1097,6 +1113,11 @@ NetExpr* elab_and_eval(Design*des, NetScope*scope, PExpr*pe,
 				// parameter create()/lookup helpers). Degrade to
 				// null for class targets instead of terminating
 				// elaboration at the cast check.
+				if (debug_elaborate)
+				      cerr << pe->get_fileline() << ": debug: "
+					   << "class-target expression has non-class type (expr_type="
+					   << expr_type << "); coerced to null"
+					   << " (compile-progress fallback)." << endl;
 				NetENull*stub = new NetENull();
 				stub->set_line(*tmp);
 				delete tmp;
@@ -1121,6 +1142,12 @@ NetExpr* elab_and_eval(Design*des, NetScope*scope, PExpr*pe,
 		  // parameterized class/container helper typing is lost and
 		  // arguments/returns are routed through the wrong scalar/string
 		  // target type. Prefer typed placeholders over hard failure.
+		  if (debug_elaborate)
+			cerr << pe->get_fileline() << ": debug: "
+			     << "UVM container/helper typing lost; expr_type="
+			     << tmp->expr_type() << " cast_type=" << cast_type
+			     << "; using typed placeholder"
+			     << " (compile-progress fallback)." << endl;
 		  if (cast_type == IVL_VT_STRING) {
 			if (const PEString*str_pe = dynamic_cast<const PEString*>(pe)) {
 			      NetECString*lit = new NetECString(str_pe->parsed_value());

--- a/vvp/vvp_darray.cc
+++ b/vvp/vvp_darray.cc
@@ -1035,6 +1035,16 @@ void vvp_queue_object::set_word(unsigned adr, const vvp_object_t&value)
 
       // Compile-progress fallback: permit sparse queue<object> indexed stores
       // by growing and null-filling intermediate elements.
+      {
+	    static bool warned_sparse_queue_store = false;
+	    if (!warned_sparse_queue_store) {
+		  cerr << "Warning: sparse queue<object> store at index " << adr
+		       << " beyond queue size " << queue.size()
+		       << "; null-filling intermediate elements"
+		       << " (compile-progress fallback; further similar warnings suppressed)." << endl;
+		  warned_sparse_queue_store = true;
+	    }
+      }
       queue.resize(adr+1);
       queue[adr] = value;
       touch();


### PR DESCRIPTION
## Summary

- Audited all 45 compile-progress fallback hot spots from the gap audit (`docs/claude/uvm_ieee1800_gap_audit_2026_05.md`)
- Added `debug_elaborate`-gated warning messages to **13 previously-silent** fallback sites across 5 source files
- Sites that already emitted `cerr` warnings were left unchanged
- Regression: **119/119 PASS** (no change from pre-patch baseline)

## Files changed

| File | Sites patched | Nature |
|---|---|---|
| `net_func_eval.cc` | 2 | `NetProc::evaluate_function` base class no-op; non-local l-value ignored in const eval |
| `netmisc.cc` | 5 | `elab_and_eval`/`elaborate_rval_expr` class/null coercion + UVM container typing-lost paths |
| `elab_expr.cc` | 4 | Enum lvalue without cast (×2); packed assignment pattern size mismatch (×2) |
| `vvp/vvp_darray.cc` | 1 | Sparse `queue<object>` indexed store — once-warned runtime warning |
| `elaborate.cc` | 1 | `PCondit` condition failed to elaborate; else/empty fallback |

## Test plan

- [x] `make -j$(nproc)` — clean build, no new errors
- [x] `PATH=$PWD/install/bin:$PATH bash .github/uvm_test.sh` — 119/119 PASS, 0 failed, 0 skipped
- [x] New warnings only fire under `debug_elaborate=1` (compile-time flag); runtime warning for sparse queue is once-warned and suppressed thereafter

https://claude.ai/code/session_01Q6zCneB23dBQNA6Hu4ujbt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6zCneB23dBQNA6Hu4ujbt)_