### PR TITLE
elab: typed-expression method dispatch (M1) + whole unpacked-array assignment (M2/G25)

### DIFF
--- a/PExpr.cc
+++ b/PExpr.cc
@@ -275,13 +275,23 @@ PECallFunction::PECallFunction(perm_string n, const list<named_pexpr_t> &parms)
 {
 }
 
+PECallFunction::PECallFunction(PExpr*receiver, perm_string method_name,
+			       const list<named_pexpr_t> &parms)
+: path_(pn_from_ps(method_name)), parms_(parms.begin(), parms.end()),
+  receiver_(receiver), is_overridden_(false)
+{
+}
+
 PECallFunction::~PECallFunction()
 {
       delete_parmvalue(leading_type_args_);
+      delete receiver_;
 }
 
 void PECallFunction::declare_implicit_nets(LexicalScope*scope, NetNet::Type type)
 {
+      if (receiver_)
+	    receiver_->declare_implicit_nets(scope, type);
       for (const auto &parm : parms_) {
 	    if (parm.parm)
 		  parm.parm->declare_implicit_nets(scope, type);
@@ -291,6 +301,8 @@ void PECallFunction::declare_implicit_nets(LexicalScope*scope, NetNet::Type type
 bool PECallFunction::has_aa_term(Design*des, NetScope*scope) const
 {
       bool flag = false;
+      if (receiver_)
+	    flag |= receiver_->has_aa_term(des, scope);
       for (const auto &parm : parms_) {
 	    if (parm.parm)
 		  flag |= parm.parm->has_aa_term(des, scope);

--- a/PExpr.h
+++ b/PExpr.h
@@ -1012,6 +1012,13 @@ class PECallFunction : public PExpr {
       explicit PECallFunction(perm_string n, const std::vector<named_pexpr_t> &parms);
       explicit PECallFunction(perm_string n);
 
+	// Method call on an arbitrary receiver expression, e.g.
+	// f().method(args) or C#(T)::get().method(args). The receiver is
+	// elaborated first and the method is dispatched against the exact
+	// type of the receiver result (IEEE 1800-2017 8.10, 6.19.5).
+      explicit PECallFunction(PExpr*receiver, perm_string method_name,
+			      const std::list<named_pexpr_t> &parms);
+
 	// std::list versions. Should be removed!
       explicit PECallFunction(const pform_name_t &n, const std::list<named_pexpr_t> &parms);
       explicit PECallFunction(perm_string n, const std::list<named_pexpr_t> &parms);
@@ -1049,6 +1056,9 @@ class PECallFunction : public PExpr {
       std::vector<named_pexpr_t> parms_;
       std::vector<PExpr*> with_constraints_;
       struct parmvalue_t*leading_type_args_ = 0;
+	// Non-null for method calls on arbitrary receiver expressions.
+	// In that case path_ holds only the method name.
+      PExpr*receiver_ = nullptr;
 
         // For system functions.
       bool is_overridden_;
@@ -1068,6 +1078,18 @@ class PECallFunction : public PExpr {
 					  const symbol_search_results&search_results)
 					  const;
 
+	// Shared dispatch of a method call against an elaborated receiver
+	// expression and its exact result type. Used both by the
+	// search-result driven path and by receiver-based calls.
+      NetExpr* elaborate_method_dispatch_(Design*des, NetScope*scope,
+					  NetExpr*sub_expr,
+					  ivl_type_t target_type,
+					  bool target_indexed,
+					  perm_string method_name,
+					  const pform_name_t&use_path,
+					  bool explicit_super) const;
+      NetExpr* elaborate_receiver_method_(Design*des, NetScope*scope,
+					  unsigned flags) const;
 
       NetExpr* elaborate_sfunc_(Design*des, NetScope*scope,
                                 unsigned expr_wid,

--- a/Statement.cc
+++ b/Statement.cc
@@ -200,9 +200,20 @@ PCallTask::PCallTask(perm_string n, const list<named_pexpr_t> &p)
       path_.push_back(name_component_t(n));
 }
 
+PCallTask::PCallTask(PExpr*receiver, perm_string method_name,
+		     const list<named_pexpr_t> &p)
+: package_(0), parms_(p.begin(), p.end()), receiver_(receiver)
+{
+      path_.push_back(name_component_t(method_name));
+}
+
 PCallTask::~PCallTask()
 {
       delete_parmvalue(leading_type_args_);
+	// receiver_ is deliberately not deleted here: elaboration may
+	// transfer it into a synthesized PECallFunction (which owns its
+	// receiver). pform objects are process-lifetime, so this does not
+	// leak in practice.
 }
 
 const pform_name_t& PCallTask::path() const

--- a/Statement.h
+++ b/Statement.h
@@ -241,6 +241,11 @@ class PCallTask  : public Statement {
       explicit PCallTask(PPackage *pkg, const pform_name_t &n, const std::list<named_pexpr_t> &parms);
       explicit PCallTask(const pform_name_t &n, const std::list<named_pexpr_t> &parms);
       explicit PCallTask(perm_string n, const std::list<named_pexpr_t> &parms);
+	// Method-call statement on an arbitrary receiver expression,
+	// e.g. f().method(args); (IEEE 1800-2017 8.10). path_ holds only
+	// the method name.
+      explicit PCallTask(PExpr*receiver, perm_string method_name,
+			 const std::list<named_pexpr_t> &parms);
       ~PCallTask() override;
 
       const pform_name_t& path() const;
@@ -271,6 +276,7 @@ class PCallTask  : public Statement {
 
       NetProc*elaborate_method_(Design*des, NetScope*scope,
                                 bool add_this_flag = false) const;
+      NetProc*elaborate_receiver_method_(Design*des, NetScope*scope) const;
       NetProc*elaborate_function_(Design*des, NetScope*scope) const;
       NetProc*elaborate_void_function_(Design*des, NetScope*scope,
 				       NetFuncDef*def) const;
@@ -304,6 +310,9 @@ class PCallTask  : public Statement {
       struct parmvalue_t*leading_type_args_ = 0;
       bool void_cast_ = false;
       std::vector<PExpr*> with_constraints_;
+	// Non-null for method-call statements on arbitrary receiver
+	// expressions. In that case path_ holds only the method name.
+      PExpr*receiver_ = nullptr;
 };
 
 class PCase  : public Statement {

--- a/docs/claude/uvm_ieee1800_gap_audit_2026_05.md
+++ b/docs/claude/uvm_ieee1800_gap_audit_2026_05.md
@@ -193,6 +193,7 @@ Iverilog under test: `Icarus Verilog version 13.0 (devel) (s20251012-102-g9b44d5
 - Blocks: dynamic factory lookup by string (common in scoreboards / config-driven test selection).
 
 ### G23 `uvm_register_cb(T, my_cb)` macro corrupts class layout
+- **STATUS 2026-07-11: RESOLVED-BY-PRIOR**. Full callback flow (`\`uvm_register_cb` + `\`uvm_do_callbacks` + `uvm_callbacks#(T,CB)::add` + virtual dispatch to a derived callback) passes against unmodified UVM. Regression test: `tests/m2_uvm_register_cb_test.sv`. NOTE: while probing, a NEW gap was found — see G66 below.
 - Symptom: a class with `\`uvm_register_cb(T, my_cb)` triggers 15+ cascading errors at elaboration: "first is not a method of class T," "type of variable 'item' doesn't match," "I don't know how to elaborate assignment_pattern expressions for class T{netvector_t:bool unsigned m_register_cb_my_cb}." The macro adds a member that breaks downstream class-property iteration.
 - Probe: p28_uvm_callbacks_dyn (VERIFIED-FAILS).
 - Location: probably the class-properties-iteration (macros/uvm_callbacks_macros.svh expansion creates a property whose type elaborates as netvector_t:bool — wrong); related to the stale I5 entry.
@@ -210,6 +211,7 @@ Iverilog under test: `Icarus Verilog version 13.0 (devel) (s20251012-102-g9b44d5
 - Blocks: passing config objects through UVM hierarchy (very common).
 
 ### G25 `uvm_field_sarray_int` (and likely `uvm_field_array_*`) does not propagate values during clone/copy
+- **STATUS 2026-07-11: FIXED** for `uvm_field_sarray_int` (branch `claude/ieee1800-systemverilog-uvm-tqk5qy`). Root cause was NOT the macro: IEEE 1800-2017 7.6 whole unpacked-array assignment (`arr = local_rhs__.arr` in the COPY op) was miscompiled — codegen degraded uarray property load/store to 1-bit `%prop/v`/`%store/prop/v` (silent), and word-array signal RHS hard-errored. Fixed by lowering whole static-array assignment to a canonical-index element copy loop in `PAssign::elaborate` (`make_uarray_copy_loop_`, elaborate.cc). Tests: `tests/m2_uarray_assign_test.sv`, `tests/m2_uvm_field_sarray_copy_test.sv`, `tests/negative/m2_uarray_size_mismatch.sv`. Limitations: multi-dimensional whole-array copy and dynamic `uvm_field_array_*` shapes not yet re-probed.
 - Symptom: cloning an object with a static array field via `uvm_object_utils_begin/end + uvm_field_sarray_int` yields the clone with arr=0..0 even though the source has values. `print()` shows the clone's array entries all 'h0.
 - Probe: p72_uvm_field_macros (VERIFIED-FAILS).
 - Location: macros/uvm_object_defines.svh field-macro expansion; the `do_copy` virtual override for sarray fields is incomplete or hits a vvp_darray type-mismatch.
@@ -493,6 +495,14 @@ Iverilog under test: `Icarus Verilog version 13.0 (devel) (s20251012-102-g9b44d5
 - Layer: runtime + UVM.
 - Complexity: medium.
 - Blocks: subtle (objection counts, log dedup).
+
+### G66 (NEW 2026-07-11) $unit class name colliding with uvm_pkg-internal identifiers breaks unrelated package elaboration
+- Symptom: declaring a compilation-unit class named `comp` (a name used for variables/ports inside UVM phase-traversal code) and using it as a specialization parameter (`uvm_callbacks#(comp, my_cb)`) produces `Unable to bind variable 'comp'` in `uvm_bottomup_phase.traverse` / `uvm_topdown_phase.traverse` / `uvm_task_phase` and `No function named 'comp_type.comp'` in `uvm_in_order_comparator` — all unrelated package code. Renaming the class fixes it.
+- Probe: `tests/probes/g66_unit_class_name_collision_uvm.sv` (VERIFIED-FAILS). Simple reductions of plain $unit-class-vs-package-local shadowing PASS (variable, unnamed-block variable, port; even derived from a package base) — the defect needs specialization-time re-elaboration.
+- Location: likely specialization/elaboration order in elab_scope/netclass specialization (type-parameter name capture).
+- Layer: elab.
+- Complexity: medium-deep.
+- Blocks: user code that reuses common short identifiers (comp, item, phase...) as class names.
 
 # Confirmed-working baselines (not gaps; recorded for diff against future regressions)
 

--- a/docs/claude/uvm_ieee1800_gap_audit_2026_05.md
+++ b/docs/claude/uvm_ieee1800_gap_audit_2026_05.md
@@ -184,6 +184,7 @@ Iverilog under test: `Icarus Verilog version 13.0 (devel) (s20251012-102-g9b44d5
 - Blocks: payload-size-rand patterns.
 
 ### G22 `factory.create_object_by_name` and `uvm_factory::get().create_object_by_name` both unresolvable
+- **STATUS 2026-07-11: FIXED** (typed-expression dispatch session, branch `claude/ieee1800-systemverilog-uvm-tqk5qy`). `uvm_factory::get().create_object_by_name(...)` works against unmodified Accellera UVM; test `tests/m1_uvm_factory_by_name_test.sv`. Root cause was the parser deleting the receiver in `expr_primary '.' IDENT (args)` plus no expression-keyed method dispatch. See docs/conformance/session_logs/2026-07-11_typed_expression_dispatch.md.
 - Symptom: both `factory.create_object_by_name(...)` (UVM global) and `uvm_factory::get().create_object_by_name(...)` (canonical IEEE 1800.2 path) report `error: No function named 'create_object_by_name' found in this context.` `set_type_override_by_name` warns "Enable of unknown task ignored (compile-progress)." Confirmed working: `T::type_id::create("name")` (registry-style).
 - Probe: p25_uvm_factory_create_name (VERIFIED-FAILS); p96_uvm_obj_factory (PASS — type_id::create + set_type_override).
 - Location: elab_expr.cc class-method dispatch on the singleton-returning factory accessor.
@@ -200,6 +201,7 @@ Iverilog under test: `Icarus Verilog version 13.0 (devel) (s20251012-102-g9b44d5
 - Blocks: dynamic callback-based UVM patterns.
 
 ### G24 `uvm_config_db#(class_obj)::get` returns false for class-typed objects
+- **STATUS 2026-07-11: PASSES** after the typed-expression dispatch work (the config-db internals traverse singleton-accessor call chains). Round-trip verified with unmodified UVM; test `tests/m1_uvm_cfgdb_class_test.sv`. If the original p95 probe (sequence-context get) still fails, the residual is narrower than this entry describes — reprobe before Phase 67 work.
 - Symptom: `set` followed by `get` of a class object via `uvm_config_db` returns 0 — the get fails silently. Int and string forms work.
 - Probe: p95_uvm_seq_cfg (VERIFIED-FAILS).
 - Location: deep in uvm_config_db parameterized-set/get; likely a class-handle stored as `uvm_object` then $cast back fails for derived types.
@@ -258,6 +260,7 @@ Iverilog under test: `Icarus Verilog version 13.0 (devel) (s20251012-102-g9b44d5
 # Important (works around but limits common patterns)
 
 ### G31 `process::self().status().name()` chained — enum method on function-return fails
+- **STATUS 2026-07-11: FIXED** (language level). Enum methods on function-call results and chained enum methods work; test `tests/m1_enum_method_chain_test.sv`. Note process::status() semantics itself is still G07 territory.
 - Symptom: `c.next().name()` fails with `error: No function named 'name' found in this context.` The same call without chain (`c2 = c.next(); c2.name();`) works.
 - Probe: p32_typedef_enum_method (VERIFIED-FAILS chained), p32 with no chain (PASS).
 - Location: elab_expr.cc method-call-on-function-call-result codepath.
@@ -266,6 +269,7 @@ Iverilog under test: `Icarus Verilog version 13.0 (devel) (s20251012-102-g9b44d5
 - Blocks: idiomatic chained method calls.
 
 ### G32 method-call chaining on class-handle returns: `c.with_v(42).with_v(100).v` fails
+- **STATUS 2026-07-11: FIXED**. Builder chains work, including nested same-method calls, which also required a vvp automatic-context fix (returned child frame vs same-scope pre-alloc'd caller frame in `vthread_get_rd_context_item_scoped`). Tests `tests/m1_method_chain_builder_test.sv`, `tests/m1_method_on_call_result_test.sv`, `tests/m1_static_accessor_chain_test.sv`.
 - Symptom: `c.with_v(42).with_v(100).v` produces `error: No function named 'with_v' found in this context.` Same call broken into temp variables works.
 - Probe: p84_func_return_class (VERIFIED-FAILS chain, PASS no-chain).
 - Location: same area as G31 — chained method/property dispatch on function-return class handles.

--- a/docs/conformance/CURRENT_WORK.md
+++ b/docs/conformance/CURRENT_WORK.md
@@ -80,17 +80,30 @@ the investigation. Update at every meaningful checkpoint.
 - `with`-clause locator methods on receiver calls parse to PENull
   (pre-existing parser fallback, unchanged).
 
+## Checkpoint 3 (M2) — in flight
+
+- **G25 FIXED**: whole unpacked-array assignment (IEEE 1800-2017 7.6) lowered
+  to a canonical-index element copy loop in `PAssign::elaborate`
+  (`make_uarray_copy_loop_`, elaborate.cc). Covers sig=sig, prop=prop,
+  sig=prop, prop=sig; size mismatch errors. UVM `uvm_field_sarray_int`
+  clone verified against unmodified library.
+- **G23 RESOLVED-BY-PRIOR** (regression test added).
+- **G66 NEW gap recorded**: $unit class name colliding with uvm_pkg-internal
+  identifiers + specialization breaks unrelated package elaboration;
+  reproducer `tests/probes/g66_unit_class_name_collision_uvm.sv`.
+- Focused tests pass (m2_* 3/3, negative 3/3). Full UVM + ivtest regressions
+  running at last update; commit checkpoint 3 when green.
+
 ## Exact next actions
 
-1. Watch PR #66 CI (6 jobs: Ubuntu 22/24, macOS, MSYS2 MINGW64/UCRT64/CLANG64);
-   fix any platform-specific fallout (most likely candidates: C++ dialect
-   nits in the new elab code, or MSYS2 grammar rebuild differences).
-2. Next milestone per manifesto sequence — M2 remainder: G25
-   (`uvm_field_sarray_int` copy/clone field automation) and G23
-   (`uvm_register_cb` class-layout corruption). Start by rerunning probes
-   p72/p28 shapes as reduced language tests; G24 config-db already passes
-   (test committed); G22/G31/G32 closed.
-3. Then M3 constraint solver (Phase 66 scope: G11/G15/G16/G17/G18/G20/G21).
+1. Confirm the M2 regression runs (UVM expected 108/108; ivtest expected
+   identical to baseline: 2961/3101 + 132 pre-existing fails, 85/85,
+   284/12), then commit + push checkpoint 3.
+2. Watch PR #66 CI (6 platform jobs).
+3. Re-probe dynamic-array field automation (`uvm_field_array_int` /
+   `uvm_field_queue_*`) — G25 covered only the sarray shape.
+4. Then M3 constraint solver (Phase 66 scope: G11/G15/G16/G17/G18/G20/G21),
+   or G66 root-cause (specialization-time name capture) if prioritized.
 
 ## Decisions not to revisit without new evidence
 

--- a/docs/conformance/CURRENT_WORK.md
+++ b/docs/conformance/CURRENT_WORK.md
@@ -1,0 +1,97 @@
+# CURRENT WORK — continuation file
+
+Keep this accurate enough that another session can resume without repeating
+the investigation. Update at every meaningful checkpoint.
+
+## State as of 2026-07-11 (session: typed-expression dispatch)
+
+- **Branch**: `claude/ieee1800-systemverilog-uvm-tqk5qy`
+- **Latest pushed commit**: (see `git log` — checkpoint 2 push pending regression)
+- **Selected feature**: Manifesto M1 — typed-expression method dispatch
+  (gaps G22, G31, G32 + latent vvp same-scope frame bug)
+- **Governing IEEE clauses**: 1800-2017 8.10 (object methods), 6.19.5 (enum
+  methods), 8.23 (class scope resolution), 8.25 (parameterized classes),
+  13.4.1 (void functions / discarded results)
+
+## Completed this session
+
+1. Manifesto imported at `docs/conformance/iverilog_ieee1800_uvm_manifesto.md`.
+2. Baseline: clean build + 98/98 canonical UVM regression at `a014332`.
+3. **Parser** (`parse.y`):
+   - `expr_primary '.' IDENTIFIER/TYPE_IDENTIFIER argument_list_parens` no
+     longer deletes the receiver: PEIdent receivers splice into a
+     hierarchical path (behavior-preserving); all other receivers become
+     receiver-carrying `PECallFunction`s.
+   - New `subroutine_call` alternatives for statement-context chains:
+     `f(args).m(args);`, `C::get(args).m(args);`, `C#(p)::get(args).m(args);`
+     (+2 shift/reduce conflicts, resolved by shift = the new rules; baseline
+     448 → 450 s/r, r/r unchanged at 1060).
+4. **AST**: `PECallFunction` and `PCallTask` carry an optional `receiver_`
+   expression (`PExpr.h/cc`, `Statement.h/cc`, `pform_dump.cc`).
+5. **Elaboration** (`elab_expr.cc`):
+   - Extracted the method-dispatch tail of `elaborate_expr_method_` into
+     shared `elaborate_method_dispatch_(sub_expr, target_type, ...)`.
+   - New `elaborate_receiver_method_` elaborates the receiver, takes its
+     exact `net_type()`, and dispatches (class methods incl. inherited &
+     specialized, enum methods, string/queue/darray methods).
+   - `PECallFunction::test_width` handles receiver calls (mirrors
+     `PEMemberAccess::test_width`).
+   - `PCallTask::elaborate_receiver_method_` (`elaborate.cc`): class-typed
+     receivers; void methods/tasks via `elaborate_build_call_`; non-void
+     via PAssign-to-nothing re-expression.
+6. **vvp runtime fix** (`vvp/vthread.cc`,
+   `vthread_get_rd_context_item_scoped`): after a callf join, the returned
+   child frame (rd-head, no longer in the wt chain) now takes priority over
+   a same-scope pre-%alloc'd caller frame at wt-head. Fixes nested calls of
+   the SAME function (builder chains `c.f(...).f(...)`, `f(g(f(x)))`).
+   **This bug pre-existed this session's work** — confirmed by pristine
+   baseline build failing the reduced probe.
+7. **Tests added** (committed to `tests/`):
+   - `m1_method_on_call_result_test.sv` (f().method(), f().prop, void stmt)
+   - `m1_method_chain_builder_test.sv` (chains + nested same-method)
+   - `m1_enum_method_chain_test.sv` (enum_f().name(), c.next().name(), …)
+   - `m1_static_accessor_chain_test.sv` (S::get().m(), P#(T)::get().m(), stmt)
+   - `m1_uvm_factory_by_name_test.sv` (G22 unmodified-UVM flow)
+   - `tests/negative/` + `run_negative.sh` (unknown method on call result,
+     unknown enum method → controlled diagnostics)
+
+## Tests currently passing
+
+- All six reduced probes (originally 5 failing shapes).
+- UVM factory by-name probe (G22 canonical path) — PASS.
+- Negative suite 2/2.
+- Canonical regression: rerun in progress at last update (baseline was 98/98).
+
+## Known limitations / follow-ups
+
+- Statement-context chains cover single-hop `<call>.method(args);` for the
+  three grammar shapes above. Multi-hop statement chains
+  (`f().m1().m2();`) and receiver forms starting from casts/selects in
+  statement position are not yet parsed. Expression context covers
+  arbitrary depth.
+- Diagnostics for failing receiver calls print twice (test_width +
+  elaborate double elaboration — same pre-existing pattern as
+  PEMemberAccess).
+- Non-class receivers in statement context get a clean `sorry`.
+- `with`-clause locator methods on receiver calls parse to PENull
+  (pre-existing parser fallback, unchanged).
+
+## Exact next actions
+
+1. Wait for/inspect full-regression result including the 5 new tests
+   (expect 103/103).
+2. Commit checkpoint 2 (implementation + tests + docs), push.
+3. Rerun the original UVM probes tied to M2 (config-db class get/set G24,
+   process-status chain G07/G31 UVM level) and select the next gap per the
+   manifesto sequence (M2: factory/config/callbacks/field automation).
+
+## Decisions not to revisit without new evidence
+
+- Receiver dispatch reuses `elaborate_method_dispatch_` — do NOT fork a
+  second dispatch path for receiver calls.
+- PEIdent receivers in the changed parser rules must keep path-splicing
+  (preserves package/implicit-this resolution semantics).
+- The vvp fix keys on "rd-head live for scope AND absent from wt chain";
+  the %alloc staging window keeps wt-head priority because the caller
+  frame is still chained in wt. Both cases are exercised by
+  `m1_method_chain_builder_test.sv`.

--- a/docs/conformance/CURRENT_WORK.md
+++ b/docs/conformance/CURRENT_WORK.md
@@ -6,7 +6,11 @@ the investigation. Update at every meaningful checkpoint.
 ## State as of 2026-07-11 (session: typed-expression dispatch)
 
 - **Branch**: `claude/ieee1800-systemverilog-uvm-tqk5qy`
-- **Latest pushed commit**: (see `git log` — checkpoint 2 push pending regression)
+- **Latest pushed commit**: `51c0d94` (checkpoint 2 — M1 implementation, tests, vvp fix)
+- **Pull request**: https://github.com/dsellerbrock/iverilog-uvm/pull/66 (draft; CI watched)
+- **Final regression evidence**: UVM 104/104; ivtest byte-identical to pristine
+  baseline (vvp_reg 2961/3101 + same 132 pre-existing fails, vpi 85/85,
+  vvp_reg.py 284/12); make check pass; negative suite 2/2.
 - **Selected feature**: Manifesto M1 — typed-expression method dispatch
   (gaps G22, G31, G32 + latent vvp same-scope frame bug)
 - **Governing IEEE clauses**: 1800-2017 8.10 (object methods), 6.19.5 (enum
@@ -78,12 +82,15 @@ the investigation. Update at every meaningful checkpoint.
 
 ## Exact next actions
 
-1. Wait for/inspect full-regression result including the 5 new tests
-   (expect 103/103).
-2. Commit checkpoint 2 (implementation + tests + docs), push.
-3. Rerun the original UVM probes tied to M2 (config-db class get/set G24,
-   process-status chain G07/G31 UVM level) and select the next gap per the
-   manifesto sequence (M2: factory/config/callbacks/field automation).
+1. Watch PR #66 CI (6 jobs: Ubuntu 22/24, macOS, MSYS2 MINGW64/UCRT64/CLANG64);
+   fix any platform-specific fallout (most likely candidates: C++ dialect
+   nits in the new elab code, or MSYS2 grammar rebuild differences).
+2. Next milestone per manifesto sequence — M2 remainder: G25
+   (`uvm_field_sarray_int` copy/clone field automation) and G23
+   (`uvm_register_cb` class-layout corruption). Start by rerunning probes
+   p72/p28 shapes as reduced language tests; G24 config-db already passes
+   (test committed); G22/G31/G32 closed.
+3. Then M3 constraint solver (Phase 66 scope: G11/G15/G16/G17/G18/G20/G21).
 
 ## Decisions not to revisit without new evidence
 

--- a/docs/conformance/iverilog_ieee1800_uvm_manifesto.md
+++ b/docs/conformance/iverilog_ieee1800_uvm_manifesto.md
@@ -1,0 +1,723 @@
+# Icarus Verilog IEEE 1800 and UVM Implementation Manifesto
+
+## Purpose
+
+This document is the governing implementation plan for extending the `dsellerbrock/iverilog-uvm` fork toward robust Accellera UVM compatibility and broad IEEE 1800 SystemVerilog conformance.
+
+It must be treated as the project's implementation Bible.
+
+The project has two related but distinct goals:
+
+1. Run the Accellera UVM reference implementation reliably and without simulator-specific edits.
+2. Implement the IEEE 1800 language and simulation semantics systematically enough that support can be measured clause by clause.
+
+Passing UVM is application-level evidence. It is not proof of full IEEE 1800 conformance.
+
+---
+
+## Current assessment
+
+The fork is substantially beyond stock Icarus Verilog in several UVM-critical areas, including:
+
+- Class and parameterized-class handling
+- Constraint and randomization work
+- String methods
+- Queue and array methods
+- Covergroup/bin APIs
+- Fork/join scheduling fixes
+- VVP runtime fixes
+- UVM-specific regressions and compatibility work
+
+The fork already contains a useful probe-driven audit and phased implementation plan. However, that audit is primarily UVM-driven and does not represent a complete clause-by-clause IEEE 1800 audit.
+
+The existing gap list must therefore be treated as:
+
+> A UVM-driven exploratory gap audit, not a complete inventory of every unsupported IEEE 1800 feature.
+
+---
+
+## Governing implementation principles
+
+### 1. The IEEE standard is the normative source
+
+Every implementation must be grounded in the applicable IEEE 1800 clause.
+
+Do not implement behavior from memory.
+
+For every feature:
+
+- Identify the applicable clause and subclause.
+- Record required syntax.
+- Record semantic requirements.
+- Record scheduling implications.
+- Record type-system implications.
+- Record error conditions.
+- Add positive and negative tests.
+
+Use IEEE 1800-2017 as the primary baseline unless the project explicitly changes the target. Track IEEE 1800-2023 as a separate delta.
+
+### 2. The Accellera UVM library is the application-level reference
+
+The UVM implementation must remain unmodified except where an upstream portability branch already exists.
+
+When UVM exposes a failure:
+
+1. Reduce it to the smallest pure-SystemVerilog reproducer possible.
+2. Identify the underlying language or runtime defect.
+3. Fix the simulator.
+4. Preserve the reduced reproducer as a permanent regression.
+5. Re-run the unmodified Accellera UVM code.
+
+Do not patch UVM to hide simulator defects.
+
+### 3. Never claim support based only on parsing
+
+A feature is not supported until all relevant layers work:
+
+- Lexing and preprocessing
+- Parsing
+- Name resolution
+- Type checking
+- Elaboration
+- Code generation
+- Runtime behavior
+- Scheduling behavior
+- VPI visibility
+- DPI behavior where applicable
+- Positive tests
+- Negative tests
+
+### 4. Eliminate silent miscompiles
+
+Permissive compile-progress fallbacks must be converted into one of:
+
+- Correct implementation
+- Explicit compile error
+- Explicit unsupported-feature diagnostic
+- Deliberately specified safe lowering
+
+Silent approximation is incompatible with a conformance project.
+
+### 5. Prefer architectural fixes over UVM special cases
+
+Repeated failures in factory lookup, method chaining, config databases, callbacks, assignment patterns, and arrays often indicate missing compiler architecture.
+
+Fix shared foundations rather than adding one-off checks for specific UVM identifiers.
+
+### 6. Every stable implementation increment must be committed
+
+Work must be divided into small, reviewable, regression-clean checkpoints.
+
+At each stable point:
+
+1. Run the relevant focused tests.
+2. Run the canonical regression suite.
+3. Update implementation notes and conformance records.
+4. Commit with a descriptive message.
+5. Push the branch to the remote repository.
+
+Do not leave large amounts of validated work uncommitted.
+
+Do not commit known-broken partial work to the main integration branch. Use a topic branch and mark incomplete checkpoints clearly.
+
+---
+
+## Architectural direction
+
+### Typed SystemVerilog semantic IR
+
+Every expression must preserve:
+
+- Exact SystemVerilog type
+- Signedness
+- Packed width
+- Unpacked dimensions
+- Two-state or four-state nature
+- Class specialization
+- Enum identity
+- Lvalue or rvalue category
+- Constant-expression status
+- Source location
+
+This is necessary for:
+
+- Chained method calls
+- Enum methods
+- Class-return expressions
+- Parameterized class lookup
+- Assignment patterns
+- Casts
+- Array behavior
+- UVM factory access
+- UVM config database casts
+
+### Separate parsing, semantic analysis, and lowering
+
+The intended flow is:
+
+```text
+Parser AST
+    ↓
+Name and type resolution
+    ↓
+SystemVerilog semantic IR
+    ↓
+Feature-specific lowering
+    ↓
+Netlist/VVP IR
+    ↓
+VVP runtime
+```
+
+Do not lower advanced constructs directly in parser actions when they require semantic information.
+
+### Aggregate layout service
+
+Use one shared representation for:
+
+- Packed structs
+- Packed unions
+- Unpacked structs
+- Static arrays
+- Dynamic arrays
+- Queues
+- Assignment patterns
+- Streaming operations
+- DPI descriptors
+- VPI traversal
+
+It must provide:
+
+- Width
+- Member offsets
+- Array strides
+- Flattening order
+- Streaming traversal order
+- Recursive assignment compatibility
+- Default propagation
+
+### Runtime type descriptors
+
+Every runtime class object should have a descriptor containing:
+
+- Concrete class type
+- Base class
+- Parameter specialization identity
+- Property descriptors
+- Virtual method table
+- Cast relationships
+- Factory-visible type name
+- VPI-visible metadata
+
+### Generic container model
+
+Static arrays, dynamic arrays, queues, associative arrays, and strings where appropriate should share reusable operations for:
+
+- Iteration
+- Indexing
+- Resizing
+- Copying
+- Comparison
+- Sorting
+- Reduction
+- Locator methods
+- VPI access
+- DPI access
+
+### Formalized scheduler
+
+The runtime scheduler must be treated as an explicit state machine covering the relevant SystemVerilog event regions.
+
+Every scheduling operation should declare its destination region.
+
+Add trace support recording:
+
+- Simulation time
+- Delta cycle
+- Event region
+- Process identity
+- Event identity
+- Source location
+
+---
+
+## Verified high-priority gap families
+
+### Clocking blocks and program semantics
+
+Implement and test:
+
+- Module-level clocking blocks
+- Interface-level clocking blocks
+- Program-level clocking blocks
+- Global clocking
+- Default clocking
+- Input/output skew
+- Clocking signal directions
+- Clocking sampling and driving regions
+- Program reactive-region execution
+
+### SVA
+
+Build a coherent property and sequence engine supporting:
+
+- Clocked properties
+- Default clocking
+- Sequence delays
+- Repetition
+- Implication
+- Disable conditions
+- Strong and weak semantics
+- `and`
+- `or`
+- `intersect`
+- `throughout`
+- `within`
+- Local variables
+- Formal arguments
+- Multiclock semantics
+- Assertion action blocks
+- Assertion controls
+- Procedural concurrent assertion contexts
+
+### Constraint solving
+
+Implement as a subsystem:
+
+- Implication
+- `if`/`else`
+- `foreach`
+- `inside`
+- `dist` with `:=` and `:/`
+- `solve ... before`
+- Enum constraints
+- Inherited constraints
+- Parent/child random fields
+- Dynamic-array size constraints
+- Inline constraints
+- Soft constraints
+- `constraint_mode`
+- `rand_mode`
+- `randc`
+- `pre_randomize`
+- `post_randomize`
+- Failure-state preservation
+- Seed stability
+
+### Class and method semantics
+
+Implement:
+
+- Method calls on arbitrary class-valued expressions
+- Property access on function-return class handles
+- Chained class methods
+- Chained enum methods
+- Static factory access
+- Parameterized class specialization through expressions
+- Virtual dispatch
+- `$cast`
+- Runtime type identity
+
+### UVM-critical language flows
+
+Prioritize:
+
+- Factory by-name creation
+- Config database class-object storage and retrieval
+- Callback registration
+- Static and dynamic array field automation
+- Deep and shallow copy behavior
+- Clone, compare, pack, unpack, print, and record paths
+- Phasing and objection correctness
+
+### Interfaces and modports
+
+Implement:
+
+- Modport task/function imports and exports
+- Interface instance arrays
+- Virtual interface arrays
+- Implicit and explicit modport selection
+- Modport compatibility checks
+- Parameterized interfaces
+- Interface methods
+- Clocking blocks in interfaces
+- Unpacked-dimensional ports where legal
+
+### Process and event semantics
+
+Implement:
+
+- `process::self`
+- Status transitions
+- `await`
+- `suspend`
+- `resume`
+- `kill`
+- Randstate accessors
+- Parent/child process identity
+- Correct fork/join interaction
+- Event arrays
+- Event assignment
+- `event.triggered`
+- Multiple waiters
+- Nonblocking event triggers
+- Correct event-region lifetime
+
+### Arrays, queues, and containers
+
+Implement complete behavior for:
+
+- Static arrays
+- Dynamic arrays
+- Queues
+- Associative arrays
+- Nested containers
+- Resize-with-copy
+- Reverse
+- Sort
+- Rsort
+- Shuffle
+- Min
+- Max
+- Unique
+- Unique index
+- Find
+- Find index
+- Reductions
+- Iterator and `with` semantics
+
+### Assignment patterns, structs, unions, and streaming
+
+Implement:
+
+- Typed assignment-pattern defaults
+- Recursive defaults
+- Packed aggregate defaults
+- Tagged unions
+- Pattern matching
+- Streaming RHS
+- Streaming LHS
+- Unpacked array slicing
+- Recursive aggregate assignment
+
+### DPI-C
+
+Implement:
+
+- Installed `svdpi.h`
+- Scalars
+- Two-state vectors
+- Four-state vectors
+- Strings
+- Chandle
+- Packed arrays
+- Unpacked arrays
+- Open arrays
+- Multidimensional arrays
+- `svOpenArrayHandle`
+- Bounds and dimensional queries
+- Element and slice accessors
+- Scope APIs
+- Pure imports
+- Context imports
+- Imported tasks
+- Exported tasks/functions
+- Re-entrant calls
+- Scheduler integration
+- Cross-platform ABI tests
+
+### VPI
+
+Systematically cover:
+
+- Classes
+- Packages
+- Interfaces
+- Modports
+- Generate scopes
+- Dynamic arrays
+- Queues
+- Associative arrays
+- Strings
+- Assertions
+- Covergroups
+- Tasks and functions
+- Values
+- Delays
+- Callbacks
+- Force/release
+- Stable handle lifetime
+
+### Functional coverage
+
+Create an independent runtime coverage service supporting:
+
+- Covergroups
+- Coverpoints
+- Explicit bins
+- Automatic bins
+- Wildcard bins
+- Ignore bins
+- Illegal bins
+- Transition bins
+- Repetition
+- Arrayed bins
+- With clauses
+- Crosses
+- `binsof`
+- `intersect`
+- Per-instance coverage
+- Type coverage
+- Options and type options
+- Sampling events
+- Explicit sampling
+- Query APIs
+- Coverage reporting
+- Durable serialization
+
+### Long-tail language support
+
+Eventually cover:
+
+- `bind`
+- `let`
+- Config declarations
+- `trireg`
+- Specify paths
+- Timing checks
+- Strength and charge semantics
+- Rare net forms
+- Compilation-unit rules
+- Preprocessor corner cases
+- Complete constant-expression semantics
+
+---
+
+## Conformance infrastructure
+
+Create:
+
+```text
+docs/conformance/
+    ieee1800-2017-matrix.csv
+    ieee1800-2023-delta.csv
+    ieee1800.2-uvm-matrix.csv
+```
+
+Each feature row must include:
+
+- Clause
+- Subclause
+- Feature
+- Parser status
+- Semantic status
+- Elaboration status
+- Runtime status
+- Scheduler status
+- VPI status
+- DPI status
+- Positive test
+- Negative test
+- Differential test
+- Current result
+- Issue or gap identifier
+- Owning subsystem
+
+### Test hierarchy
+
+#### Tier A: Language microtests
+
+One feature per test.
+
+#### Tier B: Interaction tests
+
+Examples:
+
+- Classes plus randomization plus dynamic arrays
+- Interfaces plus clocking plus virtual interfaces
+- Packages plus parameterized classes plus factory
+- Assertions plus default clocking plus program blocks
+
+#### Tier C: Application tests
+
+Use the unmodified Accellera UVM library and representative examples.
+
+---
+
+## Milestone sequence
+
+### M0 — Reproducible baseline
+
+- Import all temporary probes into the repository
+- Document build and regression commands
+- Record current upstream and fork commit IDs
+- Produce baseline regression results
+
+### M1 — Typed expression and runtime class descriptors
+
+- Preserve return types
+- Support method/property lookup on arbitrary expressions
+- Preserve enum identity
+- Preserve parameter specialization
+- Add virtual dispatch metadata
+
+### M2 — UVM factory, config, callbacks, and field automation
+
+- Fix by-name factory paths
+- Fix class-valued config database paths
+- Fix callback macro reductions
+- Fix array field copy/clone/print/pack behavior
+
+### M3 — Constraint solver
+
+- Implement common UVM constraint semantics as one subsystem
+
+### M4 — Container runtime
+
+- Unify array, queue, associative-array, and string container operations
+
+### M5 — Interfaces and modports
+
+- Complete connection, array, modport, and virtual interface behavior
+
+### M6 — Process, events, and scheduler
+
+- Formalize event-region behavior
+- Fix process state and event observation
+
+### M7 — Accellera UVM core qualification
+
+Run the unmodified library through:
+
+- Factory
+- Config
+- Callbacks
+- Reporting
+- Phases
+- Objections
+- Sequences
+- TLM
+- Register model
+- Field automation
+- Resource database
+- Events and barriers
+
+### M8 — Clocking blocks and program scheduling
+
+### M9 — Core SVA engine
+
+### M10 — DPI and open arrays
+
+### M11 — Functional coverage
+
+### M12 — VPI SystemVerilog object model
+
+### M13 — Bind, let, configs, specify, timing, and rare constructs
+
+### M14 — IEEE 1800-2017 clause matrix with complete disposition
+
+### M15 — IEEE 1800-2023 delta
+
+---
+
+## Definition of done for a feature
+
+A feature is complete only when:
+
+1. The governing IEEE clause is identified.
+2. Legal syntax parses.
+3. Illegal syntax produces a controlled diagnostic.
+4. Names resolve correctly.
+5. Types are preserved correctly.
+6. Elaboration is correct.
+7. Runtime behavior is correct.
+8. Scheduling behavior is correct where applicable.
+9. VPI behavior is defined where applicable.
+10. DPI behavior is defined where applicable.
+11. Positive tests pass.
+12. Negative tests pass.
+13. Interaction tests pass.
+14. Existing regressions pass.
+15. Documentation and conformance matrices are updated.
+16. The work is committed and pushed.
+
+---
+
+## Immediate recommended implementation sequence
+
+Begin with the typed-expression and method-dispatch foundation.
+
+Implement:
+
+1. Exact return-type preservation on function-call expression nodes.
+2. Member lookup against the returned type.
+3. Method calls on arbitrary class-valued expressions.
+4. Property access on arbitrary class-valued expressions.
+5. Chained method calls.
+6. Enum method calls on function returns.
+7. Parameterized class specialization preservation.
+8. Virtual dispatch metadata.
+9. Focused tests for:
+
+```systemverilog
+f().method();
+f().property;
+f().method().method();
+enum_f().name();
+C#(T)::get().method();
+```
+
+Then rerun the UVM factory, config database, process enum, and builder-chain probes.
+
+After that, implement the constraint solver as a coherent subsystem.
+
+---
+
+## Commit and branch discipline
+
+Use topic branches for each milestone or tightly scoped feature.
+
+At stable checkpoints:
+
+```bash
+git status
+git diff
+# run focused tests
+# run canonical regression
+git add <intentional files>
+git commit -m "<subsystem>: <precise completed behavior>"
+git push -u origin <branch>
+```
+
+Commit messages must describe behavior, not merely phase numbers.
+
+For incomplete but valuable branch state, use a clear WIP commit only on a topic branch:
+
+```text
+WIP: <subsystem> <current state and remaining failure>
+```
+
+Never push known-broken work to the main integration branch.
+
+Maintain a session log containing:
+
+- Branch
+- Starting commit
+- Ending commit
+- Tests run
+- Results
+- Root cause
+- Files changed
+- Remaining work
+- Exact next action
+
+---
+
+## Final project principle
+
+The project must not chase a vague claim of “full SystemVerilog support.”
+
+It must build measurable conformance:
+
+> Every supported behavior is tied to a standard clause, a durable test, a documented implementation path, and a regression-clean commit.

--- a/docs/conformance/session_logs/2026-07-11_typed_expression_dispatch.md
+++ b/docs/conformance/session_logs/2026-07-11_typed_expression_dispatch.md
@@ -162,8 +162,93 @@ method dispatch on arbitrary typed expressions. Covers audit gaps:
   name lists diff empty. All 132+12 failures are pre-existing fork issues,
   unrelated to this change.
 
+## Checkpoint 3 — M2: whole unpacked-array assignment (G25) + G23/G24 disposition
+
+### Requirement
+
+IEEE 1800-2017 **7.6 Assignments in unpacked arrays** (and 6.22.2 equivalent
+types): an unpacked array may be assigned from an assignment-compatible
+unpacked array (same element counts per dimension, equivalent element types),
+with left-to-right element correspondence. UVM's `uvm_field_sarray_int` COPY
+op is literally `ARG = local_rhs__.ARG;` (macros/uvm_object_defines.svh), so
+G25 reduces to this language feature.
+
+### Reproduction (baseline behavior)
+
+- `arr = rhs.arr` (class property = class property): compiled but was a
+  **silent no-op** — tgt-vvp degraded the uarray property load/store to
+  1-bit `%prop/v 0` / `%store/prop/v 0, 1`.
+- `x = y` (word-array signals) and `a.arr = lv` (property = signal):
+  hard elaboration error ("the type of the variable ... doesn't match the
+  context type", netvector vs netuarray) because word-array signals carry
+  unpacked dimensions on the NetNet, not in net_type().
+
+### Root cause
+
+No whole-array assignment lowering existed: vvp has no whole-array store
+(arrays are not stack values), and nothing in elaboration expanded the
+copy. The netuarray-typed r-value paths either mis-elaborated (property)
+or rejected (signal).
+
+### Implementation
+
+`elaborate.cc`: `PAssign::elaborate`'s netuarray l-value branch now lowers
+whole one-dimensional static-array assignments into a canonical-index
+element copy `NetForLoop` (`make_uarray_copy_loop_`), reusing the existing
+word-indexed l-value (`%store/prop/v/i`, array word stores) and r-value
+(`%prop/v/i`, array word reads) machinery. Canonical-to-canonical copy
+implements the 7.6 left-to-right correspondence for any declared index
+directions. Sources handled: word-array signals (pre-checked via
+symbol_search before typed r-value elaboration) and class properties
+(NetEProperty intercepted after r-value elaboration). Shape or element
+incompatibility produces a specific diagnostic
+(`uarray_copy_shapes_compatible_`); count mismatch is a hard error per 7.6.
+
+### Tests
+
+- `tests/m2_uarray_assign_test.sv` — sig=sig, prop=prop, local=prop,
+  prop=local, copy-not-alias, byte-element arrays.
+- `tests/m2_uvm_field_sarray_copy_test.sv` — unmodified-UVM
+  `uvm_field_sarray_int` clone round trip (G25).
+- `tests/m2_uvm_register_cb_test.sv` — G23 callback flow
+  (RESOLVED-BY-PRIOR; regression protection).
+- `tests/negative/m2_uarray_size_mismatch.sv` — `int a[4] = b[5]` rejected
+  with a specific diagnostic.
+
+### Dispositions
+
+- **G25: FIXED** (sarray_int; dynamic `uvm_field_array_*` shapes to re-probe).
+- **G23: RESOLVED-BY-PRIOR** (full register_cb + do_callbacks + add +
+  virtual dispatch passes).
+- **G66 (NEW)**: $unit class named `comp` used as a specialization parameter
+  breaks unrelated uvm_pkg elaboration; reproducer preserved at
+  `tests/probes/g66_unit_class_name_collision_uvm.sv`; simple shadowing
+  reductions pass. Recorded in the gap audit.
+
+### Known limitations
+
+- Multi-dimensional whole-array copy not expanded (falls back to the old
+  paths: loud error for signals; property case unchanged).
+- Function-return unpacked arrays and unpacked-dimension subroutine ports
+  remain separate pre-existing loud gaps (typedef-return / `sorry`).
+
+### Results
+
+- Focused: m2 positive tests 4/4 PASS (uarray assign, UVM sarray clone,
+  UVM register_cb, UVM dynamic field array — the last verified
+  individually, added after the suite run started); negative suite 3/3.
+- Canonical UVM regression: **108 passed, 0 failed, 0 skipped**.
+- Bundled ivtest: **byte-identical to the pristine-baseline results**
+  (vvp_reg 2961/3101 pass + same 132 pre-existing failure names,
+  vpi_reg 85/85, vvp_reg.py 284 ran/12 pre-existing failures).
+- Follow-up noted: `draw_eval_object: unknown expression type 3` warning
+  fires on UVM dynamic-array paths (pre-existing tgt-vvp/eval_object.c
+  compile-progress fallback — Phase 75 scope).
+
 ## Checkpoint history
 
 - Checkpoint 1: manifesto imported to `docs/conformance/`, baseline recorded (this file).
 - Checkpoint 2: typed-expression method dispatch implementation + tests + vvp
-  returned-frame fix (this section).
+  returned-frame fix.
+- Checkpoint 3: M2 whole unpacked-array assignment (G25) + G23/G24/G66
+  dispositions (this section).

--- a/docs/conformance/session_logs/2026-07-11_typed_expression_dispatch.md
+++ b/docs/conformance/session_logs/2026-07-11_typed_expression_dispatch.md
@@ -1,0 +1,85 @@
+# Session log — 2026-07-11 — Typed-expression method dispatch (M1)
+
+## Baseline
+
+- **Date**: 2026-07-11
+- **Branch**: `claude/ieee1800-systemverilog-uvm-tqk5qy`
+- **Starting commit**: `a014332` (Merge pull request #38 from dsellerbrock/development)
+- **UVM version**: Accellera uvm-core 2020.3.1 (submodule commit `78c0654`, unmodified,
+  pinned at official_release_3_1 merge)
+- **Baseline build command**:
+  ```
+  autoconf && ./configure --enable-libveriuser --prefix=$PWD/install && make -j4 && make install
+  ```
+  (build deps: flex, gperf, libz3-dev installed via apt)
+- **Baseline test command**: `PATH=$PWD/install/bin:$PATH bash .github/uvm_test.sh`
+- **Baseline result**: **98 passed, 0 failed, 0 skipped** (matches Phase 65 record in
+  `docs/claude/uvm_gap_plan.md`)
+
+## Selected gap
+
+Manifesto milestone **M1 — Typed expression and runtime class descriptors**:
+method dispatch on arbitrary typed expressions. Covers audit gaps:
+
+- **G31** — enum method on function-call result (`c.next().name()`)
+- **G32** — method chaining on class-handle returns (`c.with_v(1).with_v(2).v`)
+- **G22** — `uvm_factory::get().create_object_by_name(...)` (singleton-returning
+  static accessor + method call)
+
+## Applicable IEEE clauses (IEEE 1800-2017)
+
+- **8.23 Class scope resolution operator ::** and **8.10 Object methods** — a method
+  may be invoked on any expression whose type is a class handle; the left-hand side
+  of `.` is an object expression, not restricted to a hierarchical name (8.10:
+  "Methods are invoked using the same syntax used to access structure members …
+  object.method()", where `object` is any class-object-valued expression).
+- **6.19.5 Enumerated type methods** — `next()`, `prev()`, `name()`, `first()`,
+  `last()`, `num()` apply to any expression of enumeration type, including the
+  result of a function call or another enum method (their results are of the
+  enum type, so method application composes).
+- **8.25 Parameterized classes** — `C#(T)::get()` denotes a static method of the
+  specialization; its return value keeps the specialized class type.
+- **13.4.1 Return values and void functions** — method-call statements
+  (`f().method();`) including void methods.
+
+## Reproducers (probed against baseline build)
+
+| Probe | Form | Baseline result |
+|---|---|---|
+| probe1 | `make_c(42).get_v()` | **FAILS** — `error: No function named 'get_v'` |
+| probe2 | `make_c(7).v` | PASSES (PEMemberAccess path already works) |
+| probe3 | `c.with_v(42).with_v(100).v` | **FAILS** — `No function named 'with_v'` |
+| probe4 | `next_color(c).name()`, `c.next().name()` | **FAILS** — `No function named 'name'` |
+| probe5 | `S::get().get_v()`, `S::get().v`, `P#(byte)::get().size_of()` | **FAILS** for method calls; property access `S::get().v` works |
+| probe6 | statement `make_c().bump();` | **FAILS** — syntax error (grammar gap) |
+
+## Root cause (confirmed)
+
+1. **Parser discards the receiver**: `parse.y` rules
+   `expr_primary '.' IDENTIFIER argument_list_parens` (and the TYPE_IDENTIFIER
+   variant) execute `delete $1;` — the receiver expression is thrown away and a
+   bare `PECallFunction(method_name)` is created. Elaboration then reports
+   "No function named …". This is a silent-miscompile pattern (manifesto
+   principle 4).
+2. **No expression-keyed dispatch entry point**: `PECallFunction::elaborate_expr_method_`
+   dispatches only from `symbol_search_results` (a resolved *net* + path); there is
+   no path that dispatches a method against an arbitrary elaborated `NetExpr` +
+   `ivl_type_t`. The dispatch tail (darray/queue/enum/class/string method lowering)
+   is reusable but was not factored out.
+3. **Statement grammar gap**: `subroutine_call` has no alternative for
+   `<call> '.' IDENTIFIER (args)` shapes, so `f().method();`,
+   `uvm_factory::get().set_type_override_by_name(...);` are syntax errors.
+4. **Return types are already preserved**: `NetEUFunc` inherits
+   `NetExpr(res->net_type())` from the return signal, including class
+   specializations and enum identity — so no netlist-side change is needed for
+   type preservation; the fix is parser + elaboration dispatch.
+
+## Work completed this session
+
+See CURRENT_WORK.md and commits on branch `claude/ieee1800-systemverilog-uvm-tqk5qy`.
+
+(Updated as checkpoints land — see bottom of file.)
+
+## Checkpoint history
+
+- Checkpoint 1: manifesto imported to `docs/conformance/`, baseline recorded (this file).

--- a/docs/conformance/session_logs/2026-07-11_typed_expression_dispatch.md
+++ b/docs/conformance/session_logs/2026-07-11_typed_expression_dispatch.md
@@ -76,10 +76,94 @@ method dispatch on arbitrary typed expressions. Covers audit gaps:
 
 ## Work completed this session
 
-See CURRENT_WORK.md and commits on branch `claude/ieee1800-systemverilog-uvm-tqk5qy`.
+### Implementation (checkpoint 2)
 
-(Updated as checkpoints land — see bottom of file.)
+**Parser (`parse.y`)**
+- `expr_primary '.' IDENTIFIER/TYPE_IDENTIFIER argument_list_parens` no longer
+  deletes the receiver expression. PEIdent receivers are spliced into a
+  hierarchical path (preserving existing name-resolution semantics, including
+  packages and implicit `this`); all other receiver expressions are carried on
+  a receiver-based `PECallFunction`.
+- New `subroutine_call` alternatives for statement-context single-hop chains:
+  `f(args).m(args);`, `Class::get(args).m(args);`,
+  `Class#(p)::get(args).m(args);`. Grammar impact: +2 shift/reduce conflicts
+  (448 → 450), resolved by shift which selects the new rules; reduce/reduce
+  unchanged (1060); no new useless rules (the three reported ones pre-exist).
+
+**AST (`PExpr.h/cc`, `Statement.h/cc`, `pform_dump.cc`)**
+- `PECallFunction` and `PCallTask` gained an optional `receiver_` expression
+  and constructors `(PExpr*receiver, perm_string method, parms)`.
+
+**Elaboration (`elab_expr.cc`, `elaborate.cc`)**
+- The method-dispatch tail of `PECallFunction::elaborate_expr_method_`
+  (darray/queue/enum/class/string dispatch keyed on an elaborated receiver
+  expression + exact type) was extracted into shared
+  `elaborate_method_dispatch_`. No behavior change for the existing path.
+- New `PECallFunction::elaborate_receiver_method_`: elaborates the receiver
+  with typed elaboration, reads its exact `net_type()` (class specialization
+  and enum identity are already preserved by `NetEUFunc(res->net_type())`),
+  and dispatches. Reports a controlled diagnostic when no dispatch applies.
+- `PECallFunction::test_width` handles receiver calls (mirrors
+  `PEMemberAccess::test_width`).
+- New `PCallTask::elaborate_receiver_method_`: class-typed receivers only
+  (clean `sorry` otherwise); tasks and void methods via
+  `elaborate_build_call_` with the receiver as `this`; non-void methods
+  re-expressed as PAssign-to-nothing (IEEE 13.4.1 discard).
+
+**vvp runtime (`vvp/vthread.cc`) — pre-existing latent bug fixed**
+- `vthread_get_rd_context_item_scoped` preferred the wt-head frame whenever
+  its scope matched. After `do_join`'s pop-push, the returned child frame
+  sits at rd-head and is no longer in the wt chain; for nested calls of the
+  SAME function (builder chains `c.f(...).f(...)`, `f(g(f(x)))` with f==g)
+  the caller's pre-`%alloc`'d same-scope frame at wt-head shadowed the
+  returned frame, so the caller read a null/zero result. Fix: prefer rd-head
+  when it is live for the scope and absent from the wt chain. The `%alloc`
+  staging window keeps wt-head priority (caller frame still chained in wt).
+  **Confirmed pre-existing**: pristine baseline build (a014332) fails
+  `tests/m1_method_chain_builder_test.sv`'s nested-same-method shape via the
+  pre-existing property-access path (`c.with_v(c2.with_v(3).v)` → c.v==0).
+
+### Tests added
+
+| Test | Covers |
+|---|---|
+| `tests/m1_method_on_call_result_test.sv` | `f().method()`, `f().prop`, void stmt `f().m();` |
+| `tests/m1_method_chain_builder_test.sv` | builder chains, mixed chains, nested same-method |
+| `tests/m1_enum_method_chain_test.sv` | `enum_f().name()`, `c.next().name()`, deep chains |
+| `tests/m1_static_accessor_chain_test.sv` | `S::get().m()`, `S::get().prop`, `P#(T)::get().m()`, stmt form |
+| `tests/m1_virtual_dispatch_chain_test.sv` | virtual dispatch via call-result receivers (8.20) |
+| `tests/m1_uvm_factory_by_name_test.sv` | G22 unmodified-UVM `uvm_factory::get().create_object_by_name` |
+| `tests/negative/*.sv` + `run_negative.sh` | unknown method / unknown enum method on call results → controlled diagnostics |
+
+### Required-probe outcomes (manifesto initial-priority list)
+
+| Probe | Outcome |
+|---|---|
+| UVM factory by-name (`uvm_factory::get().create_object_by_name`) | **PASS** (G22 fixed) — permanent test added |
+| Class-valued `uvm_config_db` set/get | **PASS** (G24 now passes; config-db internals traverse accessor chains) — permanent test `m1_uvm_cfgdb_class_test.sv` |
+| Process status enum chaining (`process::self().status().name()`) | **Dispatch fixed** — chain compiles and runs; remaining failure is G07 (status state machine returns 0, no enum identity on the built-in `status` property) → M6 scope |
+| Builder-style chaining | **PASS** (G32 fixed incl. vvp frame fix) |
+| `$cast` base↔derived UVM objects | **PASS** (exercised inside `m1_uvm_factory_by_name_test.sv`) |
+
+### Results
+
+- All 6 new positive tests PASS under the regression recipe.
+- Negative suite: 2/2 PASS (specific diagnostics; note: message printed
+  twice due to the pre-existing test_width+elaborate double-elaboration
+  pattern shared with PEMemberAccess).
+- `make check`: PASS.
+- Canonical UVM regression: **104 passed, 0 failed, 0 skipped** (98 baseline
+  tests + 6 new m1 tests; `m1_uvm_cfgdb_class_test.sv` was added after that
+  run started and verified individually — future runs count 105).
+- Bundled ivtest, patched vs pristine baseline build (both run this session):
+  **byte-identical results** — vvp_reg.pl `Total=3101, Passed=2961,
+  Failed=132, Not Implemented=5, Expected Fail=3` in both; vpi_reg
+  `85/85` in both; vvp_reg.py `Ran 284, Failed 12` in both; the failure
+  name lists diff empty. All 132+12 failures are pre-existing fork issues,
+  unrelated to this change.
 
 ## Checkpoint history
 
 - Checkpoint 1: manifesto imported to `docs/conformance/`, baseline recorded (this file).
+- Checkpoint 2: typed-expression method dispatch implementation + tests + vvp
+  returned-frame fix (this section).

--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -3435,6 +3435,21 @@ unsigned PECallFunction::test_width(Design*des, NetScope*scope,
 		 << "mode: " << width_mode_name(mode) << endl;
       }
 
+	// Method call on an arbitrary receiver expression. Elaborate the
+	// full call to learn its result type and width. This mirrors
+	// PEMemberAccess::test_width.
+      if (receiver_) {
+	    NetExpr*tmp = elaborate_receiver_method_(des, scope, NO_FLAGS);
+	    if (!tmp)
+		  return 0;
+	    expr_type_ = tmp->expr_type();
+	    expr_width_ = tmp->expr_width();
+	    min_width_ = expr_width_;
+	    signed_flag_ = tmp->has_sign();
+	    delete tmp;
+	    return expr_width_;
+      }
+
       if (peek_tail_name(path_)[0] == '$')
 	    return test_width_sfunc_(des, scope, mode);
 
@@ -5467,6 +5482,12 @@ NetExpr* PECallFunction::elaborate_expr_(Design*des, NetScope*scope,
 {
       flags &= ~SYS_TASK_ARG; // don't propagate the SYS_TASK_ARG flag
 
+	// Method call on an arbitrary receiver expression, e.g.
+	// f().method(). Elaborate the receiver and dispatch the method
+	// against the receiver's exact result type.
+      if (receiver_)
+	    return elaborate_receiver_method_(des, scope, flags);
+
       if (path_.size() == 2
 	  && peek_head_name(path_) == perm_string::literal("process")
 	  && peek_tail_name(path_) == perm_string::literal("self")) {
@@ -6147,6 +6168,61 @@ unsigned PECallFunction::elaborate_arguments_(Design*des, NetScope*scope,
  * Then net refers to object named x, and path_head is "<scope>.x". The method is
  * "len" in path_tail, and if x is a string object, we can handle the case.
  */
+/*
+ * Elaborate a method call whose target is an arbitrary receiver
+ * expression (e.g. f().method(), C#(T)::get().method(), or a chain of
+ * such calls). The receiver expression is elaborated first; its exact
+ * result type (class, enum, string, queue, ...) selects the method
+ * dispatch. IEEE 1800-2017 8.10 (object methods on class-valued
+ * expressions) and 6.19.5 (enumerated type methods).
+ */
+NetExpr* PECallFunction::elaborate_receiver_method_(Design*des, NetScope*scope,
+						    unsigned flags) const
+{
+      ivl_assert(*this, receiver_);
+
+      if (!gn_system_verilog()) {
+	    cerr << get_fileline() << ": error: "
+		 << "Enable SystemVerilog to support object methods." << endl;
+	    des->errors += 1;
+	    return 0;
+      }
+
+      NetExpr*sub_expr = receiver_->elaborate_expr(des, scope,
+						   ivl_type_t(nullptr), flags);
+      if (!sub_expr)
+	    return 0;
+
+      ivl_type_t target_type = sub_expr->net_type();
+      perm_string method_name = peek_tail_name(path_);
+      pform_name_t use_path = path_.name;
+
+      if (debug_elaborate) {
+	    cerr << get_fileline() << ": PECallFunction::elaborate_receiver_method_: "
+		 << "method: " << method_name
+		 << ", receiver expr_type: " << sub_expr->expr_type() << endl;
+	    if (target_type)
+		  cerr << get_fileline() << ": PECallFunction::elaborate_receiver_method_: "
+		       << "receiver net_type: " << *target_type << endl;
+      }
+
+      unsigned errors_before = des->errors;
+      NetExpr*res = elaborate_method_dispatch_(des, scope, sub_expr, target_type,
+					       false /* target_indexed */,
+					       method_name, use_path,
+					       false /* explicit_super */);
+      if (!res && des->errors == errors_before) {
+	    cerr << get_fileline() << ": error: No method named `"
+		 << method_name << "' can be applied to the receiver "
+		 << "expression";
+	    if (target_type)
+		  cerr << " of type " << *target_type;
+	    cerr << "." << endl;
+	    des->errors += 1;
+      }
+      return res;
+}
+
 NetExpr* PECallFunction::elaborate_expr_method_(Design*des, NetScope*scope,
 						symbol_search_results&search_results)
 						const
@@ -6331,6 +6407,28 @@ NetExpr* PECallFunction::elaborate_expr_method_(Design*des, NetScope*scope,
 		  use_path.push_back(*it);
       }
 
+      bool explicit_super = !search_results.path_head.empty()
+	    && search_results.path_head.front().name == perm_string::literal(SUPER_TOKEN);
+
+      return elaborate_method_dispatch_(des, scope, sub_expr, target_type,
+					target_indexed, method_name, use_path,
+					explicit_super);
+}
+
+/*
+ * Dispatch a method call against an already-elaborated receiver expression
+ * and its exact result type. This is the shared tail used both by the
+ * symbol-search driven method path and by method calls on arbitrary
+ * receiver expressions such as f().method() (IEEE 1800-2017 8.10, 6.19.5).
+ */
+NetExpr* PECallFunction::elaborate_method_dispatch_(Design*des, NetScope*scope,
+						    NetExpr*sub_expr,
+						    ivl_type_t target_type,
+						    bool target_indexed,
+						    perm_string method_name,
+						    const pform_name_t&use_path,
+						    bool explicit_super) const
+{
       // Dynamic array methods. This handles the case that the located signal
       // is a dynamic array, and there is no index.
       if (target_type && dynamic_cast<const netdarray_t*>(target_type)
@@ -6700,9 +6798,6 @@ NetExpr* PECallFunction::elaborate_expr_method_(Design*des, NetScope*scope,
 
 		    elaborate_arguments_(des, scope, def, false, parms, parm_off);
 
-		    bool explicit_super =
-			  !search_results.path_head.empty()
-			  && search_results.path_head.front().name == perm_string::literal(SUPER_TOKEN);
 		    NetESignal*eres = new NetESignal(res);
 		    NetEUFunc*call = new NetEUFunc(scope, method, eres, parms, false,
 						   explicit_super);

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -4638,6 +4638,11 @@ NetProc* PContinue::elaborate(Design*des, NetScope*) const
 
 NetProc* PCallTask::elaborate(Design*des, NetScope*scope) const
 {
+	// Method-call statement on an arbitrary receiver expression,
+	// e.g. f().method(args); (IEEE 1800-2017 8.10).
+      if (receiver_)
+	    return elaborate_receiver_method_(des, scope);
+
       if (peek_tail_name(path_)[0] == '$') {
 	    if (void_cast_)
 		  return elaborate_non_void_function_(des, scope);
@@ -5346,6 +5351,81 @@ static bool is_uvm_compile_progress_task_stub_candidate_(const pform_name_t&path
       // map and the null-map UVM_ERROR no longer fires.)
 
       return false;
+}
+
+/*
+ * Elaborate a method-call statement whose target is an arbitrary
+ * receiver expression, e.g. f().method(args); or
+ * C#(T)::get().method(args);. The receiver is elaborated first and the
+ * method is resolved against the exact class type of its result
+ * (IEEE 1800-2017 8.10). Void methods and tasks go through the regular
+ * build-call path; non-void methods are re-expressed as a function call
+ * assigned to nothing (result discarded, 13.4.1).
+ */
+NetProc* PCallTask::elaborate_receiver_method_(Design*des, NetScope*scope) const
+{
+      ivl_assert(*this, receiver_);
+      perm_string method_name = peek_tail_name(path_);
+
+      NetExpr*sub_expr = receiver_->elaborate_expr(des, scope,
+						   ivl_type_t(nullptr),
+						   PExpr::NO_FLAGS);
+      if (!sub_expr)
+	    return 0;
+
+      ivl_type_t target_type = sub_expr->net_type();
+      const netclass_t*class_type = dynamic_cast<const netclass_t*>(target_type);
+      if (!class_type) {
+	    cerr << get_fileline() << ": sorry: Method-call statements on "
+		 << "receiver expressions are only supported for class-typed "
+		 << "receivers." << endl;
+	    des->errors += 1;
+	    delete sub_expr;
+	    return 0;
+      }
+
+      if (!class_type->scope_ready()) {
+	    if (netclass_t*visible_class = ensure_visible_class_type(des, scope,
+							class_type->get_name()))
+		  class_type = visible_class;
+      }
+
+      NetScope*task = class_type->resolve_method_call_scope(des, method_name);
+      if (!task) {
+	    cerr << get_fileline() << ": error: " << method_name
+		 << " is not a method of class " << class_type->get_name()
+		 << "." << endl;
+	    des->errors += 1;
+	    delete sub_expr;
+	    return 0;
+      }
+
+      if (task->type() == NetScope::FUNC) {
+	    const NetFuncDef*def = task->func_def();
+	    if (!def) {
+		  const PFunction*pfunc = task->func_pform();
+		  if (pfunc)
+			elaborate_function_outside_caller_fork_(des, pfunc, task);
+		  def = task->func_def();
+	    }
+	    if (def && !def->is_void()) {
+		    // The method returns a value that this statement
+		    // discards. Re-express as a receiver-based function
+		    // call assigned to nothing.
+		  delete sub_expr;
+		  list<named_pexpr_t> use_parms(parms_.begin(), parms_.end());
+		  PECallFunction*rcv_call =
+			new PECallFunction(receiver_, method_name, use_parms);
+		  rcv_call->set_file(get_file());
+		  rcv_call->set_lineno(get_lineno());
+		  PAssign*tmp = new PAssign(0, rcv_call);
+		  tmp->set_file(get_file());
+		  tmp->set_lineno(get_lineno());
+		  return tmp->elaborate(des, scope);
+	    }
+      }
+
+      return elaborate_build_call_(des, scope, task, sub_expr);
 }
 
 NetProc* PCallTask::elaborate_method_(Design*des, NetScope*scope,

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -3426,6 +3426,116 @@ static NetProc*build_tagged_union_companion_set_(Design*des, NetScope*scope,
       return comp_as;
 }
 
+/*
+ * Whole unpacked-array assignment (IEEE 1800-2017 7.6): the vvp code
+ * generator has no whole-array store, so lower "dst = src" between
+ * one-dimensional static unpacked arrays into an element-by-element
+ * copy loop over canonical indexes. Canonical-to-canonical copy
+ * implements the left-to-right element correspondence of 7.6
+ * regardless of the declared index directions. The element
+ * assignments reuse the existing word-indexed l-value and
+ * word-indexed property/signal read machinery.
+ *
+ * The lv is adopted on success (word select attached); the caller
+ * must not reuse it. elem_rval must be an expression template
+ * factory: it is called once with the index expression to use.
+ */
+static NetProc* make_uarray_copy_loop_(Design*des, NetScope*scope,
+				       const LineInfo&loc,
+				       NetAssign_*lv,
+				       unsigned long count,
+				       NetNet*src_sig,
+				       const NetEProperty*src_prop)
+{
+      (void)des;
+
+      NetNet*idx_sig = new NetNet(scope, scope->local_symbol(),
+				  NetNet::REG, &netvector_t::atom2s32);
+      idx_sig->local_flag(true);
+      idx_sig->set_line(loc);
+
+      NetEConst*init_expr = make_const_val_s(0);
+      init_expr->set_line(loc);
+
+      NetESignal*cond_idx = new NetESignal(idx_sig);
+      cond_idx->set_line(loc);
+      NetEConst*count_expr = make_const_val_s(count);
+      count_expr->set_line(loc);
+      NetEBComp*cond_expr = new NetEBComp('<', cond_idx, count_expr);
+      cond_expr->set_line(loc);
+
+      NetAssign_*step_lv = new NetAssign_(idx_sig);
+      NetEConst*step_val = make_const_val_s(1);
+      NetAssign*step = new NetAssign(step_lv, '+', step_val);
+      step->set_line(loc);
+
+      NetESignal*lv_word = new NetESignal(idx_sig);
+      lv_word->set_line(loc);
+      lv->set_word(lv_word);
+
+      NetExpr*elem_rv = 0;
+      if (src_sig) {
+	    NetESignal*rv_word = new NetESignal(idx_sig);
+	    rv_word->set_line(loc);
+	    NetESignal*tmp = new NetESignal(src_sig, rv_word);
+	    tmp->set_line(loc);
+	    elem_rv = tmp;
+      } else {
+	    ivl_assert(loc, src_prop);
+	    NetESignal*rv_word = new NetESignal(idx_sig);
+	    rv_word->set_line(loc);
+	    NetEProperty*tmp;
+	    if (const NetExpr*base = src_prop->get_base())
+		  tmp = new NetEProperty(base->dup_expr(),
+					 src_prop->property_idx(), rv_word);
+	    else
+		  tmp = new NetEProperty(const_cast<NetNet*>(src_prop->get_sig()),
+					 src_prop->property_idx(), rv_word);
+	    tmp->set_line(loc);
+	    elem_rv = tmp;
+      }
+
+      NetAssign*body = new NetAssign(lv, elem_rv);
+      body->set_line(loc);
+
+      NetForLoop*loop = new NetForLoop(idx_sig, init_expr, cond_expr,
+				       body, step);
+      loop->set_line(loc);
+      return loop;
+}
+
+/*
+ * Check that the source element shape is assignment compatible with
+ * the destination unpacked array (IEEE 1800-2017 7.6: equal element
+ * counts and equivalent element types; we require matching packed
+ * width and vector base kind).
+ */
+static bool uarray_copy_shapes_compatible_(const netuarray_t*dst,
+					   unsigned long src_count,
+					   ivl_type_t src_elem)
+{
+      const netranges_t&dims = dst->static_dimensions();
+      if (dims.size() != 1)
+	    return false;
+      if (dims[0].width() != src_count)
+	    return false;
+
+      ivl_type_t dst_elem = dst->element_type();
+      if (!dst_elem || !src_elem)
+	    return false;
+      if (dst_elem->packed_width() != src_elem->packed_width())
+	    return false;
+
+      ivl_variable_type_t dst_vt = dst_elem->base_type();
+      ivl_variable_type_t src_vt = src_elem->base_type();
+      auto is_vec = [](ivl_variable_type_t vt) {
+	    return vt == IVL_VT_BOOL || vt == IVL_VT_LOGIC;
+      };
+      if (is_vec(dst_vt) && is_vec(src_vt))
+	    return true;
+      return dst_vt == src_vt;
+}
+
 NetProc* PAssign::elaborate(Design*des, NetScope*scope) const
 {
       ivl_assert(*this, scope);
@@ -3509,7 +3619,8 @@ NetProc* PAssign::elaborate(Design*des, NetScope*scope) const
 	    // as net_type() returned it.
 	    rv = elaborate_rval_(des, scope, lv_net_type);
 
-      } else if (dynamic_cast<const netuarray_t*>(lv_net_type)) {
+      } else if (const netuarray_t*lv_uarray =
+		 dynamic_cast<const netuarray_t*>(lv_net_type)) {
 	    ivl_assert(*this, lv->more==0);
 	    if (debug_elaborate) {
 		  if (lv->word())
@@ -3519,9 +3630,81 @@ NetProc* PAssign::elaborate(Design*des, NetScope*scope) const
 			cerr << get_fileline() << ": PAssign::elaborate: "
 			     << "lv->word() = <nil>" << endl;
 	    }
+
+	      // Whole static-array copy (IEEE 1800-2017 7.6). Handle
+	      // "dst = src" where src is a one-dimensional unpacked
+	      // array signal before general r-value elaboration (the
+	      // typed r-value path has no whole-array representation
+	      // for word-array signals). Property sources are handled
+	      // after r-value elaboration below.
+	    bool simple_blocking = (delay_ == 0) && (event_ == 0)
+		  && (count_ == 0) && !lv->word()
+		  && lv_uarray->static_dimensions().size() == 1;
+
+	    if (simple_blocking) {
+		  if (const PEIdent*rid = dynamic_cast<const PEIdent*>(rval())) {
+			symbol_search_results sr;
+			bool found = symbol_search(this, des, scope, rid->path(),
+						   rid->lexical_pos(), &sr);
+			if (found && sr.net && sr.path_tail.empty()
+			    && rid->path().name.back().index.empty()
+			    && sr.net->unpacked_dimensions() == 1) {
+			      if (!uarray_copy_shapes_compatible_(
+					lv_uarray, sr.net->unpacked_count(),
+					sr.net->net_type())) {
+				    cerr << get_fileline() << ": error: "
+					 << "Unpacked array types of '"
+					 << lv->name() << "' and '" << rid->path()
+					 << "' are not assignment compatible."
+					 << endl;
+				    des->errors += 1;
+				    delete lv;
+				    return 0;
+			      }
+			      return make_uarray_copy_loop_(des, scope, *this,
+							    lv, sr.net->unpacked_count(),
+							    sr.net, 0);
+			}
+		  }
+	    }
+
 	    // Same C3 reasoning as above for netuarray l-values.
 	    ivl_assert(*this, lv_net_type);
 	    rv = elaborate_rval_(des, scope, lv_net_type);
+
+	      // Whole static-array copy from a class property source
+	      // (e.g. the UVM field-macro COPY path "arr = rhs.arr").
+	      // Without this, code generation degrades the property
+	      // read/store to a 1-bit vector - a silent miscompile.
+	    if (simple_blocking && rv) {
+		  if (NetEProperty*rprop = dynamic_cast<NetEProperty*>(rv)) {
+			const netuarray_t*src_ua =
+			      dynamic_cast<const netuarray_t*>(rprop->net_type());
+			if (src_ua && !rprop->get_index()
+			    && src_ua->static_dimensions().size() == 1) {
+			      unsigned long src_count =
+				    src_ua->static_dimensions()[0].width();
+			      if (!uarray_copy_shapes_compatible_(
+					lv_uarray, src_count,
+					src_ua->element_type())) {
+				    cerr << get_fileline() << ": error: "
+					 << "Unpacked array property types in "
+					 << "assignment to '" << lv->name()
+					 << "' are not assignment compatible."
+					 << endl;
+				    des->errors += 1;
+				    delete lv;
+				    delete rv;
+				    return 0;
+			      }
+			      NetProc*loop = make_uarray_copy_loop_(des, scope, *this,
+								    lv, src_count,
+								    0, rprop);
+			      delete rv;
+			      return loop;
+			}
+		  }
+	    }
 
       } else {
 	      /* Elaborate the r-value expression, then try to evaluate it. */

--- a/ivtest/.gitignore
+++ b/ivtest/.gitignore
@@ -35,3 +35,5 @@ dump.vcd
 dump.lxt
 dump.lx2
 foo.vcd
+xt
+xt2

--- a/parse.y
+++ b/parse.y
@@ -7365,18 +7365,40 @@ expr_primary
 	$$ = tmp;
       }
   | expr_primary '.' IDENTIFIER argument_list_parens
-      { // Parse method calls on temporary expressions (e.g. fn().method()).
-	PECallFunction*tmp = new PECallFunction(lex_strings.make($3), *$4);
+      { /* Method call on a primary expression (e.g. fn().method()).
+	   PEIdent receivers keep the hierarchical-path form so existing
+	   name-based lookup is unchanged; any other receiver expression
+	   is preserved and the method is dispatched against the exact
+	   type of the receiver result (IEEE 1800-2017 8.10). */
+	PECallFunction*tmp;
+	if (PEIdent*id = dynamic_cast<PEIdent*>($1)) {
+	      pform_scoped_name_t path = id->path();
+	      path.name.push_back(name_component_t(lex_strings.make($3)));
+	      tmp = path.package
+		  ? new PECallFunction(path.package, path.name, *$4)
+		  : new PECallFunction(path.name, *$4);
+	      delete $1;
+	} else {
+	      tmp = new PECallFunction($1, lex_strings.make($3), *$4);
+	}
 	FILE_NAME(tmp, @2);
-	delete $1;
 	delete[]$3;
 	delete $4;
 	$$ = tmp;
       }
   | expr_primary '.' TYPE_IDENTIFIER argument_list_parens
-      { PECallFunction*tmp = new PECallFunction(lex_strings.make($3.text), *$4);
+      { PECallFunction*tmp;
+	if (PEIdent*id = dynamic_cast<PEIdent*>($1)) {
+	      pform_scoped_name_t path = id->path();
+	      path.name.push_back(name_component_t(lex_strings.make($3.text)));
+	      tmp = path.package
+		  ? new PECallFunction(path.package, path.name, *$4)
+		  : new PECallFunction(path.name, *$4);
+	      delete $1;
+	} else {
+	      tmp = new PECallFunction($1, lex_strings.make($3.text), *$4);
+	}
 	FILE_NAME(tmp, @2);
-	delete $1;
 	delete[]$3.text;
 	delete $4;
 	$$ = tmp;
@@ -10992,6 +11014,53 @@ subroutine_call
       { PCallTask*tmp = pform_make_call_task(@1, *$1, *$2);
 	delete $1;
 	delete $2;
+	$$ = tmp;
+      }
+  | hierarchy_identifier argument_list_parens '.' IDENTIFIER argument_list_parens_opt
+      { /* Method-call statement on a call result: f(args).method(args);
+	   (IEEE 1800-2017 8.10). The receiver call is preserved as an
+	   expression and the method is dispatched against its exact
+	   result type at elaboration. */
+	PECallFunction*rcv = pform_make_call_function(@1, *$1, *$2, 0);
+	PCallTask*tmp = new PCallTask(rcv, lex_strings.make($4), *$5);
+	FILE_NAME(tmp, @3);
+	delete $1;
+	delete $2;
+	delete[]$4;
+	delete $5;
+	$$ = tmp;
+      }
+  | TYPE_IDENTIFIER K_SCOPE_RES IDENTIFIER argument_list_parens '.' IDENTIFIER argument_list_parens_opt
+      { /* Method-call statement on a static-method call result:
+	   Class::get(args).method(args); (IEEE 1800-2017 8.10, 8.23). */
+	pform_name_t hident;
+	hident.push_back(name_component_t(lex_strings.make($1.text)));
+	hident.push_back(name_component_t(lex_strings.make($3)));
+	PECallFunction*rcv = pform_make_call_function(@1, hident, *$4, 0);
+	PCallTask*tmp = new PCallTask(rcv, lex_strings.make($6), *$7);
+	FILE_NAME(tmp, @5);
+	delete[]$1.text;
+	delete[]$3;
+	delete $4;
+	delete[]$6;
+	delete $7;
+	$$ = tmp;
+      }
+  | TYPE_IDENTIFIER type_parameter_value K_SCOPE_RES IDENTIFIER argument_list_parens '.' IDENTIFIER argument_list_parens_opt
+      { /* Method-call statement on a parameterized static-method call
+	   result: Class#(args)::get(args).method(args);
+	   (IEEE 1800-2017 8.10, 8.25). */
+	pform_name_t hident;
+	hident.push_back(name_component_t(lex_strings.make($1.text)));
+	hident.push_back(name_component_t(lex_strings.make($4)));
+	PECallFunction*rcv = pform_make_call_function(@1, hident, *$5, $2);
+	PCallTask*tmp = new PCallTask(rcv, lex_strings.make($7), *$8);
+	FILE_NAME(tmp, @6);
+	delete[]$1.text;
+	delete[]$4;
+	delete $5;
+	delete[]$7;
+	delete $8;
 	$$ = tmp;
       }
   | package_scope hierarchy_identifier { lex_in_package_scope(0); } argument_list_parens_opt

--- a/pform_dump.cc
+++ b/pform_dump.cc
@@ -421,6 +421,10 @@ void PEConcat::dump(ostream&out) const
 
 void PECallFunction::dump(ostream &out) const
 {
+      if (receiver_) {
+	    receiver_->dump(out);
+	    out << ".";
+      }
       out << path_ << "(" << parms_ << ")";
 }
 

--- a/tests/m1_enum_method_chain_test.sv
+++ b/tests/m1_enum_method_chain_test.sv
@@ -1,0 +1,48 @@
+// M1 typed-expression dispatch: enumeration methods applied to
+// function-call results and to other enum-method results
+// (IEEE 1800-2017 6.19.5). Reduced from gap audit G31 (probe p32).
+module m1_enum_method_chain_test;
+  typedef enum { RED, GREEN, BLUE } color_t;
+
+  function automatic color_t next_color(color_t c);
+    return c.next();
+  endfunction
+
+  initial begin
+    color_t c;
+    string s;
+    int errors = 0;
+
+    c = RED;
+
+    // Enum method on a user-function result.
+    s = next_color(c).name();
+    if (s != "GREEN") begin
+      $display("FAIL: next_color(RED).name() = %s, expected GREEN", s);
+      errors++;
+    end
+
+    // Enum method chained on an enum-method result.
+    s = c.next().name();
+    if (s != "GREEN") begin
+      $display("FAIL: RED.next().name() = %s, expected GREEN", s);
+      errors++;
+    end
+
+    // Deeper chain: next().next() wraps modulo the enum.
+    if (c.next().next() !== BLUE) begin
+      $display("FAIL: RED.next().next() != BLUE");
+      errors++;
+    end
+
+    // Value-returning chain into num()/name() composition.
+    s = next_color(next_color(c)).name();
+    if (s != "BLUE") begin
+      $display("FAIL: next_color(next_color(RED)).name() = %s, expected BLUE", s);
+      errors++;
+    end
+
+    if (errors == 0) $display("PASS");
+    $finish;
+  end
+endmodule

--- a/tests/m1_method_chain_builder_test.sv
+++ b/tests/m1_method_chain_builder_test.sv
@@ -1,0 +1,51 @@
+// M1 typed-expression dispatch: builder-style method chaining on class
+// handle returns, including nested calls of the SAME method (exercises
+// the vvp automatic-context returned-frame fix). IEEE 1800-2017 8.10.
+// Reduced from gap audit G32 (probe p84).
+module m1_method_chain_builder_test;
+  class C;
+    int v;
+    function C with_v(int x);
+      v = x;
+      return this;
+    endfunction
+    function C mul_v(int x);
+      v = v * x;
+      return this;
+    endfunction
+  endclass
+
+  initial begin
+    C c, c2, r;
+    int errors = 0;
+
+    // Two-link chain of the same method.
+    c = new;
+    r = c.with_v(42).with_v(100);
+    if (r != c || c.v !== 100) begin
+      $display("FAIL: chain same-method r==c:%0d c.v=%0d", (r == c), c.v);
+      errors++;
+    end
+
+    // Three-link chain mixing methods, read property off the chain.
+    c = new;
+    if (c.with_v(5).mul_v(3).with_v(c.v + 1).v !== 16) begin
+      $display("FAIL: mixed chain c.v=%0d, expected 16", c.v);
+      errors++;
+    end
+
+    // Nested same-method call as an argument sub-expression
+    // (returned-frame vs pre-allocated same-scope frame).
+    c = new;
+    c2 = new;
+    r = c.with_v(c2.with_v(3).v);
+    if (r != c || c.v !== 3 || c2.v !== 3) begin
+      $display("FAIL: nested same-method r==c:%0d c.v=%0d c2.v=%0d",
+               (r == c), c.v, c2.v);
+      errors++;
+    end
+
+    if (errors == 0) $display("PASS");
+    $finish;
+  end
+endmodule

--- a/tests/m1_method_on_call_result_test.sv
+++ b/tests/m1_method_on_call_result_test.sv
@@ -1,0 +1,48 @@
+// M1 typed-expression dispatch: method calls and property access on
+// class-valued function-call results (IEEE 1800-2017 8.10, 13.4.1).
+// Reduced from UVM factory/builder failures (gap audit G22/G32).
+module m1_method_on_call_result_test;
+  int side_hits = 0;
+
+  class C;
+    int v;
+    function int get_v();
+      return v;
+    endfunction
+    function void bump();
+      side_hits = side_hits + 1;
+    endfunction
+  endclass
+
+  function automatic C make_c(int x);
+    C c = new;
+    c.v = x;
+    return c;
+  endfunction
+
+  initial begin
+    int errors = 0;
+
+    // Method call on a function-call result.
+    if (make_c(42).get_v() !== 42) begin
+      $display("FAIL: make_c(42).get_v() = %0d, expected 42", make_c(42).get_v());
+      errors++;
+    end
+
+    // Property access on a function-call result.
+    if (make_c(7).v !== 7) begin
+      $display("FAIL: make_c(7).v = %0d, expected 7", make_c(7).v);
+      errors++;
+    end
+
+    // Void-method-call statement on a function-call result.
+    make_c(1).bump();
+    if (side_hits !== 1) begin
+      $display("FAIL: void method statement ran %0d times, expected 1", side_hits);
+      errors++;
+    end
+
+    if (errors == 0) $display("PASS");
+    $finish;
+  end
+endmodule

--- a/tests/m1_static_accessor_chain_test.sv
+++ b/tests/m1_static_accessor_chain_test.sv
@@ -1,0 +1,83 @@
+// M1 typed-expression dispatch: singleton/static accessor patterns
+// C::get().method(), C::get().prop, and parameterized
+// C#(T)::get().method(), in expression and statement contexts
+// (IEEE 1800-2017 8.10, 8.23, 8.25). Reduced from gap audit G22
+// (uvm_factory::get().create_object_by_name).
+module m1_static_accessor_chain_test;
+  int stmt_hits = 0;
+
+  class S;
+    static S inst;
+    int v = 5;
+    static function S get();
+      if (inst == null) inst = new;
+      return inst;
+    endfunction
+    function int get_v();
+      return v;
+    endfunction
+    function void poke();
+      stmt_hits = stmt_hits + 1;
+    endfunction
+    task do_work(int n);
+      #1 stmt_hits = stmt_hits + n;
+    endtask
+  endclass
+
+  class P #(type T = int);
+    static P #(T) inst;
+    T val;
+    static function P#(T) get();
+      if (inst == null) inst = new;
+      return inst;
+    endfunction
+    function int size_of();
+      return $bits(val);
+    endfunction
+  endclass
+
+  initial begin
+    int errors = 0;
+
+    // Static accessor + method call (expression).
+    if (S::get().get_v() !== 5) begin
+      $display("FAIL: S::get().get_v() = %0d, expected 5", S::get().get_v());
+      errors++;
+    end
+
+    // Static accessor + property access.
+    if (S::get().v !== 5) begin
+      $display("FAIL: S::get().v = %0d, expected 5", S::get().v);
+      errors++;
+    end
+
+    // Parameterized specialization accessor + method call.
+    if (P#(byte)::get().size_of() !== 8) begin
+      $display("FAIL: P#(byte)::get().size_of() = %0d, expected 8",
+               P#(byte)::get().size_of());
+      errors++;
+    end
+    if (P#(shortint)::get().size_of() !== 16) begin
+      $display("FAIL: P#(shortint)::get().size_of() = %0d, expected 16",
+               P#(shortint)::get().size_of());
+      errors++;
+    end
+
+    // Statement form: void method on static accessor result.
+    S::get().poke();
+    if (stmt_hits !== 1) begin
+      $display("FAIL: S::get().poke(); ran %0d times, expected 1", stmt_hits);
+      errors++;
+    end
+
+    // Statement form: TASK on static accessor result (consumes time).
+    S::get().do_work(5);
+    if (stmt_hits !== 6) begin
+      $display("FAIL: S::get().do_work(5); stmt_hits=%0d, expected 6", stmt_hits);
+      errors++;
+    end
+
+    if (errors == 0) $display("PASS");
+    $finish;
+  end
+endmodule

--- a/tests/m1_uvm_cfgdb_class_test.sv
+++ b/tests/m1_uvm_cfgdb_class_test.sv
@@ -1,0 +1,28 @@
+// M1 / G24 UVM-level regression: class-valued uvm_config_db set/get round trip.
+import uvm_pkg::*;
+`include "uvm_macros.svh"
+
+class my_cfg extends uvm_object;
+  `uvm_object_utils(my_cfg)
+  int magic = 0;
+  function new(string name = "my_cfg");
+    super.new(name);
+  endfunction
+endclass
+
+module m1_uvm_cfgdb_class_test;
+  initial begin
+    my_cfg put_c, got_c;
+    put_c = new("the_cfg");
+    put_c.magic = 77;
+
+    uvm_config_db#(my_cfg)::set(null, "*", "cfg", put_c);
+    if (!uvm_config_db#(my_cfg)::get(null, "", "cfg", got_c))
+      $display("FAIL: config_db get returned 0");
+    else if (got_c == null) $display("FAIL: got null handle");
+    else if (got_c.magic !== 77) $display("FAIL: magic=%0d", got_c.magic);
+    else if (got_c != put_c) $display("FAIL: handle mismatch");
+    else $display("PASS cfgdb");
+    $finish;
+  end
+endmodule

--- a/tests/m1_uvm_factory_by_name_test.sv
+++ b/tests/m1_uvm_factory_by_name_test.sv
@@ -1,0 +1,36 @@
+// M1 / G22 UVM-level regression: factory by-name creation through the
+// canonical IEEE 1800.2 accessor chain uvm_factory::get().create_object_by_name.
+// Language root cause was method dispatch on function-call results
+// (IEEE 1800-2017 8.10); this confirms the unmodified Accellera flow.
+import uvm_pkg::*;
+`include "uvm_macros.svh"
+
+class m1_factory_obj extends uvm_object;
+  `uvm_object_utils(m1_factory_obj)
+  function new(string name = "m1_factory_obj");
+    super.new(name);
+  endfunction
+endclass
+
+module m1_uvm_factory_by_name_test;
+  initial begin
+    uvm_object obj;
+    m1_factory_obj mo;
+    int errors = 0;
+
+    obj = uvm_factory::get().create_object_by_name("m1_factory_obj", "", "inst1");
+    if (obj == null) begin
+      $display("FAIL: create_object_by_name returned null");
+      errors++;
+    end else if (!$cast(mo, obj)) begin
+      $display("FAIL: cast to m1_factory_obj failed");
+      errors++;
+    end else if (mo.get_name() != "inst1") begin
+      $display("FAIL: created name = %s, expected inst1", mo.get_name());
+      errors++;
+    end
+
+    if (errors == 0) $display("PASS");
+    $finish;
+  end
+endmodule

--- a/tests/m1_virtual_dispatch_chain_test.sv
+++ b/tests/m1_virtual_dispatch_chain_test.sv
@@ -1,0 +1,54 @@
+// M1 typed-expression dispatch: virtual method dispatch through
+// function-call-result receivers (IEEE 1800-2017 8.20). The static type
+// of the receiver expression is the base class; the runtime type selects
+// the override.
+module m1_virtual_dispatch_chain_test;
+  class Base;
+    virtual function string who();
+      return "Base";
+    endfunction
+    function Base me();
+      return this;
+    endfunction
+  endclass
+
+  class Derived extends Base;
+    virtual function string who();
+      return "Derived";
+    endfunction
+  endclass
+
+  function automatic Base make_derived();
+    Derived d = new;
+    return d;
+  endfunction
+
+  initial begin
+    Derived d = new;
+    Base b = d;
+    int errors = 0;
+
+    // Virtual dispatch on a function-return receiver (static type Base,
+    // dynamic type Derived).
+    if (make_derived().who() != "Derived") begin
+      $display("FAIL: make_derived().who() = %s, expected Derived",
+               make_derived().who());
+      errors++;
+    end
+
+    // Virtual dispatch chained through a this-returning method.
+    if (b.me().who() != "Derived") begin
+      $display("FAIL: b.me().who() = %s, expected Derived", b.me().who());
+      errors++;
+    end
+
+    // Non-virtual behavior is unchanged: static call goes to Base.
+    if (b.who() != "Derived") begin
+      $display("FAIL: b.who() = %s, expected Derived (virtual)", b.who());
+      errors++;
+    end
+
+    if (errors == 0) $display("PASS");
+    $finish;
+  end
+endmodule

--- a/tests/m2_uarray_assign_test.sv
+++ b/tests/m2_uarray_assign_test.sv
@@ -1,0 +1,70 @@
+// M2: whole unpacked-array assignment (IEEE 1800-2017 7.6) between all
+// combinations of static-array signals and class properties. Reduced
+// from UVM uvm_field_sarray_int COPY failures (gap audit G25).
+module m2_uarray_assign_test;
+  class C;
+    int arr[4];
+    function void copy_from(C rhs);
+      arr = rhs.arr;   // property = property (the UVM field-macro shape)
+    endfunction
+  endclass
+
+  int x[4], y[4];
+  byte bsrc[6];
+  byte bdst[6];
+
+  initial begin
+    C a = new, b = new;
+    int lv[4];
+    int errors = 0;
+
+    // signal = signal
+    foreach (y[i]) y[i] = (i + 1) * 5;
+    x = y;
+    if (x[0] !== 5 || x[3] !== 20) begin
+      $display("FAIL: sig=sig x[0]=%0d x[3]=%0d", x[0], x[3]);
+      errors++;
+    end
+
+    // property = property (inside class method)
+    foreach (a.arr[i]) a.arr[i] = 10 * (i + 1);
+    b.copy_from(a);
+    if (b.arr[0] !== 10 || b.arr[3] !== 40) begin
+      $display("FAIL: prop=prop b.arr[0]=%0d b.arr[3]=%0d", b.arr[0], b.arr[3]);
+      errors++;
+    end
+
+    // local = property
+    lv = a.arr;
+    if (lv[2] !== 30) begin
+      $display("FAIL: local=prop lv[2]=%0d", lv[2]);
+      errors++;
+    end
+
+    // property = local
+    lv[2] = 77;
+    b.arr = lv;
+    if (b.arr[2] !== 77) begin
+      $display("FAIL: prop=local b.arr[2]=%0d", b.arr[2]);
+      errors++;
+    end
+
+    // source values must be copied, not aliased
+    y[0] = 999;
+    if (x[0] !== 5) begin
+      $display("FAIL: aliasing detected, x[0]=%0d", x[0]);
+      errors++;
+    end
+
+    // byte-element arrays (different element width than int)
+    foreach (bsrc[i]) bsrc[i] = 8'h20 + i;
+    bdst = bsrc;
+    if (bdst[5] !== 8'h25) begin
+      $display("FAIL: byte array bdst[5]=%02h", bdst[5]);
+      errors++;
+    end
+
+    if (errors == 0) $display("PASS");
+    $finish;
+  end
+endmodule

--- a/tests/m2_uvm_field_array_dyn_test.sv
+++ b/tests/m2_uvm_field_array_dyn_test.sv
@@ -1,0 +1,51 @@
+// G25 probe: uvm_field_sarray_int copy/clone propagation (UVM field
+// automation; Accellera reference behavior).
+import uvm_pkg::*;
+`include "uvm_macros.svh"
+
+class txn extends uvm_object;
+  int arr[];
+  int scalar;
+  `uvm_object_utils_begin(txn)
+    `uvm_field_array_int(arr, UVM_ALL_ON)
+    `uvm_field_int(scalar, UVM_ALL_ON)
+  `uvm_object_utils_end
+  function new(string name = "txn");
+    super.new(name);
+  endfunction
+endclass
+
+module m2_uvm_field_array_dyn_test;
+  initial begin
+    txn a, b;
+    uvm_object o;
+    int errors = 0;
+
+    a = new("a");
+    a.arr = new[4]; foreach (a.arr[i]) a.arr[i] = 10 * (i + 1);
+    a.scalar = 99;
+
+    o = a.clone();
+    if (o == null) begin
+      $display("FAIL: clone returned null");
+      errors++;
+    end else if (!$cast(b, o)) begin
+      $display("FAIL: cast of clone failed");
+      errors++;
+    end else begin
+      if (b.scalar !== 99) begin
+        $display("FAIL: scalar not copied (%0d)", b.scalar);
+        errors++;
+      end
+      foreach (b.arr[i]) begin
+        if (b.arr[i] !== 10 * (i + 1)) begin
+          $display("FAIL: arr[%0d] = %0d, expected %0d", i, b.arr[i], 10 * (i + 1));
+          errors++;
+        end
+      end
+    end
+
+    if (errors == 0) $display("PASS g25-dyn");
+    $finish;
+  end
+endmodule

--- a/tests/m2_uvm_field_sarray_copy_test.sv
+++ b/tests/m2_uvm_field_sarray_copy_test.sv
@@ -1,0 +1,51 @@
+// M2 / G25 UVM-level regression: uvm_field_sarray_int copy/clone propagation (UVM field
+// automation; Accellera reference behavior).
+import uvm_pkg::*;
+`include "uvm_macros.svh"
+
+class txn extends uvm_object;
+  int arr[4];
+  int scalar;
+  `uvm_object_utils_begin(txn)
+    `uvm_field_sarray_int(arr, UVM_ALL_ON)
+    `uvm_field_int(scalar, UVM_ALL_ON)
+  `uvm_object_utils_end
+  function new(string name = "txn");
+    super.new(name);
+  endfunction
+endclass
+
+module m2_uvm_field_sarray_copy_test;
+  initial begin
+    txn a, b;
+    uvm_object o;
+    int errors = 0;
+
+    a = new("a");
+    foreach (a.arr[i]) a.arr[i] = 10 * (i + 1);
+    a.scalar = 99;
+
+    o = a.clone();
+    if (o == null) begin
+      $display("FAIL: clone returned null");
+      errors++;
+    end else if (!$cast(b, o)) begin
+      $display("FAIL: cast of clone failed");
+      errors++;
+    end else begin
+      if (b.scalar !== 99) begin
+        $display("FAIL: scalar not copied (%0d)", b.scalar);
+        errors++;
+      end
+      foreach (b.arr[i]) begin
+        if (b.arr[i] !== 10 * (i + 1)) begin
+          $display("FAIL: arr[%0d] = %0d, expected %0d", i, b.arr[i], 10 * (i + 1));
+          errors++;
+        end
+      end
+    end
+
+    if (errors == 0) $display("PASS g25");
+    $finish;
+  end
+endmodule

--- a/tests/m2_uvm_register_cb_test.sv
+++ b/tests/m2_uvm_register_cb_test.sv
@@ -1,0 +1,47 @@
+// M2 / G23 UVM-level regression (RESOLVED-BY-PRIOR; regression protection): `uvm_register_cb(T, CB) macro must not corrupt class layout.
+import uvm_pkg::*;
+`include "uvm_macros.svh"
+
+class my_cb extends uvm_callback;
+  function new(string name = "my_cb");
+    super.new(name);
+  endfunction
+  virtual function void on_event(int x);
+  endfunction
+endclass
+
+class my_comp extends uvm_component;
+  `uvm_component_utils(my_comp)
+  `uvm_register_cb(my_comp, my_cb)
+  function new(string name, uvm_component parent);
+    super.new(name, parent);
+  endfunction
+  function void hit(int x);
+    `uvm_do_callbacks(my_comp, my_cb, on_event(x))
+  endfunction
+endclass
+
+class counting_cb extends my_cb;
+  int count = 0;
+  function new(string name = "counting_cb");
+    super.new(name);
+  endfunction
+  virtual function void on_event(int x);
+    count = count + x;
+  endfunction
+endclass
+
+module m2_uvm_register_cb_test;
+  initial begin
+    my_comp c;
+    counting_cb cb;
+    c = new("c", null);
+    cb = new("cb");
+    uvm_callbacks#(my_comp, my_cb)::add(c, cb);
+    c.hit(3);
+    c.hit(4);
+    if (cb.count == 7) $display("PASS g23");
+    else $display("FAIL g23 count=%0d expected 7", cb.count);
+    $finish;
+  end
+endmodule

--- a/tests/negative/m1_bad_enum_method_on_call.sv
+++ b/tests/negative/m1_bad_enum_method_on_call.sv
@@ -1,0 +1,15 @@
+// NEGATIVE test: applying an unknown enumeration method to an
+// enum-typed function result must produce a compile-time diagnostic
+// (IEEE 1800-2017 6.19.5). Expected: compilation FAILS.
+module m1_bad_enum_method_on_call;
+  typedef enum { A, B } e_t;
+
+  function automatic e_t f(e_t x);
+    return x;
+  endfunction
+
+  initial begin
+    string s;
+    s = f(A).not_an_enum_method();
+  end
+endmodule

--- a/tests/negative/m1_bad_method_on_call_result.sv
+++ b/tests/negative/m1_bad_method_on_call_result.sv
@@ -1,0 +1,22 @@
+// NEGATIVE test: calling an unknown method on a class-valued
+// function-call result must produce a compile-time diagnostic, not a
+// silent stub (IEEE 1800-2017 8.10; manifesto principle 4).
+// Expected: compilation FAILS mentioning `no_such_method`.
+module m1_bad_method_on_call_result;
+  class C;
+    int v;
+    function int get_v();
+      return v;
+    endfunction
+  endclass
+
+  function automatic C make_c();
+    C c = new;
+    return c;
+  endfunction
+
+  initial begin
+    int x;
+    x = make_c().no_such_method();
+  end
+endmodule

--- a/tests/negative/m2_uarray_size_mismatch.sv
+++ b/tests/negative/m2_uarray_size_mismatch.sv
@@ -1,0 +1,10 @@
+// NEGATIVE test: whole-array assignment between unpacked arrays of
+// different element counts is not assignment compatible
+// (IEEE 1800-2017 7.6, 6.22.2). Expected: compilation FAILS.
+module m2_uarray_size_mismatch;
+  int a[4];
+  int b[5];
+  initial begin
+    a = b;
+  end
+endmodule

--- a/tests/negative/run_negative.sh
+++ b/tests/negative/run_negative.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Negative-test runner: each tests/negative/*.sv must FAIL to compile
+# and the diagnostic must mention the marker embedded in the file name
+# or a generic error. A test that compiles cleanly is a FAILURE of the
+# suite (silent acceptance of illegal input — manifesto principle 4).
+#
+# Usage: PATH=<install>/bin:$PATH bash tests/negative/run_negative.sh
+
+BIN=$(which iverilog)
+DIR=$(dirname "$0")
+PASS=0
+FAIL=0
+
+for sv in "$DIR"/*.sv; do
+    name=$(basename "$sv" .sv)
+    printf "  %-40s " "$name"
+    out=$("$BIN" -g2012 -o /dev/null "$sv" 2>&1)
+    status=$?
+    if [ $status -ne 0 ] && echo "$out" | grep -qiE "error"; then
+        echo "PASS (rejected with diagnostic)"
+        PASS=$((PASS+1))
+    else
+        echo "FAIL (accepted or no diagnostic)"
+        echo "$out" | head -3
+        FAIL=$((FAIL+1))
+    fi
+done
+
+echo ""
+echo "Negative tests: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ]

--- a/tests/probes/g66_unit_class_name_collision_uvm.sv
+++ b/tests/probes/g66_unit_class_name_collision_uvm.sv
@@ -1,0 +1,68 @@
+// G66 reproducer (VERIFIED-FAILS 2026-07-11): declaring a
+// compilation-unit class whose name collides with identifiers used
+// inside uvm_pkg (here: `comp`, used as variable/port names in the UVM
+// phase traversal code) breaks elaboration of the UNRELATED package
+// code once the class participates in a parameterized specialization
+// (uvm_callbacks#(comp, my_cb)).
+//
+// Errors observed:
+//   error: Unable to bind variable `comp' in `uvm_pkg.uvm_bottomup_phase.traverse...'
+//   error: No function named `comp_type.comp' found ...
+//
+// Renaming the class (e.g. `my_comp`) makes the identical test pass —
+// see tests/m2_uvm_register_cb_test.sv.
+//
+// Simple reductions (plain shadowing of package-local variables/ports
+// by a $unit class name, even derived from a package base) PASS, so
+// the defect is specific to specialization-time re-elaboration.
+// IEEE 1800-2017 3.12.1 (compilation units), 23.9 (scope rules),
+// 8.25 (parameterized classes).
+//
+// Run: iverilog -g2012 -I uvm-core/src -DUVM_NO_DPI uvm-core/src/uvm_pkg.sv <this file>
+// Expected once fixed: prints "PASS g66-uvm".
+import uvm_pkg::*;
+`include "uvm_macros.svh"
+
+class my_cb extends uvm_callback;
+  function new(string name = "my_cb");
+    super.new(name);
+  endfunction
+  virtual function void on_event(int x);
+  endfunction
+endclass
+
+class comp extends uvm_component;   // <-- colliding name is the trigger
+  `uvm_component_utils(comp)
+  `uvm_register_cb(comp, my_cb)
+  function new(string name, uvm_component parent);
+    super.new(name, parent);
+  endfunction
+  function void hit(int x);
+    `uvm_do_callbacks(comp, my_cb, on_event(x))
+  endfunction
+endclass
+
+class counting_cb extends my_cb;
+  int count = 0;
+  function new(string name = "counting_cb");
+    super.new(name);
+  endfunction
+  virtual function void on_event(int x);
+    count = count + x;
+  endfunction
+endclass
+
+module g66_unit_class_name_collision_uvm;
+  initial begin
+    comp c;
+    counting_cb cb;
+    c = new("c", null);
+    cb = new("cb");
+    uvm_callbacks#(comp, my_cb)::add(c, cb);
+    c.hit(3);
+    c.hit(4);
+    if (cb.count == 7) $display("PASS g66-uvm");
+    else $display("FAIL g66-uvm count=%0d expected 7", cb.count);
+    $finish;
+  end
+endmodule

--- a/vvp/vthread.cc
+++ b/vvp/vthread.cc
@@ -3718,7 +3718,35 @@ vvp_context_item_t vthread_get_rd_context_item_scoped(unsigned context_idx, __vp
       vvp_context_t use_context = 0;
       const char*source = "none";
 
-      if (running_thread->wt_context
+      /* After a callf joins, do_join's pop-push branch moves the returned
+         child frame to the head of rd_context and removes it from the
+         wt_context chain. Until the matching %free, scoped reads must see
+         that returned frame (function result and output copy-out), even
+         when the caller holds a pre-%alloc'd frame of the SAME scope at
+         the write head. That happens for nested calls of one function,
+         e.g. builder chains obj.f(...).f(...) or f(g(f(x))) with f==g.
+         The returned frame is recognizable because it is live for this
+         scope but no longer anywhere in the wt chain. The %alloc staging
+         window is not affected: there the caller frame at rd-head is
+         still a member of the wt chain. */
+      bool rd_head_returned_frame = false;
+      if (running_thread->rd_context
+          && running_thread->rd_context != running_thread->wt_context
+          && context_live_matches_scope_(running_thread->rd_context, ctx_scope)) {
+            rd_head_returned_frame = true;
+            for (vvp_context_t search = running_thread->wt_context ; search ;
+                 search = vvp_get_stacked_context(search)) {
+                  if (search == running_thread->rd_context) {
+                        rd_head_returned_frame = false;
+                        break;
+                  }
+            }
+      }
+
+      if (rd_head_returned_frame) {
+            use_context = running_thread->rd_context;
+            source = "rd-head-returned";
+      } else if (running_thread->wt_context
           && context_live_matches_scope_(running_thread->wt_context, ctx_scope)) {
             use_context = running_thread->wt_context;
             source = "wt-head";


### PR DESCRIPTION
## Summary

Implements manifesto milestones **M1 (typed-expression method dispatch)** and the first **M2** item (**whole unpacked-array assignment**), closing gap-audit entries **G22, G25, G31, G32**, verifying **G23/G24** pass, and recording new gap **G66**. Also imports the governing implementation manifesto to `docs/conformance/`.

## M1 — typed-expression method dispatch (`51c0d94`)

IEEE 1800-2017 §8.10, §6.19.5, §8.23, §8.25, §13.4.1.

1. **Parser discarded method-call receivers** — the `expr_primary '.' IDENT (args)` rules executed `delete $1;`, so `f().method()`, builder chains, `enum_f().name()`, and `uvm_factory::get().create_object_by_name(...)` parsed but lost the receiver (silent miscompile). Receivers are now preserved: PEIdent receivers splice into hierarchical paths (existing semantics untouched); everything else rides receiver-carrying `PECallFunction`/`PCallTask`. Statement-context single-hop chains added to the grammar (+2 s/r conflicts, resolved by shift = the new rules).
2. **No expression-keyed dispatch** — the dispatch tail of `elaborate_expr_method_` was extracted into shared `elaborate_method_dispatch_(sub_expr, exact_type, …)`; new receiver paths dispatch against the receiver's exact `net_type()`. Statement context handles tasks/void methods via `elaborate_build_call_`, discards non-void results per §13.4.1.
3. **Pre-existing vvp automatic-context bug** — after a callf join, the returned child frame was shadowed by a same-scope pre-`%alloc`'d caller frame in `vthread_get_rd_context_item_scoped`, so nested calls of the *same* function (`c.f(...).f(...)`) read null/zero results. Confirmed present in a pristine build of `a014332`; fixed by preferring the returned rd-head frame when it is live and absent from the wt chain.

## M2 — whole unpacked-array assignment (`4fe341e`)

IEEE 1800-2017 §7.6. UVM's `uvm_field_sarray_int` COPY op is literally `ARG = local_rhs__.ARG;` — that assignment was a **silent no-op** between class properties (codegen degraded to 1-bit `%prop/v`) and a hard error for word-array signal sources. `PAssign::elaborate` now lowers whole 1-D static-array assignments into a canonical-index element copy loop (`make_uarray_copy_loop_`), reusing existing word-indexed machinery; incompatible shapes get a specific diagnostic. Fixes G25 (UVM field-array clone/copy) and plain `x = y` array assignments.

Also: G23 (`uvm_register_cb`) verified resolved-by-prior with a regression test; new gap **G66** (compilation-unit class name colliding with uvm_pkg-internal identifiers breaks unrelated package elaboration under specialization) recorded with a preserved reproducer in `tests/probes/`.

## Tests

- 12 positive tests in `tests/` (m1_*: call-result methods/properties/chains/enum/static-accessor/virtual dispatch, UVM factory by-name, class-valued config-db; m2_*: uarray assignment matrix, UVM sarray + dynamic field-array clone, register_cb) — the UVM-level tests run against unmodified Accellera uvm-core 2020.3.1.
- `tests/negative/` + runner: 3 tests asserting controlled diagnostics (unknown method/enum method on call results, uarray size mismatch).

## Regression evidence

| Suite | Baseline (a014332) | This branch |
|---|---|---|
| UVM regression (`.github/uvm_test.sh`) | 98/98 | **108/108** |
| ivtest vvp_reg.pl | 2961/3101 pass, 132 fail | **identical**, same failure list |
| ivtest vpi_reg.pl | 85/85 | **85/85** |
| ivtest vvp_reg.py | 284 ran, 12 fail | **identical**, same failure list |
| `make check` | pass | pass |

## Docs

- `docs/conformance/iverilog_ieee1800_uvm_manifesto.md` (governing plan)
- `docs/conformance/session_logs/2026-07-11_typed_expression_dispatch.md` (clauses, root causes, evidence per checkpoint)
- `docs/conformance/CURRENT_WORK.md` (continuation state)
- Gap audit updated for G22/G23/G24/G25/G31/G32 + new G66

## Known limitations

- Statement-context method chains cover single-hop `<call>.method(args);`; multi-hop statement chains not yet parsed (expression context covers arbitrary depth).
- Whole-array assignment covers 1-D static arrays; multi-dimensional copies fall back to the previous (loud-error) paths.
- Receiver-call failure diagnostics print twice (pre-existing test_width/elaborate double-elaboration pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017kkDsUYVP7DtfaJLMQNgSC