### PR TITLE
elab+z3: M3 constraint solver — implication/if-else/enum/inheritance + array size & foreach constraints

### DIFF
--- a/PExpr.cc
+++ b/PExpr.cc
@@ -646,6 +646,56 @@ PEVoid::~PEVoid()
 {
 }
 
+PEConstraintIf::PEConstraintIf(PExpr*cond, std::list<PExpr*>*then_items,
+			       std::list<PExpr*>*else_items)
+: cond_(cond)
+{
+      if (then_items) {
+	    then_items_.assign(then_items->begin(), then_items->end());
+	    delete then_items;
+      }
+      if (else_items) {
+	    else_items_.assign(else_items->begin(), else_items->end());
+	    delete else_items;
+      }
+}
+
+PEConstraintIf::~PEConstraintIf()
+{
+      delete cond_;
+      for (PExpr*item : then_items_)
+	    delete item;
+      for (PExpr*item : else_items_)
+	    delete item;
+}
+
+void PEConstraintIf::dump(std::ostream&out) const
+{
+      out << "if (";
+      if (cond_) cond_->dump(out);
+      out << ") { ... }";
+      if (!else_items_.empty())
+	    out << " else { ... }";
+}
+
+unsigned PEConstraintIf::test_width(Design*, NetScope*, width_mode_t&)
+{
+      expr_type_ = IVL_VT_BOOL;
+      expr_width_ = 1;
+      min_width_ = 1;
+      signed_flag_ = false;
+      return expr_width_;
+}
+
+NetExpr* PEConstraintIf::elaborate_expr(Design*des, NetScope*, unsigned,
+					unsigned) const
+{
+      cerr << get_fileline() << ": error: Conditional constraint sets are "
+	   << "only valid inside constraint blocks." << endl;
+      des->errors += 1;
+      return 0;
+}
+
 PEInside::PEInside(PExpr* expr, std::list<inside_range_t>* ranges)
 : expr_(expr)
 {

--- a/PExpr.cc
+++ b/PExpr.cc
@@ -696,6 +696,50 @@ NetExpr* PEConstraintIf::elaborate_expr(Design*des, NetScope*, unsigned,
       return 0;
 }
 
+PEConstraintForeach::PEConstraintForeach(perm_string array_name,
+					 std::list<perm_string>*loop_vars,
+					 std::list<PExpr*>*items)
+: array_name_(array_name)
+{
+      if (loop_vars) {
+	    loop_vars_.assign(loop_vars->begin(), loop_vars->end());
+	    delete loop_vars;
+      }
+      if (items) {
+	    items_.assign(items->begin(), items->end());
+	    delete items;
+      }
+}
+
+PEConstraintForeach::~PEConstraintForeach()
+{
+      for (PExpr*item : items_)
+	    delete item;
+}
+
+void PEConstraintForeach::dump(std::ostream&out) const
+{
+      out << "foreach (" << array_name_ << "[...]) { ... }";
+}
+
+unsigned PEConstraintForeach::test_width(Design*, NetScope*, width_mode_t&)
+{
+      expr_type_ = IVL_VT_BOOL;
+      expr_width_ = 1;
+      min_width_ = 1;
+      signed_flag_ = false;
+      return expr_width_;
+}
+
+NetExpr* PEConstraintForeach::elaborate_expr(Design*des, NetScope*, unsigned,
+					     unsigned) const
+{
+      cerr << get_fileline() << ": error: Iterative constraints are only "
+	   << "valid inside constraint blocks." << endl;
+      des->errors += 1;
+      return 0;
+}
+
 PEInside::PEInside(PExpr* expr, std::list<inside_range_t>* ranges)
 : expr_(expr)
 {

--- a/PExpr.h
+++ b/PExpr.h
@@ -1030,6 +1030,8 @@ class PECallFunction : public PExpr {
       const struct parmvalue_t* leading_type_args() const
             { return leading_type_args_; }
 
+      const pform_scoped_name_t& path() const { return path_; }
+
       virtual void dump(std::ostream &) const override;
 
       virtual void declare_implicit_nets(LexicalScope*scope, NetNet::Type type) override;
@@ -1304,6 +1306,34 @@ class PEConstraintIf : public PExpr {
       PExpr*cond_;
       std::list<PExpr*> then_items_;
       std::list<PExpr*> else_items_;
+};
+
+/*
+ * Represents an iterative constraint (IEEE 1800-2017 18.5.8):
+ *   foreach (array_name[i]) { items... }
+ * Only meaningful in constraint IR generation.
+ */
+class PEConstraintForeach : public PExpr {
+    public:
+      PEConstraintForeach(perm_string array_name,
+			  std::list<perm_string>*loop_vars,
+			  std::list<PExpr*>*items);
+      ~PEConstraintForeach() override;
+
+      perm_string array_name() const { return array_name_; }
+      const std::vector<perm_string>& loop_vars() const { return loop_vars_; }
+      const std::list<PExpr*>& items() const { return items_; }
+
+      void dump(std::ostream&out) const override;
+      unsigned test_width(Design*des, NetScope*scope,
+			  width_mode_t&mode) override;
+      NetExpr* elaborate_expr(Design*des, NetScope*scope,
+			      unsigned w, unsigned flags) const override;
+
+    private:
+      perm_string array_name_;
+      std::vector<perm_string> loop_vars_;
+      std::list<PExpr*> items_;
 };
 
 /*

--- a/PExpr.h
+++ b/PExpr.h
@@ -1275,6 +1275,38 @@ class PESoft : public PExpr {
 };
 
 /*
+ * Represents conditional constraint forms inside constraint blocks
+ * (IEEE 1800-2017 18.5.6 implication with a constraint set,
+ * 18.5.7 if-else constraints):
+ *   cond -> { items... }
+ *   if (cond) { items... } [ else { items... } ]
+ * The item lists are constraint expressions that apply only when the
+ * condition holds (resp. fails). Only meaningful in constraint IR
+ * generation; ordinary expression elaboration reports an error.
+ */
+class PEConstraintIf : public PExpr {
+    public:
+      PEConstraintIf(PExpr*cond, std::list<PExpr*>*then_items,
+		     std::list<PExpr*>*else_items);
+      ~PEConstraintIf() override;
+
+      PExpr* get_cond() const { return cond_; }
+      const std::list<PExpr*>& then_items() const { return then_items_; }
+      const std::list<PExpr*>& else_items() const { return else_items_; }
+
+      void dump(std::ostream&out) const override;
+      unsigned test_width(Design*des, NetScope*scope,
+			  width_mode_t&mode) override;
+      NetExpr* elaborate_expr(Design*des, NetScope*scope,
+			      unsigned w, unsigned flags) const override;
+
+    private:
+      PExpr*cond_;
+      std::list<PExpr*> then_items_;
+      std::list<PExpr*> else_items_;
+};
+
+/*
  * Represents the SystemVerilog "inside" expression:
  *   expr inside {[lo:hi], val, ...}
  */

--- a/docs/claude/uvm_ieee1800_gap_audit_2026_05.md
+++ b/docs/claude/uvm_ieee1800_gap_audit_2026_05.md
@@ -96,6 +96,7 @@ Iverilog under test: `Icarus Verilog version 13.0 (devel) (s20251012-102-g9b44d5
 - Blocks: standard idioms in scoreboard reductions, RAL frontdoor.
 
 ### G11 `solve…before` partially works, but `a -> b == K` implication is dropped
+- **STATUS 2026-07-11: FIXED (implication part)**. `->` implications now emitted as `(impl ...)` IR and enforced by Z3 (M3 checkpoint). `solve...before` ordering is still parsed-and-ignored (distribution handled by the xor-diversity objective; staged ordering semantics deferred). Test `tests/m3_constraint_semantics_test.sv` (SolveC).
 - Symptom: histogram split is correct (a=0 and a=1 both occur ~25 times in 50), but the implications `a -> b == 100` and `a == 0 -> b == 0` are NOT applied. Most iterations show b at random non-100 values.
 - Probe: p17_solve_before (VERIFIED-FAILS).
 - Location: constraint pipeline (elab_expr.cc constraint nodes + Z3 backend).
@@ -128,6 +129,7 @@ Iverilog under test: `Icarus Verilog version 13.0 (devel) (s20251012-102-g9b44d5
 - Blocks: clean defaulting in field-rich uvm_objects.
 
 ### G15 implication `->` constraint not enforced (basic)
+- **STATUS 2026-07-11: FIXED**. Root cause: `pexpr_to_constraint_ir` had no case for PEBLogic op q (`->`), so the whole item silently vanished; `A -> {set}` additionally lost its consequent in parse.y (constraint_trigger returned nothing). Both fixed (PEConstraintIf + `(impl ...)` IR + Z3_mk_implies). IEEE 1800-2017 18.5.6.
 - Symptom: `(x == 0) -> (y == 99)` produces y values all over the int range when x==0; same for `(x != 0) -> (y inside ...)`. Range constraints work, implication does not.
 - Probe: p24_constraint_dist_more (VERIFIED-FAILS).
 - Location: Z3 constraint backend + elab_expr.cc implication codegen.
@@ -144,6 +146,7 @@ Iverilog under test: `Icarus Verilog version 13.0 (devel) (s20251012-102-g9b44d5
 - Blocks: array-of-fields randomization (common in packet-class definitions).
 
 ### G17 `if-block constraint` syntax: nothing inside the `if(cond) { ... }` block is enforced
+- **STATUS 2026-07-11: FIXED**. Root cause: parse.y dropped the whole constraint_set (`$$ = nullptr`). Now builds PEConstraintIf lowered to `(impl C then)` / `(impl (not C) else)`. IEEE 1800-2017 18.5.7.
 - Symptom: `if(cond==1){ x inside {[100:200]}; y inside {[1:5]}; }` else `{ ... }` — every iteration fails both branches (`t=0 f=0` over 40 iterations).
 - Probe: p45_constraint_imp_block (VERIFIED-FAILS).
 - Location: same as G15.
@@ -152,6 +155,7 @@ Iverilog under test: `Icarus Verilog version 13.0 (devel) (s20251012-102-g9b44d5
 - Blocks: structured constraint blocks.
 
 ### G18 `inside {enum_set}` constraint excluded values still picked
+- **STATUS 2026-07-11: FIXED**. Root cause: enum literal identifiers resolved to neither property nor constant in `pexpr_to_constraint_ir`, so ranges silently dropped out of the `(inside ...)` IR, leaving it empty/underconstrained. Enum literals now resolve through the class scope chain to constants. IEEE 1800-2017 18.5.3.
 - Symptom: `c inside {RED, BLUE, MAGENTA}` over 60 iterations yields GREEN=8 and YELLOW=10 (both supposed to be excluded).
 - Probe: p82_constraint_enum (VERIFIED-FAILS).
 - Location: constraint backend — enum value propagation to Z3.
@@ -168,6 +172,7 @@ Iverilog under test: `Icarus Verilog version 13.0 (devel) (s20251012-102-g9b44d5
 - Blocks: common dist syntax.
 
 ### G20 `rand`-on-extends: child class `rand` properties + parent constraints not solved together
+- **STATUS 2026-07-11: FIXED**. Two root causes: (a) derived classes never saw base constraint IRs — fixed by lazy inheritance merge in netclass_t (property indexes are chain-stable; local same-name constraints override per IEEE 1800-2017 18.5.2); (b) `x * 2` used `mul`, which the IR generator dropped and the Z3 parser did not implement — arithmetic ops (add/sub/mul/div/mod) now supported end-to-end.
 - Symptom: child `C extends P` with `rand int y; constraint cC { y == x*2; }` and parent `rand int x; constraint cP { x inside {[1:50]}; }` — y comes back as random int (1801979802 etc.), constraint `y == x*2` ignored.
 - Probe: p98_class_inherit_constr (VERIFIED-FAILS).
 - Location: elaborate.cc / class_type rand-property merge across inheritance.

--- a/docs/claude/uvm_ieee1800_gap_audit_2026_05.md
+++ b/docs/claude/uvm_ieee1800_gap_audit_2026_05.md
@@ -96,6 +96,7 @@ Iverilog under test: `Icarus Verilog version 13.0 (devel) (s20251012-102-g9b44d5
 - Blocks: standard idioms in scoreboard reductions, RAL frontdoor.
 
 ### G11 `solve…before` partially works, but `a -> b == K` implication is dropped
+- **UPDATE 2026-07-12**: signed comparisons and negative constraint bounds now supported (checkpoint 6): unary minus folds to two's complement; signed properties marked `p:N:W:s`; bvslt-family predicates and sign extension applied per IEEE 1800-2017 11.8.1. Test `tests/m3_constraint_signed_test.sv`.
 - **STATUS 2026-07-11: FIXED (implication part)**. `->` implications now emitted as `(impl ...)` IR and enforced by Z3 (M3 checkpoint). `solve...before` ordering is still parsed-and-ignored (distribution handled by the xor-diversity objective; staged ordering semantics deferred). Test `tests/m3_constraint_semantics_test.sv` (SolveC).
 - Symptom: histogram split is correct (a=0 and a=1 both occur ~25 times in 50), but the implications `a -> b == 100` and `a == 0 -> b == 0` are NOT applied. Most iterations show b at random non-100 values.
 - Probe: p17_solve_before (VERIFIED-FAILS).

--- a/docs/claude/uvm_ieee1800_gap_audit_2026_05.md
+++ b/docs/claude/uvm_ieee1800_gap_audit_2026_05.md
@@ -138,6 +138,7 @@ Iverilog under test: `Icarus Verilog version 13.0 (devel) (s20251012-102-g9b44d5
 - Blocks: any non-trivial constraint program.
 
 ### G16 `foreach(arr[i]) arr[i] inside {[i*10:i*10+5]}` — index-dependent constraints not enforced
+- **STATUS 2026-07-12: FIXED (static arrays)**. foreach constraint sets now parse to PEConstraintForeach and unroll at elaboration over 0-based one-dimensional static rand arrays; elements are solver variables (e:N:W:I) written back after the solve; %randomize now fills static-array elements with random bits. Dynamic-array foreach still deferred. Test `tests/m3_constraint_array_test.sv`. IEEE 1800-2017 18.5.8.
 - Symptom: `arr[2]=0`, `arr[3]=0` consistently when constraint says they should be in `[20:25]` and `[30:35]`. Only the first array element occasionally gets a non-zero from the implication chain; rest stay at 0.
 - Probe: p24_constraint_dist_more (VERIFIED-FAILS).
 - Location: same as G15; foreach-over-rand-array constraint codegen — Phase 50c entry in MEMORY.md (still open).
@@ -181,6 +182,7 @@ Iverilog under test: `Icarus Verilog version 13.0 (devel) (s20251012-102-g9b44d5
 - Blocks: any UVM stimulus class hierarchy.
 
 ### G21 `rand int arr[]` size-constraining `arr.size() == sz` ignored
+- **STATUS 2026-07-12: FIXED**. `arr.size()` becomes a solver size variable (s:N:T); after solving, the darray property is created/resized to the solved size (cap 65536) and filled with random elements. Test `tests/m3_constraint_array_test.sv`. IEEE 1800-2017 18.4.
 - Symptom: constraint `sz inside {[3:5]}; arr.size() == sz` produces randomized sz but arr.size always 0.
 - Probe: p71_constraint_with_array (VERIFIED-FAILS).
 - Location: dynamic-array sizing in randomize — needs runtime resize hook.

--- a/docs/conformance/CURRENT_WORK.md
+++ b/docs/conformance/CURRENT_WORK.md
@@ -105,13 +105,20 @@ the investigation. Update at every meaningful checkpoint.
   **111/111**; ivtest **byte-identical to baseline**. WIP marker on
   6f7e875 superseded by the regression-confirmation docs commit.
 
+## Checkpoint 6 (M3 tail: signed comparisons) — regression-clean
+
+- Unary minus folded to two's complement (was silently dropped);
+  signed p:/e: markers; bvslt-family + sign extension per IEEE
+  1800-2017 11.8.1; signed inside/dist ranges.
+- Test `tests/m3_constraint_signed_test.sv`. UVM **112/112**; ivtest
+  **byte-identical to baseline**. WIP 889d084 superseded.
+
 ## Exact next actions
 
-1. Watch PR #67 CI (Ubuntu/macOS green earlier; MSYS2 re-running after
-   the checkpoint-5 push).
+1. Watch PR #67 CI (re-running after the checkpoint-6 push).
 2. Remaining M3 tail: dynamic-array foreach (solve-time template
-   expansion after the size var fixes), signed comparisons in the IR,
-   `solve...before` staged ordering, non-0-based array ranges.
+   expansion after the size var fixes), `solve...before` staged
+   ordering, non-0-based array ranges.
 3. Alternatives per manifesto sequence: M4 container runtime, M5
    interfaces/modports (Phase 70), M6 scheduler audit, or G66 root-cause.
 

--- a/docs/conformance/CURRENT_WORK.md
+++ b/docs/conformance/CURRENT_WORK.md
@@ -113,14 +113,30 @@ the investigation. Update at every meaningful checkpoint.
 - Test `tests/m3_constraint_signed_test.sv`. UVM **112/112**; ivtest
   **byte-identical to baseline**. WIP 889d084 superseded.
 
+## Checkpoint 7 (M6 scheduler audit) — docs + litmus regressions
+
+- `docs/conformance/scheduler_audit_2026_07.md`: queue inventory
+  (start/active/inactive/nbassign/rwsync/rosync/del_thr + init/final
+  lists), IEEE 4.4.2 region mapping (Preponed/Observed/Reactive ABSENT),
+  implicit-ordering inventory (%fork push_flag, insertion-order
+  dependence), direct-execution findings (callf synchronous drains and
+  the staged-context heuristics), event-trigger lifetime (G08),
+  VPI callback mapping, end-of-slot behavior, and a 5-step remediation
+  priority list for M6 implementation.
+- `tests/m6_sched_litmus_test.sv`: NBA-vs-blocking, #0 inactive, and
+  $strobe postponed-region orderings as durable characterization
+  regressions (PASS).
+
 ## Exact next actions
 
-1. Watch PR #67 CI (re-running after the checkpoint-6 push).
-2. Remaining M3 tail: dynamic-array foreach (solve-time template
-   expansion after the size var fixes), `solve...before` staged
+1. Watch PR #67 CI.
+2. M6 implementation per the audit's remediation priorities: (1) region
+   tagging + trace hook, (2) Reactive region for program blocks,
+   (3) slot-persistent event.triggered (G08), (4) Preponed/Observed
+   stubs, (5) scheduled-call protocol replacing callf sync drains.
+3. Remaining M3 tail: dynamic-array foreach, `solve...before` staged
    ordering, non-0-based array ranges.
-3. Alternatives per manifesto sequence: M4 container runtime, M5
-   interfaces/modports (Phase 70), M6 scheduler audit, or G66 root-cause.
+4. Alternatives: M4 container runtime, M5 interfaces/modports, G66.
 
 ## Manifesto v2 alignment review (2026-07-11)
 

--- a/docs/conformance/CURRENT_WORK.md
+++ b/docs/conformance/CURRENT_WORK.md
@@ -80,32 +80,32 @@ the investigation. Update at every meaningful checkpoint.
 - `with`-clause locator methods on receiver calls parse to PENull
   (pre-existing parser fallback, unchanged).
 
-## Checkpoint 3 (M2) — in flight
+## Checkpoint 4 (M3) — regression-clean, PR #67
 
-- **G25 FIXED**: whole unpacked-array assignment (IEEE 1800-2017 7.6) lowered
-  to a canonical-index element copy loop in `PAssign::elaborate`
-  (`make_uarray_copy_loop_`, elaborate.cc). Covers sig=sig, prop=prop,
-  sig=prop, prop=sig; size mismatch errors. UVM `uvm_field_sarray_int`
-  clone verified against unmodified library.
-- **G23 RESOLVED-BY-PRIOR** (regression test added).
-- **G66 NEW gap recorded**: $unit class name colliding with uvm_pkg-internal
-  identifiers + specialization breaks unrelated package elaboration;
-  reproducer `tests/probes/g66_unit_class_name_collision_uvm.sv`.
-- Focused tests pass (m2_* 3/3, negative 3/3). Full UVM + ivtest regressions
-  running at last update; commit checkpoint 3 when green.
+- **G15/G17/G18/G20 FIXED + G11 implication half**: constraint implication,
+  if-else sets, enum-literal sets, inheritance merge, and solver arithmetic
+  (impl/iff/add/sub/mul/div/mod). See session log checkpoint 4.
+- PR #66 (M1+M2) was MERGED into main; branch restarted from merged main.
+- M3 work on PR #67 (draft): WIP commit `9d64dda` + regression-confirmation
+  docs commit.
+- Regressions: UVM **110/110**; ivtest **byte-identical to baseline**
+  (2961/3101+132, 85/85, 284/12); make check pass.
 
 ## Exact next actions
 
-1. Confirm the M2 regression runs (UVM expected 108/108; ivtest expected
-   identical to baseline: 2961/3101 + 132 pre-existing fails, 85/85,
-   284/12), then commit + push checkpoint 3.
-2. Watch PR #66 CI (6 platform jobs).
-3. Re-probe dynamic-array field automation (`uvm_field_array_int` /
-   `uvm_field_queue_*`) — G25 covered only the sarray shape.
-4. Then M3 constraint solver (Phase 66 scope: G11/G15/G16/G17/G18/G20/G21),
-   or G66 root-cause (specialization-time name capture) if prioritized.
+1. Watch PR #67 CI (6 platform jobs); post/act on failures.
+2. Next M3 increment: array-property constraint support — G16 (foreach
+   iterative constraints) and G21 (`arr.size()` with runtime resize hook).
+   Requires extending the p:N:W IR with array-element addressing and a
+   resize protocol in %randomize.
+3. Then: signed comparison support in the IR (p:N:W:s + bvslt family),
+   `solve...before` staged ordering, state-variable (non-rand) references
+   via value slots for class constraints.
+4. Alternatives per manifesto sequence: M5 interfaces/modports (Phase 70)
+   or G66 root-cause.
 
 ## Decisions not to revisit without new evidence
+
 
 - Receiver dispatch reuses `elaborate_method_dispatch_` — do NOT fork a
   second dispatch path for receiver calls.

--- a/docs/conformance/CURRENT_WORK.md
+++ b/docs/conformance/CURRENT_WORK.md
@@ -91,7 +91,7 @@ the investigation. Update at every meaningful checkpoint.
 - Regressions: UVM **110/110**; ivtest **byte-identical to baseline**
   (2961/3101+132, 85/85, 284/12); make check pass.
 
-## Checkpoint 5 (M3 increment 2) — in flight
+## Checkpoint 5 (M3 increment 2) — regression-clean
 
 - **G21 FIXED**: `arr.size()` → solver size var `s:N:T`; darray created/
   resized at write-back (cap 65536), elements filled randomly.
@@ -101,18 +101,18 @@ the investigation. Update at every meaningful checkpoint.
 - **Hang fixed**: solver inside/dist range parser now expression-capable
   and always makes forward progress (previously hung on compound ranges).
 - Focused: single-shot probes + 10-iteration probe + permanent test
-  `tests/m3_constraint_array_test.sv` all PASS. Full UVM + ivtest
-  regressions running; commit checkpoint 5 when green (expect 112/112 and
-  baseline-identical ivtest).
+  `tests/m3_constraint_array_test.sv` all PASS. UVM regression
+  **111/111**; ivtest **byte-identical to baseline**. WIP marker on
+  6f7e875 superseded by the regression-confirmation docs commit.
 
 ## Exact next actions
 
-1. Confirm checkpoint-5 regressions; commit + push; update PR #67.
-2. Watch PR #67 CI (Ubuntu/macOS green at last check; MSYS2 pending).
-3. Remaining M3 tail: dynamic-array foreach (solve-time template
+1. Watch PR #67 CI (Ubuntu/macOS green earlier; MSYS2 re-running after
+   the checkpoint-5 push).
+2. Remaining M3 tail: dynamic-array foreach (solve-time template
    expansion after the size var fixes), signed comparisons in the IR,
    `solve...before` staged ordering, non-0-based array ranges.
-4. Alternatives per manifesto sequence: M4 container runtime, M5
+3. Alternatives per manifesto sequence: M4 container runtime, M5
    interfaces/modports (Phase 70), M6 scheduler audit, or G66 root-cause.
 
 ## Manifesto v2 alignment review (2026-07-11)

--- a/docs/conformance/CURRENT_WORK.md
+++ b/docs/conformance/CURRENT_WORK.md
@@ -91,18 +91,29 @@ the investigation. Update at every meaningful checkpoint.
 - Regressions: UVM **110/110**; ivtest **byte-identical to baseline**
   (2961/3101+132, 85/85, 284/12); make check pass.
 
+## Checkpoint 5 (M3 increment 2) — in flight
+
+- **G21 FIXED**: `arr.size()` → solver size var `s:N:T`; darray created/
+  resized at write-back (cap 65536), elements filled randomly.
+- **G16 FIXED (static arrays)**: PEConstraintForeach + compile-time unroll
+  with loop-var env; element vars `e:N:W:I` solved and written back;
+  %randomize now fills static-array rand property elements.
+- **Hang fixed**: solver inside/dist range parser now expression-capable
+  and always makes forward progress (previously hung on compound ranges).
+- Focused: single-shot probes + 10-iteration probe + permanent test
+  `tests/m3_constraint_array_test.sv` all PASS. Full UVM + ivtest
+  regressions running; commit checkpoint 5 when green (expect 112/112 and
+  baseline-identical ivtest).
+
 ## Exact next actions
 
-1. Watch PR #67 CI (6 platform jobs); post/act on failures.
-2. Next M3 increment: array-property constraint support — G16 (foreach
-   iterative constraints) and G21 (`arr.size()` with runtime resize hook).
-   Requires extending the p:N:W IR with array-element addressing and a
-   resize protocol in %randomize.
-3. Then: signed comparison support in the IR (p:N:W:s + bvslt family),
-   `solve...before` staged ordering, state-variable (non-rand) references
-   via value slots for class constraints.
-4. Alternatives per manifesto sequence: M5 interfaces/modports (Phase 70)
-   or G66 root-cause.
+1. Confirm checkpoint-5 regressions; commit + push; update PR #67.
+2. Watch PR #67 CI (Ubuntu/macOS green at last check; MSYS2 pending).
+3. Remaining M3 tail: dynamic-array foreach (solve-time template
+   expansion after the size var fixes), signed comparisons in the IR,
+   `solve...before` staged ordering, non-0-based array ranges.
+4. Alternatives per manifesto sequence: M4 container runtime, M5
+   interfaces/modports (Phase 70), M6 scheduler audit, or G66 root-cause.
 
 ## Manifesto v2 alignment review (2026-07-11)
 

--- a/docs/conformance/CURRENT_WORK.md
+++ b/docs/conformance/CURRENT_WORK.md
@@ -104,6 +104,45 @@ the investigation. Update at every meaningful checkpoint.
 4. Alternatives per manifesto sequence: M5 interfaces/modports (Phase 70)
    or G66 root-cause.
 
+## Manifesto v2 alignment review (2026-07-11)
+
+The governing manifesto was updated to v2 (commit c2e53d3). Review of this
+session's M1-M3 implementations against v2:
+
+- **Semantic IR remediation**: the M1 receiver-dispatch work matches v2's
+  prescribed migration entry point (expression and member-access
+  semantics). `elaborate_method_dispatch_` is the shared typed-expression
+  dispatch interface; return types flow through `NetEUFunc(net_type)`.
+- **Code-pattern scan** of the full session diff: no added TODO/FIXME,
+  no compile-progress fallbacks, no UVM identifier checks; one explicit
+  `sorry` diagnostic (non-class receivers in statement context) per
+  manifesto principle 4.
+- **Tracked diagnostics added** (v2: "convert silent type-recovery
+  fallbacks into tracked diagnostics"): unrepresentable-constraint-item
+  warning; uarray shape-mismatch errors.
+
+### Architectural debt register (v2 Risks)
+
+1. **PEIdent path-splice adapter** (parse.y receiver rules): legacy
+   name-based lookup retained for identifier receivers. Acceptable
+   adapter now; must not become a permanent duplicate dispatch path
+   (fold into receiver dispatch when the semantic IR migration reaches
+   name resolution).
+2. **test_width double-elaboration** (receiver calls, PEMemberAccess
+   pattern): duplicate diagnostics; symptomatic of missing typed
+   expression interface (v2 Risk 4).
+3. **vvp automatic-context heuristics** (`staged_alloc_rd_*`,
+   `skip_free_*`, chain-membership fix): the returned-frame fix is
+   correct but the surrounding machinery relies on implicit ordering —
+   squarely in v2's scheduler remediation program scope (M6 audit item 4/5:
+   direct thread execution + synchronous-child assumptions in callf).
+4. **Constraint IR is string-based S-expressions** with unsigned-only
+   comparisons and scalar-only properties: adequate for current gaps,
+   but array/signed/ordering support (G16/G21) will strain it; consider
+   a typed constraint IR when extending.
+5. **Pre-existing compile-progress fallback inventory** (45 sites,
+   audit section) remains open — Phase 75 scope.
+
 ## Decisions not to revisit without new evidence
 
 

--- a/docs/conformance/iverilog_ieee1800_uvm_manifesto.md
+++ b/docs/conformance/iverilog_ieee1800_uvm_manifesto.md
@@ -239,6 +239,96 @@ Add trace support recording:
 - Event identity
 - Source location
 
+### Scheduler remediation program
+
+The current scheduler must not be assumed correct merely because individual UVM tests pass. The existing runtime has accumulated behavior through local fixes, and failures involving fork/join, events, clocking, assertions, program blocks, task calls, and UVM phasing can share the same underlying scheduling defects.
+
+Before adding advanced SVA, program-block, or clocking semantics, perform a scheduler architecture audit.
+
+The audit must:
+
+1. Inventory every runtime queue and scheduling entry point.
+2. Map each queue and callback to an IEEE event region.
+3. Identify operations that currently rely on implicit ordering.
+4. Identify direct thread execution that bypasses normal scheduling.
+5. Identify places where child processes are expected to complete synchronously.
+6. Identify event-trigger lifetime and waiter-registration behavior.
+7. Identify VPI and DPI callbacks whose region is ambiguous.
+8. Identify end-of-time-slot and end-of-simulation behavior.
+9. Add invariants and debug assertions for illegal transitions.
+10. Produce scheduler litmus tests before restructuring code.
+
+The target scheduler model should make the following concepts explicit:
+
+- Time slot
+- Delta cycle
+- Event region
+- Runnable process
+- Suspended process
+- NBA update
+- Reactive/program process
+- Assertion sampling and evaluation
+- Clocking-block sampling and driving
+- VPI callback
+- DPI task suspension and resumption
+- End-of-step cleanup
+
+Do not perform a blind rewrite. Preserve working behavior through characterization tests, then replace implicit ordering incrementally.
+
+The scheduler remediation is complete only when:
+
+- Region ownership is documented for every scheduling API.
+- Race-sensitive litmus tests are durable regressions.
+- Process and event semantics no longer depend on incidental queue order.
+- Clocking blocks, program blocks, SVA, VPI, and DPI use the same documented region model.
+- Existing UVM regressions remain clean.
+
+### Semantic IR remediation program
+
+The current compiler architecture must not be assumed capable of full SystemVerilog merely because isolated syntax has been added successfully.
+
+Repeated failures involving method chaining, parameterized classes, enum identity, assignment patterns, arrays, constraints, and UVM factory paths indicate that semantic information is lost or reconstructed inconsistently across compiler stages.
+
+The typed semantic IR must therefore be introduced as a migration program, not only as a design preference.
+
+The migration must:
+
+1. Inventory existing AST, netlist, expression, type, and elaboration node families.
+2. Identify where type, width, signedness, dimensions, class specialization, and enum identity are discarded.
+3. Identify parser actions that perform premature lowering.
+4. Define one canonical semantic type descriptor.
+5. Define typed expression and typed lvalue interfaces.
+6. Define ownership and lifetime rules for semantic nodes.
+7. Add conversion boundaries between legacy nodes and the new semantic IR.
+8. Migrate one feature family at a time.
+9. Preserve existing behavior with characterization tests.
+10. Remove legacy fallback paths only after equivalent semantic coverage exists.
+
+The migration should begin with expression and member-access semantics because they unblock:
+
+- Function-return method chaining
+- Enum method chaining
+- UVM factory access
+- Parameterized class specialization
+- Class-valued config database operations
+- Assignment compatibility
+- Aggregate member access
+- Constraint expression typing
+
+Do not attempt an all-at-once compiler rewrite.
+
+Use adapters where necessary, but do not let adapters become permanent duplicate type systems.
+
+The semantic IR remediation is complete only when:
+
+- A single canonical type representation is used across name resolution, elaboration, and lowering.
+- Function-call results retain exact static type.
+- Lvalues and rvalues use consistent aggregate layout information.
+- Parameterized class specializations remain distinct.
+- Enum identity survives expression lowering.
+- Unsupported semantic forms fail explicitly rather than entering compile-progress fallbacks.
+- UVM-specific fixes no longer require identifier-based compiler branches.
+
 ---
 
 ## Verified high-priority gap families
@@ -545,6 +635,76 @@ Use the unmodified Accellera UVM library and representative examples.
 
 ---
 
+## Constructive assessment of the current implementation strategy
+
+The existing phase-based work has produced real progress, but the project must avoid interpreting a growing passing-test count as evidence that the architecture is ready for full IEEE 1800 support.
+
+The following risks must remain visible throughout implementation:
+
+### Risk 1: UVM success can conceal incomplete language semantics
+
+UVM exercises a large and valuable subset of SystemVerilog, but it does not exercise every legal language form, scheduling interaction, timing construct, assertion behavior, coverage rule, VPI object, or DPI shape.
+
+A UVM regression is therefore necessary but insufficient.
+
+### Risk 2: Parser acceptance can conceal semantic no-ops
+
+Several advanced constructs can be made to parse while still being ignored, incorrectly lowered, or scheduled in the wrong region.
+
+Every feature must be tested for observable semantics, not syntax alone.
+
+### Risk 3: Local VVP fixes can conceal scheduler inconsistency
+
+A runtime warning or UVM phase failure may be fixed locally while leaving the event-region model inconsistent.
+
+Fork/join, events, process handles, clocking, assertions, program blocks, DPI tasks, and VPI callbacks must ultimately share one scheduler model.
+
+### Risk 4: Repeated type reconstruction signals an inadequate IR
+
+When downstream code must infer class type, enum identity, packed width, array shape, or specialization from context, correctness becomes fragile.
+
+The semantic IR migration is a prerequisite for sustainable completion of the class, aggregate, constraint, and UVM feature sets.
+
+### Risk 5: The existing phase estimates understate some subsystems
+
+Full SVA, functional coverage, DPI open arrays, VPI SystemVerilog coverage, scheduler conformance, and constraint solving are not small parser patches.
+
+They must be planned as multi-stage subsystems with architecture, tests, diagnostics, and runtime support.
+
+### Risk 6: Permissive fallbacks create false progress
+
+A compile-progress path that emits plausible code can be more dangerous than a hard error.
+
+Unsupported semantics must be explicit until implemented correctly.
+
+### Risk 7: Differential testing is evidence, not specification
+
+Commercial and open-source simulators can disagree or contain bugs.
+
+The IEEE standard remains normative; differential results help expose ambiguity and implementation defects.
+
+### Risk 8: Full conformance requires negative testing
+
+Legal examples alone do not validate:
+
+- Illegal syntax rejection
+- Type errors
+- Lifetime restrictions
+- Scheduling restrictions
+- Context restrictions
+- Required diagnostics
+- Failed randomization behavior
+
+Every major feature family needs negative tests.
+
+### Risk 9: Compatibility must not freeze poor architecture
+
+Preserving current regressions is mandatory, but legacy implementation structure should not be treated as untouchable when it prevents correct semantics.
+
+Use characterization tests and incremental migration rather than indefinite accumulation of special cases.
+
+---
+
 ## Milestone sequence
 
 ### M0 — Reproducible baseline
@@ -554,13 +714,21 @@ Use the unmodified Accellera UVM library and representative examples.
 - Record current upstream and fork commit IDs
 - Produce baseline regression results
 
-### M1 — Typed expression and runtime class descriptors
+### M1 — Semantic IR foundation and runtime class descriptors
 
+This milestone is an architectural migration gate, not a collection of isolated UVM fixes.
+
+- Inventory the current AST, elaboration, expression, type, and netlist representations
+- Define the canonical SystemVerilog semantic type descriptor
 - Preserve return types
 - Support method/property lookup on arbitrary expressions
 - Preserve enum identity
 - Preserve parameter specialization
 - Add virtual dispatch metadata
+- Introduce typed lvalue and aggregate-layout interfaces
+- Add adapters for legacy lowering paths
+- Convert silent type-recovery fallbacks into tracked diagnostics
+- Document which compiler paths still bypass the semantic IR
 
 ### M2 — UVM factory, config, callbacks, and field automation
 
@@ -581,10 +749,18 @@ Use the unmodified Accellera UVM library and representative examples.
 
 - Complete connection, array, modport, and virtual interface behavior
 
-### M6 — Process, events, and scheduler
+### M6 — Scheduler architecture, processes, and events
 
+This milestone must precede claims of complete clocking, program, SVA, DPI-task, or race-free UVM behavior.
+
+- Inventory all scheduling queues and entry points
+- Map runtime operations to IEEE event regions
+- Add scheduler trace and invariant checking
+- Add race-sensitive scheduler litmus tests
 - Formalize event-region behavior
 - Fix process state and event observation
+- Remove incidental queue-order dependencies
+- Document VPI, DPI, assertion, program, and clocking integration points
 
 ### M7 — Accellera UVM core qualification
 

--- a/docs/conformance/scheduler_audit_2026_07.md
+++ b/docs/conformance/scheduler_audit_2026_07.md
@@ -1,0 +1,130 @@
+# vvp Scheduler Architecture Audit — 2026-07-12
+
+Manifesto-v2 "Scheduler remediation program" audit (M6 gate). Evidence:
+`vvp/schedule.h`, `vvp/schedule.cc` (event queues and main loop),
+`vvp/vthread.cc` (thread execution, callf, fork), `vvp/vpi_priv.cc`
+(callback registration), plus defects root-caused in this session's
+checkpoints. IEEE references are to 1800-2017 clause 4 (scheduling
+semantics) region names; the mapping below records what EXISTS, not a
+claim of conformance.
+
+## 1. Queue inventory (per time slot: `struct event_time_s`, schedule.cc)
+
+| Queue | Enqueued by | Drained |
+|---|---|---|
+| `start` | `schedule_at_start_of_simtime` (cbAtStartOfSimTime) | at time advance, after `vpiNextSimTime()` |
+| `active` | `schedule_vthread(delay=0)`, `schedule_set_vector`, propagate/force events, promotions | main loop, one event at a time |
+| `inactive` | `schedule_inactive` (#0), `schedule_t0_trigger` (always_comb T0) | promoted wholesale into `active` when `active` empties |
+| `nbassign` | `schedule_assign_vector` / `schedule_assign_array_word` (NBA), `schedule_vthread(delay>0)` lands via new slot's active | promoted into `active` after `inactive` |
+| `rwsync` | `schedule_generic(sync_flag=1, ro_flag=0)` (cbReadWriteSynch) | promoted into `active` after `nbassign` |
+| `rosync` | `schedule_generic(sync_flag=1, ro_flag=1)` (cbReadOnlySynch, `$strobe`, `$monitor`) | `run_rosync` at slot teardown; writes guarded by `schedule_at_rosync()` |
+| `del_thr` | `schedule_del_thr` | with rosync at slot teardown |
+
+Global (non-slot) lists: `schedule_init_list` (pre-simulation variable
+init, drained before `vpiStartOfSim`), `schedule_final_list` (final
+blocks, drained after the event loop).
+
+Slot sequencing (main loop, `schedule_simulate`): on time advance →
+`vpiNextSimTime` → `start` queue → loop { pop `active`; when empty:
+`inactive`→active, then `nbassign`→active, then `rwsync`→active, then
+`run_rosync` + delete slot }.
+
+## 2. IEEE 1800-2017 region mapping
+
+| IEEE region (4.4.2) | vvp | Status |
+|---|---|---|
+| Preponed | — | **ABSENT** (no sampled-value region; blocks SVA/clocking sampling) |
+| Active | `active` | present |
+| Inactive | `inactive` | present (#0) |
+| Pre-NBA (cbNBASynch) | — | not distinct from NBA |
+| NBA | `nbassign` | present |
+| Post-NBA | — | absent |
+| Observed | — | **ABSENT** (no SVA evaluation region) |
+| Reactive / Re-Inactive / Re-NBA | — | **ABSENT** — program-block code runs in Active (elaborate.cc already warns: "Program blocking assignments are not currently scheduled in the Reactive region") |
+| Pre-Postponed (cbReadWriteSynch) | `rwsync` | present; correctly re-promotes into active so writes re-trigger evaluation |
+| Postponed (cbReadOnlySynch) | `rosync` | present with rosync write guard |
+
+## 3. Implicit-ordering dependencies (audit point 3)
+
+- `schedule_vthread(..., push_flag=true)` pushes to the FRONT of
+  `active`; `%fork` relies on this to run children ahead of pending
+  NBAs. Ordering is a property of queue position, not a declared
+  region.
+- Same-queue events run in insertion order (circular singly linked
+  list, append at tail); several UVM-phasing behaviors observed in this
+  fork depend on that stability (see uvm_gap_plan Phase 64 notes and
+  the I5 static-init ordering fix, add_process_at_tail).
+- `inactive` promotion is wholesale (whole queue moved), so #0 events
+  scheduled DURING inactive draining land in the next promotion round —
+  consistent with LRM iteration, but implicit.
+
+## 4/5. Direct thread execution and synchronous-child assumptions
+
+- `%callf/*` (vthread.cc `do_callf_void` and friends) executes the
+  callee thread synchronously inside the caller's opcode dispatch,
+  bypassing the scheduler. Three defects root-caused this session live
+  here: the chunk-boundary `%fork`/`%join_detach` misparse (Phase 64),
+  the "callf child did not end synchronously" join-wait fallback (G48,
+  suppressed diagnostic), and the same-scope returned-frame shadowing
+  (fixed in checkpoint 2). The automatic-context staging heuristics
+  (`staged_alloc_rd_*`, `skip_free_*`) exist to patch over this
+  direct-execution model and remain the highest-risk area.
+- `%fork ... %join_detach` when detected synchronously executes the
+  fork body inline (vthread.cc of_FORK); interaction with `$finish`
+  inside such bodies previously stalled callf drains (Phase 64 fix).
+
+## 6. Event-trigger lifetime and waiter registration
+
+- Named-event triggers wake `@(event)` waiters but a concurrently
+  queued `wait (e.triggered)` can miss the trigger (gap **G08**,
+  VERIFIED-FAILS): `.triggered` does not implement the LRM
+  time-slot-persistent property (1800-2017 15.5.3); there is no
+  slot-scoped trigger state cleared at slot end.
+- Nonblocking event trigger `->>` is unimplemented (gap G51).
+
+## 7. VPI/DPI callback regions
+
+- Mapped: cbAtStartOfSimTime→`start`, cbReadWriteSynch→`rwsync`,
+  cbReadOnlySynch→`rosync`, cbNextSimTime→`vpiNextSimTime()` at time
+  advance, cbAfterDelay→generic events.
+- cbNBASynch and post-NBA callbacks have no distinct home. DPI blocking
+  tasks execute on the calling thread (no suspension region concept).
+
+## 8. End-of-slot / end-of-simulation
+
+- Slot teardown: `run_rosync` + thread deletion, then the slot is
+  freed. End of simulation: event loop exits when `sched_list` empties
+  or `schedule_finish()`; then final blocks (`schedule_final_list`),
+  `signals_revert`, `vpiPostsim`. `$finish` abandons remaining events
+  (schedule_finished flag checked in opcode loops — the Phase 64 bug
+  showed opcode-level drains must re-check it).
+
+## 9. Invariants / debug support present
+
+- `IVL_SAME_TIME_LIMIT` zero-time-spin watchdog, `IVL_TIME_TRACE_NS`
+  time tracing, `vthread_dump_live_threads` on quiesce/watchdog,
+  `IVL_CTX_TRACE` automatic-context tracing, `IVL_SCHED_DUMP_THREADS`.
+- No region-transition assertions yet; no per-event region tagging.
+
+## 10. Litmus tests (durable regressions added)
+
+`tests/m6_sched_litmus_test.sv`: (a) blocking-then-NBA read ordering
+within a slot, (b) #0 inactive ordering across initial blocks,
+(c) `$strobe` (rosync) observes post-NBA values while `$display`
+(active) observes pre-NBA values. These characterize CURRENT behavior
+per LRM-required outcomes and must stay green through any scheduler
+restructuring.
+
+## Remediation priorities (for M6 implementation, in order)
+
+1. Introduce region tagging on events (enum already exists:
+   `event_queue_e`) + optional trace hook (time, delta, region, event).
+2. Add Reactive/Re-Inactive/Re-NBA queues and route program-block
+   processes there (unblocks 1800-2017 24.x program semantics and the
+   existing elaborate.cc warning).
+3. Add slot-persistent `event.triggered` state (fixes G08) — 15.5.3.
+4. Add Preponed sampling + Observed evaluation stubs as the SVA/clocking
+   foundation (M8/M9 prerequisite).
+5. Replace callf synchronous-drain assumptions with an explicit
+   scheduled-call protocol (retiring the staged-context heuristics) —
+   the largest, riskiest item; requires characterization tests first.

--- a/docs/conformance/session_logs/2026-07-11_typed_expression_dispatch.md
+++ b/docs/conformance/session_logs/2026-07-11_typed_expression_dispatch.md
@@ -403,6 +403,44 @@ indexes and shadow outer names).
   85/85, vvp_reg.py 284/12).
 - WIP marker on `6f7e875` superseded by this regression confirmation.
 
+## Checkpoint 6 — M3: signed constraint comparisons and negative bounds
+
+### Requirement
+
+IEEE 1800-2017 **11.8.1** (comparisons are signed when both operands are
+signed; integer literals are signed) and **11.4.13/18.5.3** (inside with
+signed subjects). Constraints on `int` fields with negative bounds are
+routine in UVM stimulus.
+
+### Root causes
+
+- Unary minus (`-5`) had no IR conversion (PEUnary handled only `!`), so
+  any constraint item containing a negative literal was silently dropped
+  (surfaced by the checkpoint-4 honesty warning).
+- The IR carried no signedness: all comparisons and inside ranges used
+  unsigned BV predicates, making `y < 0` unsatisfiable and negative
+  ranges meaningless.
+
+### Implementation
+
+- Generator (`elaborate.cc`): PEUnary `-` folds literals to 64-bit two's
+  complement (solver numerals reduce mod 2^W at the use width) and lowers
+  non-literal operands to `(sub c:0 x)`; unary `+` passes through.
+  Signed property/element types append `:s` to their `p:`/`e:` tokens.
+- Solver (`vvp/vvp_z3.cc`): signed-variable tracking; comparisons use
+  the bvslt family with sign extension when a signed variable
+  participates; `inside`/`dist` ranges use signed predicates and
+  sign-extended bounds when the subject is signed.
+
+### Tests
+
+- `tests/m3_constraint_signed_test.sv`: `x inside {[-5:5]}`, `y < 0`,
+  `y >= -20` over 20 iterations.
+
+### Results
+
+(recorded when regressions complete)
+
 ## Checkpoint history
 
 - Checkpoint 1: manifesto imported to `docs/conformance/`, baseline recorded (this file).

--- a/docs/conformance/session_logs/2026-07-11_typed_expression_dispatch.md
+++ b/docs/conformance/session_logs/2026-07-11_typed_expression_dispatch.md
@@ -329,6 +329,73 @@ this checkpoint; the topic branch was restarted from the merged main and
 the M3 work committed on top (WIP commit `9d64dda`, regression
 confirmation in the follow-up docs commit). New PR: #67.
 
+## Checkpoint 5 — M3: array-property constraints (G21 size, G16 foreach)
+
+### Requirement
+
+IEEE 1800-2017 **18.4** (the size of a rand dynamic array is randomized
+subject to constraints; elements are randomized) and **18.5.8 / 18.5.8.1**
+(iterative foreach constraints; loop variables range over the array
+indexes and shadow outer names).
+
+### Root causes
+
+- **G21**: `arr.size()` in constraints had no IR representation (item
+  dropped with the honesty warning); no runtime mechanism resized rand
+  dynamic arrays after solving.
+- **G16**: foreach constraint sets were dropped in parse.y; array
+  ELEMENTS had no IR representation; and rand static-array properties
+  were never even filled with random bits by %randomize (only word 0
+  scalars).
+- **Hang found during implementation**: the solver's inside/dist range
+  parser read only literal tokens and made NO forward progress on
+  unexpected input — an unparseable range hung the simulation. Fixed
+  with expression-capable range parsing plus a guaranteed-progress
+  guard. (This robustness defect pre-existed; it was unreachable only
+  because nothing emitted compound ranges before.)
+
+### Implementation
+
+- `PExpr.h/cc`, `parse.y`: new `PEConstraintForeach` pform node
+  (array name, loop vars, item list) replacing the silent drop.
+- `elaborate.cc` (IR generator):
+  - `arr.size()` → size variable `s:N:T` (T = darray type text for
+    write-back construction, derived from the element type).
+  - foreach over one-dimensional 0-based static-array rand properties:
+    compile-time unroll with a loop-variable environment
+    (`loop_env` parameter; loop vars shadow properties per 18.5.8);
+    indexed property refs `arr[i]` → element variables `e:N:W:I`.
+  - Constant folding for add/sub/mul/div/mod over literal operands so
+    unrolled index arithmetic stays `c:V` in range bounds.
+- `vvp/class_type.h/cc`: properties retain base type text + array size
+  (`property_base_type`, `property_array_size`).
+- `vvp/vthread.cc`: %randomize (both plain and with-variants) fills
+  every element of static-array rand properties with random bits.
+- `vvp/vvp_z3.cc`: `s:`/`e:` variables; pre-check equality includes
+  current sizes/elements; xor-diversity objectives for both; hard size
+  cap 65536 (implementation limit for under-constrained sizes);
+  write-back creates the darray via a type-text factory, fills
+  unconstrained elements randomly, then applies solved element values;
+  inside/dist ranges accept expressions and always make progress.
+
+### Tests
+
+- `tests/m3_constraint_array_test.sv`: SizeC (`sz inside {[3:5]};
+  arr.size() == sz`) and ForeachC (`foreach (arr[i]) arr[i] inside
+  {[i*10:i*10+5]}`) × 10 iterations.
+
+### Known limitations
+
+- foreach over DYNAMIC arrays (runtime-sized) not yet expanded (needs
+  solve-time template expansion after the size var is fixed).
+- Element addressing assumes 0-based one-dimensional declared ranges.
+- Element constraints and `arr.size()` for the SAME array in one solve
+  are independent (element vars index only compile-time-known slots).
+
+### Results
+
+(recorded when regressions complete)
+
 ## Checkpoint history
 
 - Checkpoint 1: manifesto imported to `docs/conformance/`, baseline recorded (this file).

--- a/docs/conformance/session_logs/2026-07-11_typed_expression_dispatch.md
+++ b/docs/conformance/session_logs/2026-07-11_typed_expression_dispatch.md
@@ -315,7 +315,19 @@ membership (enum literals in sets), 18.5.2 constraint inheritance
 
 ### Results
 
-(recorded when the regression runs complete)
+- Focused: `m3_constraint_semantics_test` PASS (5 families × 20 iterations).
+- Canonical UVM regression: **110 passed, 0 failed, 0 skipped** (108 prior
+  + m3 test + probes dir excluded by the runner glob).
+- Bundled ivtest: **byte-identical to the pristine-baseline results**
+  (vvp_reg 2961/3101 + same 132 pre-existing failure names, vpi_reg 85/85,
+  vvp_reg.py 284/12).
+- The one-shot "constraint item not representable" warning fires once
+  during uvm_pkg compile (honest surface of a pre-existing dropped item).
+
+Note: PR #66 (M1+M2) was merged into main by the repository owner during
+this checkpoint; the topic branch was restarted from the merged main and
+the M3 work committed on top (WIP commit `9d64dda`, regression
+confirmation in the follow-up docs commit). New PR: #67.
 
 ## Checkpoint history
 

--- a/docs/conformance/session_logs/2026-07-11_typed_expression_dispatch.md
+++ b/docs/conformance/session_logs/2026-07-11_typed_expression_dispatch.md
@@ -439,7 +439,13 @@ routine in UVM stimulus.
 
 ### Results
 
-(recorded when regressions complete)
+- Focused: `m3_constraint_signed_test` PASS (plain and under the UVM
+  regression recipe).
+- Canonical UVM regression: **112 passed, 0 failed, 0 skipped**.
+- Bundled ivtest: **byte-identical to the pristine-baseline results**
+  (vvp_reg 2961/3101 + same 132 pre-existing failure names, vpi_reg
+  85/85, vvp_reg.py 284/12).
+- WIP marker on `889d084` superseded by this regression confirmation.
 
 ## Checkpoint history
 

--- a/docs/conformance/session_logs/2026-07-11_typed_expression_dispatch.md
+++ b/docs/conformance/session_logs/2026-07-11_typed_expression_dispatch.md
@@ -394,7 +394,14 @@ indexes and shadow outer names).
 
 ### Results
 
-(recorded when regressions complete)
+- Focused: single-shot size/foreach probes, the 10-iteration combined
+  probe, and `m3_constraint_array_test` under the regression recipe all
+  PASS.
+- Canonical UVM regression: **111 passed, 0 failed, 0 skipped**.
+- Bundled ivtest: **byte-identical to the pristine-baseline results**
+  (vvp_reg 2961/3101 + same 132 pre-existing failure names, vpi_reg
+  85/85, vvp_reg.py 284/12).
+- WIP marker on `6f7e875` superseded by this regression confirmation.
 
 ## Checkpoint history
 

--- a/docs/conformance/session_logs/2026-07-11_typed_expression_dispatch.md
+++ b/docs/conformance/session_logs/2026-07-11_typed_expression_dispatch.md
@@ -245,6 +245,78 @@ incompatibility produces a specific diagnostic
   fires on UVM dynamic-array paths (pre-existing tgt-vvp/eval_object.c
   compile-progress fallback — Phase 75 scope).
 
+## Checkpoint 4 — M3: constraint solver semantics (G15/G17/G18/G20 + G11 impl)
+
+### Requirement
+
+IEEE 1800-2017 Chapter 18 constraint blocks: 18.5.6 implication
+(`expr -> constraint_set`), 18.5.7 if-else constraints, 18.5.3 set
+membership (enum literals in sets), 18.5.2 constraint inheritance
+(derived classes inherit base constraints; same-name overrides).
+
+### Root causes (per gap)
+
+- **G15** (implication): `pexpr_to_constraint_ir` had no case for
+  PEBLogic 'q' (`->`) so the whole item silently vanished; the
+  `A -> { set }` form additionally lost its consequent in parse.y
+  (constraint_trigger returned nothing, action `$$ = $1`).
+- **G17** (if-else): parse.y dropped the entire constraint set
+  (`$$ = nullptr`).
+- **G18** (enum inside): enum literal identifiers resolved to neither
+  property nor constant, so set ranges silently dropped out of the
+  `(inside ...)` IR (leaving it empty ⇒ true ⇒ underconstrained).
+- **G20** (inheritance): (a) derived netclass_t never saw base
+  constraint IRs; (b) the `x * 2` expression used `mul`, absent from
+  both the IR generator switch and the Z3 parser (as were add/sub in
+  the parser — generator emitted them but the solver silently treated
+  them as `true`).
+- **G11**: the implication half is the G15 fix; `solve...before`
+  ordering remains parsed-and-ignored (xor-diversity provides the
+  distribution; staged-order solving deferred).
+
+### Implementation
+
+- `PExpr.h/cc`: new `PEConstraintIf` pform node (cond + then/else item
+  lists) for constraint-set implication and if-else.
+- `parse.y`: constraint_set / constraint_expression_list /
+  constraint_trigger now build `std::list<PExpr*>`; the if/else,
+  `A -> {...}` and foreach rules no longer leak or silently drop
+  (foreach still unsupported: items deleted, documented).
+  Grammar conflicts unchanged (450 s/r, 1060 r/r).
+- `elaborate.cc` (`pexpr_to_constraint_ir`): new ops impl/iff and
+  mul/div/mod; PEConstraintIf lowering
+  `(impl C then) [and (impl (not C) else)]`; enum-literal resolution
+  through the class scope chain (new `scope` parameter); enum-typed
+  property widths; a one-shot warning when a constraint item cannot be
+  represented (silent weakening is a manifesto-4 violation).
+- `netclass.h/cc`: lazy inheritance merge
+  (`merge_inherited_constraint_irs_`), deferred until the base chain
+  has elaborated; local same-name constraints override (18.5.2).
+  Verified property indexes are chain-stable (vvp `.class` dumps show
+  base properties keep their slots in derived classes).
+- `vvp/vvp_z3.cc`: `impl` (Z3_mk_implies), `iff` (Z3_mk_iff),
+  `add/sub/mul/div/mod` bitvector arithmetic with width harmonization.
+
+### Tests
+
+- `tests/m3_constraint_semantics_test.sv`: five constraint families ×
+  20 iterations (implication, if-else sets, enum-literal inside,
+  inherited constraint + child arithmetic constraint, solve-before with
+  implications and distribution sanity check).
+
+### Known limitations (recorded in audit)
+
+- `foreach` iterative constraints (G16) and `arr.size()` constraints
+  (G21): rand arrays are not representable in the scalar p:N:W IR —
+  needs array-property solver support (next M3 increment).
+- `solve...before` ordering semantics; signed comparisons (IR carries
+  no sign; bvult/bvule used); state-variable (non-rand) references in
+  class constraints still drop (now warned).
+
+### Results
+
+(recorded when the regression runs complete)
+
 ## Checkpoint history
 
 - Checkpoint 1: manifesto imported to `docs/conformance/`, baseline recorded (this file).

--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -54,7 +54,8 @@ using namespace std;
  * be evaluated at the call site and substituted as v:N:W at runtime. */
 extern string pexpr_to_constraint_ir(const PExpr*expr,
 				     const netclass_t*cls,
-				     vector<const PExpr*>*value_slots);
+				     vector<const PExpr*>*value_slots,
+				     const NetScope*scope = nullptr);
 
 /* Build a NetESFunc for randomize() with inline with-constraints.
  * The mangled function name encodes the N_vals count and IR string so
@@ -71,7 +72,7 @@ static NetESFunc* make_randomize_with_expr(
 
       for (const PExpr*wc : call->with_constraints()) {
 	    if (!wc) continue;
-	    string ir = pexpr_to_constraint_ir(wc, class_type, &value_slots);
+	    string ir = pexpr_to_constraint_ir(wc, class_type, &value_slots, scope);
 	    if (ir.empty()) continue;
 	    if (!combined_ir.empty()) combined_ir += " ";
 	    combined_ir += ir;

--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -55,7 +55,8 @@ using namespace std;
 extern string pexpr_to_constraint_ir(const PExpr*expr,
 				     const netclass_t*cls,
 				     vector<const PExpr*>*value_slots,
-				     const NetScope*scope = nullptr);
+				     const NetScope*scope = nullptr,
+				     const std::map<perm_string,uint64_t>*loop_env = nullptr);
 
 /* Build a NetESFunc for randomize() with inline with-constraints.
  * The mangled function name encodes the N_vals count and IR string so

--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -9210,7 +9210,19 @@ NetExpr* PEIdent::elaborate_expr_(Design*des, NetScope*scope,
 		      && sr.path_tail.size() == 1
 		      && peek_head_name(sr.path_tail) == perm_string::literal("triggered")
 		      && sr.path_tail.front().index.empty()) {
-			NetEConst*tmp = make_const_0(1);
+			  // IEEE 1800-2017 15.5.3: the triggered event
+			  // property is true if the event has been
+			  // triggered in the current time step. Lower to
+			  // a runtime query of the event's trigger stamp
+			  // (previously this was a constant-0 silent
+			  // miscompile that made wait(e.triggered) block
+			  // forever).
+			NetESFunc*tmp = new NetESFunc(
+			      "$ivl_event_method$triggered",
+			      IVL_VT_BOOL, 1, 1);
+			NetEEvent*ev = new NetEEvent(sr.eve);
+			ev->set_line(*this);
+			tmp->parm(0, ev);
 			tmp->set_line(*this);
 			return tmp;
 		  }

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -8103,7 +8103,47 @@ NetProc* PEventStatement::elaborate_wait(Design*des, NetScope*scope,
                                 wait_set->add(nx, 0, nx->vector_width());
                     }
               }
-	      if (wait_set == 0) {
+
+	      // Named events referenced through the triggered property
+	      // (IEEE 1800-2017 15.5.3) contribute event sensitivity, not
+	      // nexus sensitivity: wait (e.triggered) must wake when the
+	      // event fires and must fall straight through when the event
+	      // already fired in the current time step.
+	    std::vector<NetEvent*> trig_events;
+	    {
+		  std::function<void(const NetExpr*)> collect_trig_events;
+		  collect_trig_events = [&](const NetExpr*e) -> void {
+			if (!e) return;
+			if (const NetEBinary*bin = dynamic_cast<const NetEBinary*>(e)) {
+			      collect_trig_events(bin->left());
+			      collect_trig_events(bin->right());
+			      return;
+			}
+			if (const NetEUnary*un = dynamic_cast<const NetEUnary*>(e)) {
+			      collect_trig_events(un->expr());
+			      return;
+			}
+			if (const NetESFunc*sf = dynamic_cast<const NetESFunc*>(e)) {
+			      if (strcmp(sf->name(), "$ivl_event_method$triggered") == 0
+				  && sf->nparms() == 1) {
+				    if (const NetEEvent*ee =
+					dynamic_cast<const NetEEvent*>(sf->parm(0))) {
+					  trig_events.push_back(
+						const_cast<NetEvent*>(ee->event()));
+					  return;
+				    }
+			      }
+			      for (unsigned i = 0; i < sf->nparms(); ++i)
+				    collect_trig_events(sf->parm(i));
+			      return;
+			}
+		  };
+		  collect_trig_events(expr);
+	    }
+	    for (NetEvent*tev : trig_events)
+		  wait->add_event(tev);
+
+	      if (wait_set == 0 && trig_events.empty()) {
 		    if (gn_system_verilog()) {
 			  if (!warned_wait_no_event_sources) {
 				cerr << get_fileline() << ": warning: wait expression has no event "
@@ -8120,7 +8160,7 @@ NetProc* PEventStatement::elaborate_wait(Design*des, NetScope*scope,
 	    return 0;
       }
 
-	      if (wait_set->size() == 0) {
+	      if (wait_set != 0 && wait_set->size() == 0 && trig_events.empty()) {
 		    if (gn_system_verilog()) {
 			  if (!warned_wait_empty_event_set) {
 				cerr << get_fileline() << ": warning: wait expression has empty event "
@@ -8138,14 +8178,17 @@ NetProc* PEventStatement::elaborate_wait(Design*des, NetScope*scope,
 	    return 0;
       }
 
-      NetEvProbe*wait_pr = new NetEvProbe(scope, scope->local_symbol(),
-					  wait_event, NetEvProbe::ANYEDGE,
-					  wait_set->size());
-      for (unsigned idx = 0; idx < wait_set->size() ;  idx += 1)
-	    connect(wait_set->at(idx).lnk, wait_pr->pin(idx));
+      NetEvProbe*wait_pr = 0;
+      if (wait_set != 0 && wait_set->size() > 0) {
+	    wait_pr = new NetEvProbe(scope, scope->local_symbol(),
+				     wait_event, NetEvProbe::ANYEDGE,
+				     wait_set->size());
+	    for (unsigned idx = 0; idx < wait_set->size() ;  idx += 1)
+		  connect(wait_set->at(idx).lnk, wait_pr->pin(idx));
 
+	    des->add_node(wait_pr);
+      }
       delete wait_set;
-      des->add_node(wait_pr);
 
       // Phase 55/58: Detect VIF signal chain in wait() for RTL-driven wakeup.
       // Mirrors the @(posedge/anyedge) detection at lines ~7067-7123.
@@ -8193,7 +8236,7 @@ NetProc* PEventStatement::elaborate_wait(Design*des, NetScope*scope,
 					  ivl_type_t pt = vif_host_cls->get_prop_type(
 					      mid_p->property_idx());
 					  const netclass_t*vif_cls = dynamic_cast<const netclass_t*>(pt);
-					  if (vif_cls && vif_cls->is_interface()) {
+					  if (vif_cls && vif_cls->is_interface() && wait_pr) {
 						wait_pr->set_vif_anyedge(mid_p->property_idx(),
 									 outer_p->property_idx(), pre_N);
 						return true;

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -10268,11 +10268,14 @@ bool Module::elaborate(Design*des, NetScope*scope) const
  *               Caller must elaborate and push these at the call site.
  * scope:        if non-null, non-property identifiers are first resolved
  *               as enumeration literals through this scope chain and
- *               emitted as constants (IEEE 1800-2017 18.5.3). */
+ *               emitted as constants (IEEE 1800-2017 18.5.3).
+ * loop_env:     if non-null, maps foreach loop-variable names to their
+ *               unrolled constant values (IEEE 1800-2017 18.5.8). */
 string pexpr_to_constraint_ir(const PExpr*expr,
 			      const netclass_t*cls,
 			      vector<const PExpr*>*value_slots,
-			      const NetScope*scope)
+			      const NetScope*scope,
+			      const map<perm_string,uint64_t>*loop_env)
 {
       using namespace std;
 
@@ -10290,11 +10293,55 @@ string pexpr_to_constraint_ir(const PExpr*expr,
 
       if (const PEIdent*id = dynamic_cast<const PEIdent*>(expr)) {
 	    perm_string name = id->path().back().name;
+
+	      // foreach loop variables shadow properties inside the
+	      // iterated constraint set (IEEE 1800-2017 18.5.8).
+	    if (loop_env && id->path().size() == 1
+		&& id->path().back().index.empty()) {
+		  map<perm_string,uint64_t>::const_iterator lit =
+			loop_env->find(name);
+		  if (lit != loop_env->end())
+			return "c:" + to_string(lit->second);
+	    }
+
 	    int idx = cls->property_idx_from_name(name);
 	    if (idx >= 0) {
 		  property_qualifier_t q = cls->get_prop_qual((size_t)idx);
 		  if (!q.test_rand()) return "";
 		  ivl_type_t ptype = cls->get_prop_type((size_t)idx);
+
+		    // Indexed reference to a static-array rand property
+		    // (arr[i] in a foreach set): emit an element variable
+		    // e:N:W:I. The index must fold to a constant under the
+		    // loop environment.
+		  if (!id->path().back().index.empty()) {
+			const netuarray_t*ua =
+			      dynamic_cast<const netuarray_t*>(ptype);
+			if (!ua || id->path().back().index.size() != 1)
+			      return "";
+			const index_component_t&ic = id->path().back().index.front();
+			if (!ic.msb || ic.lsb
+			    || ic.sel != index_component_t::SEL_BIT)
+			      return "";
+			string idx_ir = pexpr_to_constraint_ir(ic.msb, cls,
+						value_slots, scope, loop_env);
+			if (idx_ir.compare(0, 2, "c:") != 0)
+			      return "";
+			uint64_t elem = strtoull(idx_ir.c_str() + 2, nullptr, 10);
+			const netranges_t&dims = ua->static_dimensions();
+			if (dims.size() != 1)
+			      return "";
+			  // Element addressing assumes a 0-based canonical
+			  // range; other declared ranges not yet supported.
+			if (dims[0].get_msb() != 0 && dims[0].get_lsb() != 0)
+			      return "";
+			ivl_type_t etype = ua->element_type();
+			unsigned ewid = etype ? etype->packed_width() : 32;
+			if (ewid == 0) ewid = 32;
+			return "e:" + to_string(idx) + ":" + to_string(ewid)
+			      + ":" + to_string(elem);
+		  }
+
 		  unsigned wid = 0;
 		  if (ptype) {
 			const netvector_t*nvec = dynamic_cast<const netvector_t*>(ptype);
@@ -10337,7 +10384,7 @@ string pexpr_to_constraint_ir(const PExpr*expr,
       // Z3_optimize_assert_soft (default weight 1) instead of a hard
       // conjunct.
       if (const PESoft*sf = dynamic_cast<const PESoft*>(expr)) {
-	    string s = pexpr_to_constraint_ir(sf->get_inner(), cls, value_slots, scope);
+	    string s = pexpr_to_constraint_ir(sf->get_inner(), cls, value_slots, scope, loop_env);
 	    if (s.empty() || s[0] == '?') return "";
 	    return "(soft " + s + ")";
       }
@@ -10347,7 +10394,7 @@ string pexpr_to_constraint_ir(const PExpr*expr,
 	// (impl C then) [and (impl (not C) else)].
       if (const PEConstraintIf*cif = dynamic_cast<const PEConstraintIf*>(expr)) {
 	    string cond = pexpr_to_constraint_ir(cif->get_cond(), cls,
-						 value_slots, scope);
+						 value_slots, scope, loop_env);
 	    if (cond.empty()) return "";
 
 	    auto items_to_ir = [&](const std::list<PExpr*>&items) -> string {
@@ -10355,7 +10402,8 @@ string pexpr_to_constraint_ir(const PExpr*expr,
 		  for (const PExpr*item : items) {
 			if (!item) continue;
 			string s = pexpr_to_constraint_ir(item, cls,
-							  value_slots, scope);
+							  value_slots, scope,
+							  loop_env);
 			if (s.empty()) return "";
 			acc = acc.empty() ? s : "(and " + acc + " " + s + ")";
 		  }
@@ -10374,8 +10422,83 @@ string pexpr_to_constraint_ir(const PExpr*expr,
 	    return result;
       }
 
+	// Dynamic-array size in a constraint: `arr.size()` becomes a
+	// solver size variable s:N:T (IEEE 1800-2017 18.4: the size of a
+	// rand dynamic array is randomized subject to constraints). T is
+	// the darray type text used to construct the array at write-back.
+      if (const PECallFunction*call = dynamic_cast<const PECallFunction*>(expr)) {
+	    const pform_name_t&cpath = call->path().name;
+	    if (cpath.size() == 2
+		&& cpath.back().name == perm_string::literal("size")
+		&& cpath.back().index.empty()
+		&& cpath.front().index.empty()) {
+		  perm_string aname = cpath.front().name;
+		  int idx = cls->property_idx_from_name(aname);
+		  if (idx >= 0
+		      && cls->get_prop_qual((size_t)idx).test_rand()) {
+			ivl_type_t ptype = cls->get_prop_type((size_t)idx);
+			const netdarray_t*da =
+			      dynamic_cast<const netdarray_t*>(ptype);
+			if (da && !dynamic_cast<const netqueue_t*>(ptype)) {
+			      ivl_type_t etype = da->element_type();
+			      unsigned ewid = etype ? etype->packed_width() : 32;
+			      if (ewid == 0) ewid = 32;
+			      bool esigned = etype && etype->get_signed();
+			      string ttext;
+			      if (ewid == 8 || ewid == 16
+				  || ewid == 32 || ewid == 64)
+				    ttext = (esigned ? "sb" : "b")
+					  + to_string(ewid);
+			      else
+				    ttext = (esigned ? "sv" : "v")
+					  + to_string(ewid);
+			      return "s:" + to_string(idx) + ":" + ttext;
+			}
+		  }
+	    }
+	    return "";
+      }
+
+	// Iterative constraint over a one-dimensional static-array rand
+	// property (IEEE 1800-2017 18.5.8): unroll at elaboration time,
+	// binding the loop variable to each canonical index.
+      if (const PEConstraintForeach*cfe =
+	  dynamic_cast<const PEConstraintForeach*>(expr)) {
+	    if (cfe->loop_vars().size() != 1 || cfe->loop_vars()[0].nil())
+		  return "";
+	    int idx = cls->property_idx_from_name(cfe->array_name());
+	    if (idx < 0 || !cls->get_prop_qual((size_t)idx).test_rand())
+		  return "";
+	    const netuarray_t*ua =
+		  dynamic_cast<const netuarray_t*>(cls->get_prop_type((size_t)idx));
+	    if (!ua)
+		  return "";  // dynamic-array foreach: not yet supported
+	    const netranges_t&dims = ua->static_dimensions();
+	    if (dims.size() != 1)
+		  return "";
+	    if (dims[0].get_msb() != 0 && dims[0].get_lsb() != 0)
+		  return "";
+	    unsigned long count = dims[0].width();
+
+	    string acc;
+	    for (unsigned long i = 0 ; i < count ; i += 1) {
+		  map<perm_string,uint64_t> env2;
+		  if (loop_env) env2 = *loop_env;
+		  env2[cfe->loop_vars()[0]] = i;
+		  for (const PExpr*item : cfe->items()) {
+			if (!item) continue;
+			string s = pexpr_to_constraint_ir(item, cls,
+						value_slots, scope, &env2);
+			if (s.empty())
+			      return "";
+			acc = acc.empty() ? s : "(and " + acc + " " + s + ")";
+		  }
+	    }
+	    return acc;
+      }
+
       if (const PEInside*ins = dynamic_cast<const PEInside*>(expr)) {
-	    string s = pexpr_to_constraint_ir(ins->get_expr(), cls, value_slots, scope);
+	    string s = pexpr_to_constraint_ir(ins->get_expr(), cls, value_slots, scope, loop_env);
 	    if (s.empty() || s[0] == '?') return "";
 	    // C7 (Phase 62b): dist form preserves per-branch weights as
 	    // `(dist <expr> (b W <range>) ...)` where W is the literal
@@ -10386,12 +10509,12 @@ string pexpr_to_constraint_ir(const PExpr*expr,
 	    for (auto& r : ins->get_ranges()) {
 		  string range_ir;
 		  if (r.is_range) {
-			string lo = pexpr_to_constraint_ir(r.lo, cls, value_slots, scope);
-			string hi = pexpr_to_constraint_ir(r.hi, cls, value_slots, scope);
+			string lo = pexpr_to_constraint_ir(r.lo, cls, value_slots, scope, loop_env);
+			string hi = pexpr_to_constraint_ir(r.hi, cls, value_slots, scope, loop_env);
 			if (lo.empty() || hi.empty()) continue;
 			range_ir = "[" + lo + "," + hi + "]";
 		  } else {
-			string v = pexpr_to_constraint_ir(r.hi, cls, value_slots, scope);
+			string v = pexpr_to_constraint_ir(r.hi, cls, value_slots, scope, loop_env);
 			if (v.empty()) continue;
 			range_ir = v;
 		  }
@@ -10400,7 +10523,7 @@ string pexpr_to_constraint_ir(const PExpr*expr,
 			// dist (rare, but legal in mixed forms).
 			string w = "1";
 			if (r.weight) {
-			      string we = pexpr_to_constraint_ir(r.weight, cls, value_slots, scope);
+			      string we = pexpr_to_constraint_ir(r.weight, cls, value_slots, scope, loop_env);
 			      if (!we.empty()) w = we;
 			}
 			result += " (b " + w + " " + range_ir + ")";
@@ -10413,8 +10536,8 @@ string pexpr_to_constraint_ir(const PExpr*expr,
       }
 
       if (const PEBinary*bin = dynamic_cast<const PEBinary*>(expr)) {
-	    string left = pexpr_to_constraint_ir(bin->get_left(), cls, value_slots, scope);
-	    string right = pexpr_to_constraint_ir(bin->get_right(), cls, value_slots, scope);
+	    string left = pexpr_to_constraint_ir(bin->get_left(), cls, value_slots, scope, loop_env);
+	    string right = pexpr_to_constraint_ir(bin->get_right(), cls, value_slots, scope, loop_env);
 	    if (left.empty() || right.empty()) return "";
 	    string op;
 	    switch (bin->get_op()) {
@@ -10435,11 +10558,27 @@ string pexpr_to_constraint_ir(const PExpr*expr,
 		case '%': op = "mod"; break;
 		default:  return "";
 	    }
+	      // Fold constant arithmetic (e.g. unrolled foreach index
+	      // expressions like i*10) so inside/dist range bounds stay
+	      // simple c:V literals.
+	    if (left.compare(0, 2, "c:") == 0 && right.compare(0, 2, "c:") == 0
+		&& (op == "add" || op == "sub" || op == "mul"
+		    || op == "div" || op == "mod")) {
+		  uint64_t lv = strtoull(left.c_str() + 2, nullptr, 10);
+		  uint64_t rv = strtoull(right.c_str() + 2, nullptr, 10);
+		  uint64_t res = 0;
+		  if (op == "add") res = lv + rv;
+		  else if (op == "sub") res = lv - rv;
+		  else if (op == "mul") res = lv * rv;
+		  else if (op == "div") res = rv ? lv / rv : 0;
+		  else res = rv ? lv % rv : 0;
+		  return "c:" + to_string(res);
+	    }
 	    return "(" + op + " " + left + " " + right + ")";
       }
 
       if (const PEUnary*un = dynamic_cast<const PEUnary*>(expr)) {
-	    string sub = pexpr_to_constraint_ir(un->get_expr(), cls, value_slots, scope);
+	    string sub = pexpr_to_constraint_ir(un->get_expr(), cls, value_slots, scope, loop_env);
 	    if (sub.empty()) return "";
 	    if (un->get_op() == '!') return "(not " + sub + ")";
 	    return "";
@@ -10496,7 +10635,7 @@ void netclass_t::elaborate(Design*des, PClass*pclass)
 		    for (PExpr*item : cit.second) {
 			  if (!item) continue;
 			  string s = pexpr_to_constraint_ir(item, this, nullptr,
-							    class_scope_);
+							    class_scope_, nullptr);
 			  if (!s.empty()) {
 				if (!ir.empty()) ir += " ";
 				ir += s;

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -10338,8 +10338,9 @@ string pexpr_to_constraint_ir(const PExpr*expr,
 			ivl_type_t etype = ua->element_type();
 			unsigned ewid = etype ? etype->packed_width() : 32;
 			if (ewid == 0) ewid = 32;
+			string esfx = (etype && etype->get_signed()) ? ":s" : "";
 			return "e:" + to_string(idx) + ":" + to_string(ewid)
-			      + ":" + to_string(elem);
+			      + ":" + to_string(elem) + esfx;
 		  }
 
 		  unsigned wid = 0;
@@ -10351,7 +10352,10 @@ string pexpr_to_constraint_ir(const PExpr*expr,
 			      wid = nenum->packed_width();
 		  }
 		  if (wid == 0) wid = 32;
-		  return "p:" + to_string(idx) + ":" + to_string(wid);
+		    // Signed properties are marked so the solver uses
+		    // signed comparison semantics (IEEE 1800-2017 11.8.1).
+		  string sfx = (ptype && ptype->get_signed()) ? ":s" : "";
+		  return "p:" + to_string(idx) + ":" + to_string(wid) + sfx;
 	    }
 	      // Enumeration literal (IEEE 1800-2017 18.5.3: sets may name
 	      // enum values): resolve to its constant through the scope
@@ -10581,6 +10585,17 @@ string pexpr_to_constraint_ir(const PExpr*expr,
 	    string sub = pexpr_to_constraint_ir(un->get_expr(), cls, value_slots, scope, loop_env);
 	    if (sub.empty()) return "";
 	    if (un->get_op() == '!') return "(not " + sub + ")";
+	    if (un->get_op() == '-') {
+		    // Negation: literals fold to their 64-bit two's
+		    // complement (the solver reduces numerals mod 2^W at
+		    // the use width); other operands become (sub 0 x).
+		  if (sub.compare(0, 2, "c:") == 0) {
+			uint64_t v = strtoull(sub.c_str() + 2, nullptr, 10);
+			return "c:" + to_string((uint64_t)(0 - v));
+		  }
+		  return "(sub c:0 " + sub + ")";
+	    }
+	    if (un->get_op() == '+') return sub;
 	    return "";
       }
 

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -10265,10 +10265,14 @@ bool Module::elaborate(Design*des, NetScope*scope) const
  * cls:          class being constrained (for property lookup).
  * value_slots:  if non-null, non-property caller-scope identifiers are
  *               collected here (returned as "v:N:W" placeholders in IR).
- *               Caller must elaborate and push these at the call site. */
+ *               Caller must elaborate and push these at the call site.
+ * scope:        if non-null, non-property identifiers are first resolved
+ *               as enumeration literals through this scope chain and
+ *               emitted as constants (IEEE 1800-2017 18.5.3). */
 string pexpr_to_constraint_ir(const PExpr*expr,
 			      const netclass_t*cls,
-			      vector<const PExpr*>*value_slots)
+			      vector<const PExpr*>*value_slots,
+			      const NetScope*scope)
 {
       using namespace std;
 
@@ -10295,9 +10299,29 @@ string pexpr_to_constraint_ir(const PExpr*expr,
 		  if (ptype) {
 			const netvector_t*nvec = dynamic_cast<const netvector_t*>(ptype);
 			if (nvec) wid = nvec->packed_width();
+			else if (const netenum_t*nenum =
+				 dynamic_cast<const netenum_t*>(ptype))
+			      wid = nenum->packed_width();
 		  }
 		  if (wid == 0) wid = 32;
 		  return "p:" + to_string(idx) + ":" + to_string(wid);
+	    }
+	      // Enumeration literal (IEEE 1800-2017 18.5.3: sets may name
+	      // enum values): resolve to its constant through the scope
+	      // chain. Without this, enum names silently vanish from
+	      // inside/dist sets and under-constrain the solve (G18).
+	    if (id->path().size() == 1) {
+		  for (const NetScope*sc = scope ; sc ; sc = sc->parent()) {
+			const NetExpr*en =
+			      const_cast<NetScope*>(sc)->enumeration_expr(name);
+			if (!en) continue;
+			if (const NetEConst*ec =
+			    dynamic_cast<const NetEConst*>(en)) {
+			      uint64_t val = ec->value().as_unsigned();
+			      return "c:" + to_string(val);
+			}
+			break;
+		  }
 	    }
 	    // Non-class-property identifier: treat as caller-scope runtime value.
 	    if (value_slots) {
@@ -10313,13 +10337,45 @@ string pexpr_to_constraint_ir(const PExpr*expr,
       // Z3_optimize_assert_soft (default weight 1) instead of a hard
       // conjunct.
       if (const PESoft*sf = dynamic_cast<const PESoft*>(expr)) {
-	    string s = pexpr_to_constraint_ir(sf->get_inner(), cls, value_slots);
+	    string s = pexpr_to_constraint_ir(sf->get_inner(), cls, value_slots, scope);
 	    if (s.empty() || s[0] == '?') return "";
 	    return "(soft " + s + ")";
       }
 
+	// Conditional constraint sets: if-else (IEEE 1800-2017 18.5.7)
+	// and "cond -> { ... }" implication sets (18.5.6). Lower to
+	// (impl C then) [and (impl (not C) else)].
+      if (const PEConstraintIf*cif = dynamic_cast<const PEConstraintIf*>(expr)) {
+	    string cond = pexpr_to_constraint_ir(cif->get_cond(), cls,
+						 value_slots, scope);
+	    if (cond.empty()) return "";
+
+	    auto items_to_ir = [&](const std::list<PExpr*>&items) -> string {
+		  string acc;
+		  for (const PExpr*item : items) {
+			if (!item) continue;
+			string s = pexpr_to_constraint_ir(item, cls,
+							  value_slots, scope);
+			if (s.empty()) return "";
+			acc = acc.empty() ? s : "(and " + acc + " " + s + ")";
+		  }
+		  return acc;
+	    };
+
+	    string then_ir = items_to_ir(cif->then_items());
+	    if (then_ir.empty()) return "";
+	    string result = "(impl " + cond + " " + then_ir + ")";
+	    if (!cif->else_items().empty()) {
+		  string else_ir = items_to_ir(cif->else_items());
+		  if (else_ir.empty()) return "";
+		  result = "(and " + result + " (impl (not " + cond + ") "
+			+ else_ir + "))";
+	    }
+	    return result;
+      }
+
       if (const PEInside*ins = dynamic_cast<const PEInside*>(expr)) {
-	    string s = pexpr_to_constraint_ir(ins->get_expr(), cls, value_slots);
+	    string s = pexpr_to_constraint_ir(ins->get_expr(), cls, value_slots, scope);
 	    if (s.empty() || s[0] == '?') return "";
 	    // C7 (Phase 62b): dist form preserves per-branch weights as
 	    // `(dist <expr> (b W <range>) ...)` where W is the literal
@@ -10330,12 +10386,12 @@ string pexpr_to_constraint_ir(const PExpr*expr,
 	    for (auto& r : ins->get_ranges()) {
 		  string range_ir;
 		  if (r.is_range) {
-			string lo = pexpr_to_constraint_ir(r.lo, cls, value_slots);
-			string hi = pexpr_to_constraint_ir(r.hi, cls, value_slots);
+			string lo = pexpr_to_constraint_ir(r.lo, cls, value_slots, scope);
+			string hi = pexpr_to_constraint_ir(r.hi, cls, value_slots, scope);
 			if (lo.empty() || hi.empty()) continue;
 			range_ir = "[" + lo + "," + hi + "]";
 		  } else {
-			string v = pexpr_to_constraint_ir(r.hi, cls, value_slots);
+			string v = pexpr_to_constraint_ir(r.hi, cls, value_slots, scope);
 			if (v.empty()) continue;
 			range_ir = v;
 		  }
@@ -10344,7 +10400,7 @@ string pexpr_to_constraint_ir(const PExpr*expr,
 			// dist (rare, but legal in mixed forms).
 			string w = "1";
 			if (r.weight) {
-			      string we = pexpr_to_constraint_ir(r.weight, cls, value_slots);
+			      string we = pexpr_to_constraint_ir(r.weight, cls, value_slots, scope);
 			      if (!we.empty()) w = we;
 			}
 			result += " (b " + w + " " + range_ir + ")";
@@ -10357,8 +10413,8 @@ string pexpr_to_constraint_ir(const PExpr*expr,
       }
 
       if (const PEBinary*bin = dynamic_cast<const PEBinary*>(expr)) {
-	    string left = pexpr_to_constraint_ir(bin->get_left(), cls, value_slots);
-	    string right = pexpr_to_constraint_ir(bin->get_right(), cls, value_slots);
+	    string left = pexpr_to_constraint_ir(bin->get_left(), cls, value_slots, scope);
+	    string right = pexpr_to_constraint_ir(bin->get_right(), cls, value_slots, scope);
 	    if (left.empty() || right.empty()) return "";
 	    string op;
 	    switch (bin->get_op()) {
@@ -10370,15 +10426,20 @@ string pexpr_to_constraint_ir(const PExpr*expr,
 		case 'n': op = "ne";  break;  // K_NE (!=)
 		case 'a': op = "and"; break;  // && (K_LAND)
 		case 'o': op = "or";  break;  // || (K_LOR)
+		case 'q': op = "impl"; break; // -> (IEEE 1800-2017 18.5.6)
+		case 'Q': op = "iff"; break;  // <-> (equivalence)
 		case '+': op = "add"; break;
 		case '-': op = "sub"; break;
+		case '*': op = "mul"; break;
+		case '/': op = "div"; break;
+		case '%': op = "mod"; break;
 		default:  return "";
 	    }
 	    return "(" + op + " " + left + " " + right + ")";
       }
 
       if (const PEUnary*un = dynamic_cast<const PEUnary*>(expr)) {
-	    string sub = pexpr_to_constraint_ir(un->get_expr(), cls, value_slots);
+	    string sub = pexpr_to_constraint_ir(un->get_expr(), cls, value_slots, scope);
 	    if (sub.empty()) return "";
 	    if (un->get_op() == '!') return "(not " + sub + ")";
 	    return "";
@@ -10434,10 +10495,25 @@ void netclass_t::elaborate(Design*des, PClass*pclass)
 		    string ir;
 		    for (PExpr*item : cit.second) {
 			  if (!item) continue;
-			  string s = pexpr_to_constraint_ir(item, this, nullptr);
+			  string s = pexpr_to_constraint_ir(item, this, nullptr,
+							    class_scope_);
 			  if (!s.empty()) {
 				if (!ir.empty()) ir += " ";
 				ir += s;
+			  } else {
+				  // Manifesto principle 4: a dropped item
+				  // silently WEAKENS the constraint. Say so.
+				static bool warned_unconvertible_constraint = false;
+				if (!warned_unconvertible_constraint) {
+				      cerr << item->get_fileline() << ": warning: "
+					   << "Constraint item in '" << cit.first
+					   << "' of class " << get_name()
+					   << " is not representable in the "
+					   << "constraint solver and is ignored "
+					   << "(further similar warnings "
+					   << "suppressed)." << endl;
+				      warned_unconvertible_constraint = true;
+				}
 			  }
 		    }
 		    if (!ir.empty())

--- a/netclass.cc
+++ b/netclass.cc
@@ -587,6 +587,45 @@ void netclass_t::add_constraint_ir(const string&name, const string&ir)
       constraint_irs_.push_back(c);
 }
 
+void netclass_t::merge_inherited_constraint_irs_() const
+{
+      if (constraint_irs_merged_)
+	    return;
+
+      if (!super_) {
+	    constraint_irs_merged_ = true;
+	    return;
+      }
+
+	// A count query can arrive while classes are still elaborating
+	// (e.g. netlist dumps). Defer the merge - without latching the
+	// flag - until the base chain has elaborated its own constraint
+	// blocks, so nothing is lost.
+      for (const netclass_t*sup = super_ ; sup ; sup = sup->get_super()) {
+	    if (!sup->body_elaborated())
+		  return;
+      }
+      constraint_irs_merged_ = true;
+
+	// Recurse so the base class merges its own chain first, then
+	// inherit every base entry that is not overridden by a local
+	// constraint of the same name (IEEE 1800-2017 18.5.2). The
+	// synthesized _enum_* constraints regenerate per class and match
+	// by name, so they do not duplicate.
+      super_->merge_inherited_constraint_irs_();
+      for (const constraint_ir_t&base_c : super_->constraint_irs_) {
+	    bool overridden = false;
+	    for (const constraint_ir_t&own_c : constraint_irs_) {
+		  if (own_c.name == base_c.name) {
+			overridden = true;
+			break;
+		  }
+	    }
+	    if (!overridden)
+		  constraint_irs_.push_back(base_c);
+      }
+}
+
 void netclass_t::add_covgrp_bin(unsigned cp, unsigned prop, uint64_t lo, uint64_t hi,
 				unsigned kind)
 {

--- a/netclass.h
+++ b/netclass.h
@@ -154,7 +154,8 @@ class netclass_t : public ivl_type_s {
 	// Format: each item is "name\tir_string" where ir_string is an
 	// S-expression like "(lt p:1:8 c:255)".
       void add_constraint_ir(const std::string&name, const std::string&ir);
-      size_t constraint_ir_count() const { return constraint_irs_.size(); }
+      size_t constraint_ir_count() const
+	    { merge_inherited_constraint_irs_(); return constraint_irs_.size(); }
       const std::string& constraint_ir_name(size_t idx) const;
       const std::string& constraint_ir_str(size_t idx)  const;
       void set_body_elaborated(bool flag) { body_elaborated_ = flag; }
@@ -219,7 +220,17 @@ class netclass_t : public ivl_type_s {
 	    std::string name;
 	    std::string ir;
       };
-      std::vector<constraint_ir_t> constraint_irs_;
+      mutable std::vector<constraint_ir_t> constraint_irs_;
+	// Constraint inheritance (IEEE 1800-2017 18.5.2): derived classes
+	// inherit base-class constraints unless overridden by a local
+	// constraint of the same name. The merge runs lazily on the first
+	// count query, which happens at code-emission time after all
+	// classes have elaborated their own constraint blocks. Property
+	// indexes are stable across the inheritance chain (base properties
+	// keep their slots in derived classes), so base IR strings apply
+	// verbatim.
+      void merge_inherited_constraint_irs_() const;
+      mutable bool constraint_irs_merged_ = false;
 
     public:
 	// Covergroup bin metadata (for synthesized covergroup class types).

--- a/parse.y
+++ b/parse.y
@@ -1204,6 +1204,7 @@ Module::port_t *module_declare_port(const YYLTYPE&loc, char *id,
 
 %type <expr>  constraint_expression constraint_block_item
 %type <exprs> constraint_block_item_list constraint_block_item_list_opt
+%type <exprs> constraint_expression_list constraint_set constraint_trigger
 
 %type <decl_assignment> variable_decl_assignment
 %type <decl_assignments> list_of_variable_decl_assignments
@@ -2579,13 +2580,29 @@ constraint_expression /* IEEE1800-2005 A.1.9 */
         }
       }
   | expression constraint_trigger
-      { $$ = $1; }
+      { /* A -> { items... } — implication onto a constraint set
+	   (IEEE 1800-2017 18.5.6). */
+	PEConstraintIf*tmp = new PEConstraintIf($1, $2, nullptr);
+	FILE_NAME(tmp, @2);
+	$$ = tmp;
+      }
   | K_if '(' expression ')' constraint_set %prec less_than_K_else
-      { $$ = nullptr; }
+      { PEConstraintIf*tmp = new PEConstraintIf($3, $5, nullptr);
+	FILE_NAME(tmp, @1);
+	$$ = tmp;
+      }
   | K_if '(' expression ')' constraint_set K_else constraint_set
-      { $$ = nullptr; }
+      { PEConstraintIf*tmp = new PEConstraintIf($3, $5, $7);
+	FILE_NAME(tmp, @1);
+	$$ = tmp;
+      }
   | K_foreach '(' IDENTIFIER '[' loop_variables ']' ')' constraint_set
-      { $$ = nullptr; delete[] $3; }
+      { $$ = nullptr; delete[] $3;
+	if ($8) {
+	      for (PExpr*item : *$8) delete item;
+	      delete $8;
+	}
+      }
   /* I4 (Phase 62c): soft constraint — wrap in PESoft so the IR emitter
      marks it for Z3_optimize_assert_soft (default weight 1).  Other
      contexts (non-constraint elaboration) delegate through to the inner
@@ -2663,11 +2680,18 @@ dist_item
 
 constraint_trigger
   : K_CONSTRAINT_IMPL '{' constraint_expression_list '}'
+      { $$ = $3; }
   ;
 
 constraint_expression_list /* */
   : constraint_expression_list constraint_expression
+      { $$ = $1;
+	if ($2) $$->push_back($2);
+      }
   | constraint_expression
+      { $$ = new std::list<PExpr*>();
+	if ($1) $$->push_back($1);
+      }
   ;
 
 constraint_prototype /* IEEE1800-2005: A.1.9 */
@@ -2682,7 +2706,11 @@ constraint_prototype /* IEEE1800-2005: A.1.9 */
 
 constraint_set /* IEEE1800-2005 A.1.9 */
   : constraint_expression
+      { $$ = new std::list<PExpr*>();
+	if ($1) $$->push_back($1);
+      }
   | '{' constraint_expression_list '}'
+      { $$ = $2; }
   ;
 
 /* ========= Covergroup grammar (functional coverage) ========= */

--- a/parse.y
+++ b/parse.y
@@ -2597,11 +2597,12 @@ constraint_expression /* IEEE1800-2005 A.1.9 */
 	$$ = tmp;
       }
   | K_foreach '(' IDENTIFIER '[' loop_variables ']' ')' constraint_set
-      { $$ = nullptr; delete[] $3;
-	if ($8) {
-	      for (PExpr*item : *$8) delete item;
-	      delete $8;
-	}
+      { /* Iterative constraint (IEEE 1800-2017 18.5.8). */
+	PEConstraintForeach*tmp =
+	      new PEConstraintForeach(lex_strings.make($3), $5, $8);
+	FILE_NAME(tmp, @1);
+	delete[] $3;
+	$$ = tmp;
       }
   /* I4 (Phase 62c): soft constraint — wrap in PESoft so the IR emitter
      marks it for Z3_optimize_assert_soft (default weight 1).  Other

--- a/tests/m3_constraint_array_test.sv
+++ b/tests/m3_constraint_array_test.sv
@@ -1,0 +1,38 @@
+// M3 array-constraint regression: dynamic-array size constraints (G21) and
+// foreach iterative constraints (G16). IEEE 1800-2017 18.5.8.
+module m3_constraint_array_test;
+  class SizeC;                        // G21
+    rand int unsigned sz;
+    rand byte arr[];
+    constraint c { sz inside {[3:5]}; arr.size() == sz; }
+  endclass
+
+  class ForeachC;                     // G16
+    rand int unsigned arr[4];
+    constraint c { foreach (arr[i]) arr[i] inside {[i*10 : i*10+5]}; }
+  endclass
+
+  initial begin
+    SizeC s = new;
+    ForeachC f = new;
+    int errors = 0;
+
+    repeat (10) begin
+      void'(s.randomize());
+      if (!(s.sz >= 3 && s.sz <= 5 && s.arr.size() == s.sz)) begin
+        $display("FAIL size sz=%0d arr.size=%0d", s.sz, s.arr.size());
+        errors++;
+      end
+      void'(f.randomize());
+      foreach (f.arr[i]) begin
+        if (!(f.arr[i] >= i*10 && f.arr[i] <= i*10+5)) begin
+          $display("FAIL foreach arr[%0d]=%0d", i, f.arr[i]);
+          errors++;
+        end
+      end
+    end
+
+    if (errors == 0) $display("PASS");
+    else $display("TOTAL FAILS: %0d", errors);
+  end
+endmodule

--- a/tests/m3_constraint_semantics_test.sv
+++ b/tests/m3_constraint_semantics_test.sv
@@ -1,0 +1,88 @@
+// M3 constraint regression: implication, if-else, enum inside, inheritance
+// (IEEE 1800-2017 Ch. 18 constraint blocks).
+module m3_constraint_semantics_test;
+  typedef enum { RED, GREEN, BLUE, YELLOW, MAGENTA } color_t;
+
+  class ImplC;                       // G15: implication
+    rand int unsigned x;
+    rand int unsigned y;
+    constraint c { x < 2; (x == 0) -> (y == 99); (x != 0) -> (y == 7); }
+  endclass
+
+  class IfC;                         // G17: if-else constraint set
+    rand int unsigned m;
+    rand int unsigned v;
+    constraint c {
+      m < 2;
+      if (m == 1) { v inside {[100:200]}; }
+      else        { v inside {[1:5]}; }
+    }
+  endclass
+
+  class EnumC;                       // G18: inside over enum literals
+    rand color_t col;
+    constraint c { col inside {RED, BLUE, MAGENTA}; }
+  endclass
+
+  class Par;                         // G20: inherited constraints
+    rand int unsigned x;
+    constraint cp { x inside {[1:50]}; }
+  endclass
+  class Chi extends Par;
+    rand int unsigned y;
+    constraint cc { y == x * 2; }
+  endclass
+
+  class SolveC;                      // G11: solve-before + implication
+    rand bit a;
+    rand int unsigned b;
+    constraint c { solve a before b; a -> b == 100; (!a) -> b == 0; }
+  endclass
+
+  initial begin
+    ImplC ic = new;
+    IfC   fc = new;
+    EnumC ec = new;
+    Chi   ch = new;
+    SolveC sc = new;
+    int errors = 0;
+    int a0, a1;
+
+    repeat (20) begin
+      void'(ic.randomize());
+      if (!((ic.x == 0 && ic.y == 99) || (ic.x == 1 && ic.y == 7))) begin
+        $display("FAIL impl x=%0d y=%0d", ic.x, ic.y);
+        errors++;
+      end
+      void'(fc.randomize());
+      if (!((fc.m == 1 && fc.v >= 100 && fc.v <= 200)
+            || (fc.m == 0 && fc.v >= 1 && fc.v <= 5))) begin
+        $display("FAIL ifelse m=%0d v=%0d", fc.m, fc.v);
+        errors++;
+      end
+      void'(ec.randomize());
+      if (!(ec.col inside {RED, BLUE, MAGENTA})) begin
+        $display("FAIL enum col=%0d", ec.col);
+        errors++;
+      end
+      void'(ch.randomize());
+      if (!(ch.x >= 1 && ch.x <= 50 && ch.y == ch.x * 2)) begin
+        $display("FAIL inherit x=%0d y=%0d", ch.x, ch.y);
+        errors++;
+      end
+      void'(sc.randomize());
+      if (!((sc.a == 1 && sc.b == 100) || (sc.a == 0 && sc.b == 0))) begin
+        $display("FAIL solve a=%0d b=%0d", sc.a, sc.b);
+        errors++;
+      end
+      if (sc.a) a1++; else a0++;
+    end
+
+    // solve-before should give both a-values a fair share (soft check).
+    if (a0 == 0 || a1 == 0)
+      $display("WARN solve-before distribution a0=%0d a1=%0d", a0, a1);
+
+    if (errors == 0) $display("PASS");
+    else $display("TOTAL FAILS: %0d", errors);
+  end
+endmodule

--- a/tests/m3_constraint_signed_test.sv
+++ b/tests/m3_constraint_signed_test.sv
@@ -1,0 +1,22 @@
+// M3 signed-constraint regression (IEEE 1800-2017 11.8.1; Ch.18).
+module m3_constraint_signed_test;
+  class SC;
+    rand int x;                       // signed
+    rand int y;
+    constraint c { x inside {[-5:5]}; y < 0; y >= -20; }
+  endclass
+  initial begin
+    SC s = new;
+    int errors = 0;
+    repeat (20) begin
+      void'(s.randomize());
+      if (!(s.x >= -5 && s.x <= 5)) begin
+        $display("FAIL x=%0d", s.x); errors++;
+      end
+      if (!(s.y < 0 && s.y >= -20)) begin
+        $display("FAIL y=%0d", s.y); errors++;
+      end
+    end
+    if (errors == 0) $display("PASS");
+  end
+endmodule

--- a/tests/m6_event_triggered_test.sv
+++ b/tests/m6_event_triggered_test.sv
@@ -1,0 +1,37 @@
+// M6 / G08 regression: event.triggered must be true for the remainder of
+// the time slot in which the event fires (IEEE 1800-2017 15.5.3), so
+// both an @(e) waiter and a wait(e.triggered) waiter observe one
+// trigger, with no race.
+module m6_event_triggered_test;
+  event e;
+  int hits = 0;
+
+  initial begin
+    fork
+      begin @(e);              hits += 1; end
+      begin wait (e.triggered); hits += 1; end
+    join_none
+    #1 ->e;
+    #1;
+    if (hits != 2) $display("FAIL g08a hits=%0d expected 2", hits);
+
+    // triggered must read true LATER in the same slot even for a
+    // process that starts waiting AFTER the trigger fired.
+    fork
+      begin #1 ->e; end
+      begin #1 wait (e.triggered); hits += 10; end
+    join
+    if (hits != 12) $display("FAIL g08b hits=%0d expected 12", hits);
+
+    // and must read false again in the NEXT slot.
+    #1;
+    fork
+      begin wait (e.triggered); hits += 100; end
+      begin #1; end
+    join_any
+    disable fork;
+    if (hits == 12) $display("PASS");
+    else $display("FAIL g08c hits=%0d (stale trigger leaked)", hits);
+    $finish;
+  end
+endmodule

--- a/tests/m6_sched_litmus_test.sv
+++ b/tests/m6_sched_litmus_test.sv
@@ -1,0 +1,43 @@
+// M6 scheduler litmus tests (characterization regressions for the
+// scheduler audit — docs/conformance/scheduler_audit_2026_07.md).
+// Each checks an IEEE 1800-2017 clause-4 required ordering that the
+// current stratified queues deliver; they must stay green through any
+// scheduler restructuring.
+module m6_sched_litmus_test;
+  int errors = 0;
+
+  // (a) NBA update is not visible to blocking reads in the same slot
+  // before the NBA region runs (4.9.3): b reads the OLD value of a.
+  int a = 1, b = 0;
+  initial begin
+    a <= 2;
+    b = a;                  // Active region: must see a==1
+    if (b !== 1) begin $display("FAIL litmus-a b=%0d", b); errors++; end
+    #1;
+    if (a !== 2) begin $display("FAIL litmus-a2 a=%0d", a); errors++; end
+  end
+
+  // (b) #0 defers to the Inactive region: the peer initial block's
+  // active-region assignment is visible after #0 (4.4.2.3).
+  int x = 0;
+  initial begin
+    #0;
+    if (x !== 5) begin $display("FAIL litmus-b x=%0d", x); errors++; end
+  end
+  initial x = 5;
+
+  // (c) $strobe runs in the Postponed region and sees the NBA result;
+  // an immediate check in the Active region sees the old value (4.4.2.9).
+  int c = 10;
+  initial begin
+    c <= 20;
+    if (c !== 10) begin $display("FAIL litmus-c1 c=%0d", c); errors++; end
+    $strobe("strobe c=%0d (expect 20)", c);
+  end
+
+  initial begin
+    #2;
+    if (errors == 0) $display("PASS");
+    $finish;
+  end
+endmodule

--- a/tgt-vvp/eval_vec4.c
+++ b/tgt-vvp/eval_vec4.c
@@ -1481,6 +1481,14 @@ static void draw_sfunc_vec4(ivl_expr_t expr)
 	    draw_darray_pop(expr);
 	    return;
       }
+      if (strcmp(ivl_expr_name(expr),"$ivl_event_method$triggered")==0) {
+	      /* IEEE 1800-2017 15.5.3: read the named event's
+	         triggered-this-time-step state. */
+	    ivl_expr_t earg = ivl_expr_parm(expr, 0);
+	    assert(earg && ivl_expr_type(earg) == IVL_EX_EVENT);
+	    fprintf(vvp_out, "    %%evtest E_%p;\n", ivl_expr_event(earg));
+	    return;
+      }
       if (strcmp(ivl_expr_name(expr),"$ivl_class_method$randomize")==0) {
 	    ivl_expr_t arg = (parm_count > 0) ? ivl_expr_parm(expr, 0) : 0;
 	    /* Phase 50e: invoke pre_randomize / post_randomize hooks on

--- a/vvp/class_type.cc
+++ b/vvp/class_type.cc
@@ -865,6 +865,21 @@ bool class_type::property_is_randc(size_t idx) const
       return properties_[idx].randc_flag;
 }
 
+const std::string& class_type::property_base_type(size_t idx) const
+{
+      static const std::string nil;
+      if (idx >= properties_.size())
+	    return nil;
+      return properties_[idx].base_type;
+}
+
+uint64_t class_type::property_array_size(size_t idx) const
+{
+      if (idx >= properties_.size())
+	    return 1;
+      return properties_[idx].array_size;
+}
+
 void class_type::add_constraint(const string&name, const string&ir)
 {
       constraint_t c;
@@ -941,6 +956,9 @@ void class_type::set_property(size_t idx, const string&name, const string&type, 
 	    base_type = type.substr(1);
       }
       const string&type_to_use = base_type;
+
+      properties_[idx].base_type = base_type;
+      properties_[idx].array_size = array_size ? array_size : 1;
 
       const string&t = type_to_use;
       if (t == "b8")

--- a/vvp/class_type.h
+++ b/vvp/class_type.h
@@ -63,6 +63,13 @@ class class_type : public __vpiHandle {
       bool property_is_rand(size_t idx) const;
       bool property_is_randc(size_t idx) const;
 
+	// Base type text (rand prefix stripped, e.g. "sb32", "o") and
+	// static array element count (1 for scalars) as recorded from
+	// the .class directive. Used by randomize to fill and write
+	// back array-typed rand properties.
+      const std::string& property_base_type(size_t idx) const;
+      uint64_t property_array_size(size_t idx) const;
+
       void add_constraint(const std::string&name, const std::string&ir);
       size_t constraint_count() const { return constraints_.size(); }
       const std::string& constraint_name(size_t idx) const;
@@ -104,6 +111,8 @@ class class_type : public __vpiHandle {
 	    class_property_t*type;
 	    bool rand_flag  = false;
 	    bool randc_flag = false;
+	    std::string base_type;
+	    uint64_t array_size = 1;
       };
       std::vector<prop_t> properties_;
       size_t instance_size_;

--- a/vvp/codes.h
+++ b/vvp/codes.h
@@ -200,6 +200,7 @@ extern bool of_DUP_STR(vthread_t thr, vvp_code_t code);
 extern bool of_DUP_VEC4(vthread_t thr, vvp_code_t code);
 extern bool of_END(vthread_t thr, vvp_code_t code);
 extern bool of_EVENT(vthread_t thr, vvp_code_t code);
+extern bool of_EVTEST(vthread_t thr, vvp_code_t code);
 extern bool of_EVENT_NB(vthread_t thr, vvp_code_t code);
 extern bool of_EVCTL(vthread_t thr, vvp_code_t code);
 extern bool of_EVCTLC(vthread_t thr, vvp_code_t code);

--- a/vvp/compile.cc
+++ b/vvp/compile.cc
@@ -269,6 +269,7 @@ static const struct opcode_table_s opcode_table[] = {
       { "%evctl/s",of_EVCTLS, 2,  {OA_FUNC_PTR, OA_BIT1,     OA_NONE} },
       { "%event",    of_EVENT,    1, {OA_FUNC_PTR, OA_NONE, OA_NONE} },
       { "%event/nb", of_EVENT_NB, 2, {OA_FUNC_PTR, OA_BIT1, OA_NONE} },
+      { "%evtest",   of_EVTEST,   1, {OA_FUNC_PTR, OA_NONE, OA_NONE} },
       { "%flag_get/vec4", of_FLAG_GET_VEC4, 1, {OA_NUMBER, OA_NONE, OA_NONE} },
       { "%flag_inv",      of_FLAG_INV,      1, {OA_BIT1,   OA_NONE, OA_NONE} },
       { "%flag_mov",      of_FLAG_MOV,      2, {OA_BIT1,   OA_BIT2, OA_NONE} },

--- a/vvp/event.cc
+++ b/vvp/event.cc
@@ -1041,9 +1041,21 @@ vthread_t vvp_named_event_sa::add_waiting_thread(vthread_t thread)
       return tmp;
 }
 
+void vvp_named_event::note_triggered(void)
+{
+      last_trigger_time_ = schedule_simtime();
+      ever_triggered_ = true;
+}
+
+bool vvp_named_event::triggered_now(void) const
+{
+      return ever_triggered_ && last_trigger_time_ == schedule_simtime();
+}
+
 void vvp_named_event_sa::recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bit,
                                    vvp_context_t)
 {
+      note_triggered();
       run_waiting_threads_(threads_);
       vvp_net_t*net = port.ptr();
       net->send_vec4(bit, 0);
@@ -1107,6 +1119,7 @@ void vvp_named_event_aa::recv_vec4(vvp_net_ptr_t port, const vvp_vector4_t&bit,
       waitable_state_s*state = static_cast<waitable_state_s*>
             (vvp_get_context_item(context, context_idx_));
 
+      note_triggered();
       run_waiting_threads_(state->threads);
       vvp_net_t*net = port.ptr();
       net->send_vec4(bit, context);

--- a/vvp/event.h
+++ b/vvp/event.h
@@ -378,8 +378,17 @@ class vvp_named_event : public vvp_net_fun_t, public waitable_hooks_s {
       explicit vvp_named_event(class __vpiHandle*eh);
       ~vvp_named_event() override;
 
+	// IEEE 1800-2017 15.5.3 triggered property: record each trigger
+	// and report whether the event fired in the current time step.
+      void note_triggered(void);
+      bool triggered_now(void) const;
+
     protected:
       class __vpiHandle*handle_;
+
+    private:
+      vvp_time64_t last_trigger_time_ = 0;
+      bool ever_triggered_ = false;
 };
 
 /*

--- a/vvp/vthread.cc
+++ b/vvp/vthread.cc
@@ -2082,6 +2082,25 @@ bool of_RANDOMIZE(vthread_t thr, vvp_code_t)
 		    // foreach is currently dropped at parse, so this is the
 		    // only mechanism that puts non-zero values in the assoc;
 		    // downstream code that checks `freq > 0` works.
+		    // Static-array rand properties (e.g. `rand int arr[4]`):
+		    // fill every element with random bits. Without this only
+		    // word 0 is touched and elements stay at 0.
+		  if (defn->property_array_size(pid) > 1) {
+			uint64_t asize = defn->property_array_size(pid);
+			for (uint64_t adr = 0 ; adr < asize ; adr += 1) {
+			      vvp_vector4_t val;
+			      cobj->get_vec4(pid, val, adr);
+			      unsigned wid = val.size();
+			      if (wid == 0)
+				    break;
+			      vvp_vector4_t nv(wid, BIT4_0);
+			      for (unsigned b = 0 ; b < wid ; b += 1)
+				    nv.set_bit(b, (rand() & 1) ? BIT4_1 : BIT4_0);
+			      cobj->set_vec4(pid, nv, adr);
+			}
+			continue;
+		  }
+
 		  {
 			vvp_object_t propobj;
 			cobj->get_object(pid, propobj, 0);
@@ -2205,6 +2224,23 @@ bool of_RANDOMIZE_WITH(vthread_t thr, vvp_code_t code)
 	    for (size_t pid = 0 ; pid < defn->property_count() ; pid += 1) {
 		  if (!defn->property_is_rand(pid)) continue;
 		  if (!cobj->rand_mode(pid)) continue;
+		    // Static-array rand properties: fill each element
+		    // (mirrors of_RANDOMIZE).
+		  if (defn->property_array_size(pid) > 1) {
+			uint64_t asize = defn->property_array_size(pid);
+			for (uint64_t adr = 0 ; adr < asize ; adr += 1) {
+			      vvp_vector4_t cur;
+			      cobj->get_vec4(pid, cur, adr);
+			      unsigned awid = cur.size();
+			      if (awid == 0)
+				    break;
+			      vvp_vector4_t nv(awid, BIT4_0);
+			      for (unsigned b = 0 ; b < awid ; b += 1)
+				    nv.set_bit(b, (rand() & 1) ? BIT4_1 : BIT4_0);
+			      cobj->set_vec4(pid, nv, adr);
+			}
+			continue;
+		  }
 		  vvp_vector4_t val;
 		  cobj->get_vec4(pid, val);
 		  unsigned wid = val.size();

--- a/vvp/vthread.cc
+++ b/vvp/vthread.cc
@@ -8122,6 +8122,21 @@ bool of_END(vthread_t thr, vvp_code_t)
 /*
  * %event <var-label>
  */
+/*
+ * %evtest <event-label>
+ * Push a 1-bit vec4: 1 if the named event has been triggered in the
+ * current time step (IEEE 1800-2017 15.5.3 triggered property), else 0.
+ */
+bool of_EVTEST(vthread_t thr, vvp_code_t cp)
+{
+      vvp_net_t*net = cp->net;
+      vvp_named_event*fun = net ? dynamic_cast<vvp_named_event*>(net->fun) : 0;
+      bool trig = fun && fun->triggered_now();
+      vvp_vector4_t val(1, trig ? BIT4_1 : BIT4_0);
+      thr->push_vec4(val);
+      return true;
+}
+
 bool of_EVENT(vthread_t thr, vvp_code_t cp)
 {
       vvp_net_ptr_t ptr (cp->net, 0);

--- a/vvp/vvp_z3.cc
+++ b/vvp/vvp_z3.cc
@@ -25,6 +25,7 @@
 # include  <cstdlib>
 # include  <cstring>
 # include  <sstream>
+# include  <set>
 # include  <string>
 # include  <vector>
 # include  <stdint.h>
@@ -148,6 +149,13 @@ struct Z3Builder {
 	    return var;
       }
 
+	// Variables whose SystemVerilog type is signed. Comparisons where
+	// a signed variable participates use the signed BV predicates
+	// (IEEE 1800-2017 11.8.1; integer literals are signed).
+      std::set<Z3_ast> signed_vars;
+      bool is_signed(Z3_ast a) const
+	    { return signed_vars.find(a) != signed_vars.end(); }
+
       Z3Builder(Z3_context c, const class_type* d, vvp_cobject* o)
       : ctx(c), defn(d), cobj(o), opt(0) {}
 
@@ -172,15 +180,19 @@ struct Z3Builder {
 // Forward declaration
 static Z3_ast build_z3_expr(IRParser&, Z3Builder&);
 
-// Parse "p:N:W" — returns Z3 bitvector variable
+// Parse "p:N:W[:s]" — returns Z3 bitvector variable
 static Z3_ast parse_prop(IRParser&, Z3Builder& b, const string& tok)
 {
       const char* s = tok.c_str() + 2; // skip "p:"
       unsigned idx = (unsigned)atoi(s);
       while (*s && *s != ':') ++s;
       unsigned width = 32;
-      if (*s == ':') width = (unsigned)atoi(s + 1);
-      return b.get_prop_var(idx, width);
+      if (*s == ':') { width = (unsigned)atoi(s + 1); ++s; }
+      while (*s && *s != ':') ++s;
+      bool sflag = (*s == ':' && s[1] == 's');
+      Z3_ast var = b.get_prop_var(idx, width);
+      if (sflag) b.signed_vars.insert(var);
+      return var;
 }
 
 // Get width from a Z3 bitvector AST
@@ -235,7 +247,7 @@ static Z3_ast build_z3_atom(IRParser& par, Z3Builder& b)
 	    return b.get_size_var(idx, dtype);
       }
       if (tok.substr(0,2) == "e:") {
-	      // e:N:W:I — element I of array property N, width W.
+	      // e:N:W:I[:s] — element I of array property N, width W.
 	    const char*s = tok.c_str() + 2;
 	    unsigned idx = (unsigned)atoi(s);
 	    while (*s && *s != ':') ++s;
@@ -243,8 +255,12 @@ static Z3_ast build_z3_atom(IRParser& par, Z3Builder& b)
 	    if (*s == ':') { width = (unsigned)atoi(s + 1); ++s; }
 	    while (*s && *s != ':') ++s;
 	    unsigned elem = 0;
-	    if (*s == ':') elem = (unsigned)atoi(s + 1);
-	    return b.get_elem_var(idx, width, elem);
+	    if (*s == ':') { elem = (unsigned)atoi(s + 1); ++s; }
+	    while (*s && *s != ':') ++s;
+	    bool sflag = (*s == ':' && s[1] == 's');
+	    Z3_ast var = b.get_elem_var(idx, width, elem);
+	    if (sflag) b.signed_vars.insert(var);
+	    return var;
       }
       return b.mk_true();
 }
@@ -325,24 +341,34 @@ static Z3_ast build_z3_expr(IRParser& par, Z3Builder& b)
 	    Z3_ast right = build_z3_atom(par, b);
 	    par.skip_ws(); par.expect(')');
 
+	      // A signed variable on either side selects signed compare
+	      // semantics (IEEE 1800-2017 11.8.1; bare integer literals
+	      // are themselves signed).
+	    bool use_signed = b.is_signed(left) || b.is_signed(right);
+
 	    // Make sure both sides have the same BV width
 	    unsigned lw = bv_width(b.ctx, left);
 	    unsigned rw = bv_width(b.ctx, right);
 	    if (lw != rw) {
-		  // Resize the constant (right) to match left
-		  // This handles cases like c:8 with a p:N:32 var
 		  if (rw < lw) {
-			// zero-extend right
-			right = Z3_mk_zero_ext(b.ctx, lw - rw, right);
+			right = use_signed
+			      ? Z3_mk_sign_ext(b.ctx, lw - rw, right)
+			      : Z3_mk_zero_ext(b.ctx, lw - rw, right);
 		  } else {
-			left = Z3_mk_zero_ext(b.ctx, rw - lw, left);
+			left = use_signed
+			      ? Z3_mk_sign_ext(b.ctx, rw - lw, left)
+			      : Z3_mk_zero_ext(b.ctx, rw - lw, left);
 		  }
 	    }
 
-	    if (op == "lt") return Z3_mk_bvult(b.ctx, left, right);
-	    if (op == "le") return Z3_mk_bvule(b.ctx, left, right);
-	    if (op == "gt") return Z3_mk_bvugt(b.ctx, left, right);
-	    if (op == "ge") return Z3_mk_bvuge(b.ctx, left, right);
+	    if (op == "lt") return use_signed ? Z3_mk_bvslt(b.ctx, left, right)
+					      : Z3_mk_bvult(b.ctx, left, right);
+	    if (op == "le") return use_signed ? Z3_mk_bvsle(b.ctx, left, right)
+					      : Z3_mk_bvule(b.ctx, left, right);
+	    if (op == "gt") return use_signed ? Z3_mk_bvsgt(b.ctx, left, right)
+					      : Z3_mk_bvugt(b.ctx, left, right);
+	    if (op == "ge") return use_signed ? Z3_mk_bvsge(b.ctx, left, right)
+					      : Z3_mk_bvuge(b.ctx, left, right);
 	    if (op == "eq") return Z3_mk_eq(b.ctx, left, right);
 	    // ne
 	    return Z3_mk_not(b.ctx, Z3_mk_eq(b.ctx, left, right));
@@ -353,13 +379,26 @@ static Z3_ast build_z3_expr(IRParser& par, Z3Builder& b)
 	    // atoms: c:V literals or parenthesized expressions.
 	    Z3_ast subject = build_z3_atom(par, b);
 	    unsigned sw = bv_width(b.ctx, subject);
+	      // A signed subject selects signed range semantics
+	      // (IEEE 1800-2017 11.4.13, 11.8.1).
+	    bool subj_signed = b.is_signed(subject);
 
 	    // Match an atom's width to the subject for the comparisons.
 	    auto match_width = [&](Z3_ast a) -> Z3_ast {
 		  unsigned aw = bv_width(b.ctx, a);
-		  if (aw < sw) return Z3_mk_zero_ext(b.ctx, sw - aw, a);
+		  if (aw < sw) return subj_signed
+			? Z3_mk_sign_ext(b.ctx, sw - aw, a)
+			: Z3_mk_zero_ext(b.ctx, sw - aw, a);
 		  if (aw > sw) return Z3_mk_extract(b.ctx, sw - 1, 0, a);
 		  return a;
+	    };
+	    auto range_ge = [&](Z3_ast x, Z3_ast lo) -> Z3_ast {
+		  return subj_signed ? Z3_mk_bvsge(b.ctx, x, lo)
+				     : Z3_mk_bvuge(b.ctx, x, lo);
+	    };
+	    auto range_le = [&](Z3_ast x, Z3_ast hi) -> Z3_ast {
+		  return subj_signed ? Z3_mk_bvsle(b.ctx, x, hi)
+				     : Z3_mk_bvule(b.ctx, x, hi);
 	    };
 
 	    vector<Z3_ast> clauses;
@@ -372,8 +411,8 @@ static Z3_ast build_z3_expr(IRParser& par, Z3Builder& b)
 			Z3_ast hi = match_width(build_z3_atom(par, b));
 			par.expect(']');
 			// subject >= lo && subject <= hi
-			Z3_ast c1 = Z3_mk_bvuge(b.ctx, subject, lo);
-			Z3_ast c2 = Z3_mk_bvule(b.ctx, subject, hi);
+			Z3_ast c1 = range_ge(subject, lo);
+			Z3_ast c2 = range_le(subject, hi);
 			Z3_ast both[2] = {c1, c2};
 			clauses.push_back(Z3_mk_and(b.ctx, 2, both));
 		  } else if (par.peek() == '(') {

--- a/vvp/vvp_z3.cc
+++ b/vvp/vvp_z3.cc
@@ -17,6 +17,7 @@
 
 # include  "class_type.h"
 # include  "vvp_cobject.h"
+# include  "vvp_darray.h"
 # include  "vvp_z3.h"
 
 # include  <z3.h>
@@ -100,6 +101,53 @@ struct Z3Builder {
             return false;
       }
 
+	// Dynamic-array size variables ("s:N:T"): one 32-bit BV per
+	// property index. T is the %new/darray type text used to create
+	// the array at write-back (IEEE 1800-2017 18.4: the size of a
+	// rand dynamic array is itself randomized subject to constraints).
+      struct SizeVar {
+	    unsigned idx;
+	    string darray_type;
+	    Z3_ast var;
+      };
+      vector<SizeVar> size_vars;
+
+	// Array element variables ("e:N:W:I"): property index, element
+	// width, constant element index (IEEE 1800-2017 18.5.8.1
+	// iterative constraints over static arrays).
+      struct ElemVar {
+	    unsigned idx;
+	    unsigned width;
+	    unsigned elem;
+	    Z3_ast var;
+      };
+      vector<ElemVar> elem_vars;
+
+      Z3_ast get_size_var(unsigned idx, const string&dtype) {
+	    for (auto& v : size_vars)
+		  if (v.idx == idx) return v.var;
+	    char name[32];
+	    snprintf(name, sizeof(name), "s%u", idx);
+	    Z3_sort sort = Z3_mk_bv_sort(ctx, 32);
+	    Z3_ast var = Z3_mk_const(ctx, Z3_mk_string_symbol(ctx, name), sort);
+	    SizeVar sv; sv.idx = idx; sv.darray_type = dtype; sv.var = var;
+	    size_vars.push_back(sv);
+	    return var;
+      }
+
+      Z3_ast get_elem_var(unsigned idx, unsigned width, unsigned elem) {
+	    for (auto& v : elem_vars)
+		  if (v.idx == idx && v.elem == elem) return v.var;
+	    char name[48];
+	    snprintf(name, sizeof(name), "e%u_%u", idx, elem);
+	    Z3_sort sort = Z3_mk_bv_sort(ctx, width ? width : 32);
+	    Z3_ast var = Z3_mk_const(ctx, Z3_mk_string_symbol(ctx, name), sort);
+	    ElemVar ev; ev.idx = idx; ev.width = width ? width : 32;
+	    ev.elem = elem; ev.var = var;
+	    elem_vars.push_back(ev);
+	    return var;
+      }
+
       Z3Builder(Z3_context c, const class_type* d, vvp_cobject* o)
       : ctx(c), defn(d), cobj(o), opt(0) {}
 
@@ -177,6 +225,26 @@ static Z3_ast build_z3_atom(IRParser& par, Z3Builder& b)
 	    uint64_t v = (uint64_t)strtoull(tok.c_str()+2, nullptr, 10);
 	    Z3_sort sort = Z3_mk_bv_sort(b.ctx, 32);
 	    return Z3_mk_unsigned_int64(b.ctx, v, sort);
+      }
+      if (tok.substr(0,2) == "s:") {
+	      // s:N:T — size of dynamic-array property N, darray type T.
+	    const char*s = tok.c_str() + 2;
+	    unsigned idx = (unsigned)atoi(s);
+	    while (*s && *s != ':') ++s;
+	    string dtype = (*s == ':') ? string(s + 1) : string("v32");
+	    return b.get_size_var(idx, dtype);
+      }
+      if (tok.substr(0,2) == "e:") {
+	      // e:N:W:I — element I of array property N, width W.
+	    const char*s = tok.c_str() + 2;
+	    unsigned idx = (unsigned)atoi(s);
+	    while (*s && *s != ':') ++s;
+	    unsigned width = 32;
+	    if (*s == ':') { width = (unsigned)atoi(s + 1); ++s; }
+	    while (*s && *s != ':') ++s;
+	    unsigned elem = 0;
+	    if (*s == ':') elem = (unsigned)atoi(s + 1);
+	    return b.get_elem_var(idx, width, elem);
       }
       return b.mk_true();
 }
@@ -281,38 +349,49 @@ static Z3_ast build_z3_expr(IRParser& par, Z3Builder& b)
       }
 
       if (op == "inside") {
-	    // Format: (inside p:N:W [c:lo,c:hi] c:val ...)
+	    // Format: (inside p:N:W [lo,hi] val ...) where lo/hi/val are
+	    // atoms: c:V literals or parenthesized expressions.
 	    Z3_ast subject = build_z3_atom(par, b);
 	    unsigned sw = bv_width(b.ctx, subject);
+
+	    // Match an atom's width to the subject for the comparisons.
+	    auto match_width = [&](Z3_ast a) -> Z3_ast {
+		  unsigned aw = bv_width(b.ctx, a);
+		  if (aw < sw) return Z3_mk_zero_ext(b.ctx, sw - aw, a);
+		  if (aw > sw) return Z3_mk_extract(b.ctx, sw - 1, 0, a);
+		  return a;
+	    };
 
 	    vector<Z3_ast> clauses;
 	    par.skip_ws();
 	    while (par.peek() != ')' && !par.at_end()) {
 		  if (par.peek() == '[') {
 			par.consume(); // '['
-			string lo_tok = par.read_token();
+			Z3_ast lo = match_width(build_z3_atom(par, b));
 			par.expect(',');
-			string hi_tok = par.read_token();
+			Z3_ast hi = match_width(build_z3_atom(par, b));
 			par.expect(']');
-			uint64_t lo_v = strtoull(lo_tok.c_str()+2, nullptr, 10);
-			uint64_t hi_v = strtoull(hi_tok.c_str()+2, nullptr, 10);
-			Z3_ast lo = Z3_mk_unsigned_int64(b.ctx, lo_v,
-						 Z3_mk_bv_sort(b.ctx, sw));
-			Z3_ast hi = Z3_mk_unsigned_int64(b.ctx, hi_v,
-						 Z3_mk_bv_sort(b.ctx, sw));
 			// subject >= lo && subject <= hi
 			Z3_ast c1 = Z3_mk_bvuge(b.ctx, subject, lo);
 			Z3_ast c2 = Z3_mk_bvule(b.ctx, subject, hi);
 			Z3_ast both[2] = {c1, c2};
 			clauses.push_back(Z3_mk_and(b.ctx, 2, both));
+		  } else if (par.peek() == '(') {
+			Z3_ast v = match_width(build_z3_atom(par, b));
+			clauses.push_back(Z3_mk_eq(b.ctx, subject, v));
 		  } else {
-			// Single value
+			// Single value token
 			string tok = par.read_token();
 			if (tok.substr(0,2) == "c:") {
 			      uint64_t v = strtoull(tok.c_str()+2, nullptr, 10);
 			      Z3_ast cv = Z3_mk_unsigned_int64(b.ctx, v,
 						      Z3_mk_bv_sort(b.ctx, sw));
 			      clauses.push_back(Z3_mk_eq(b.ctx, subject, cv));
+			} else if (tok.empty()) {
+			      // Unrecognized input: consume one char so the
+			      // scan always makes forward progress (a stuck
+			      // parser here previously hung the simulation).
+			      if (!par.at_end()) par.consume();
 			}
 		  }
 		  par.skip_ws();
@@ -471,6 +550,87 @@ static void cobj_set_prop_bits(vvp_cobject* cobj, unsigned idx, uint64_t bits)
       cobj->set_vec4(idx, vec);
 }
 
+/* Create a fresh vvp_darray for the given %new/darray-style type text
+ * (subset used by rand dynamic-array properties). */
+static vvp_darray* make_darray_for_type(const string&text, size_t size)
+{
+      unsigned word_wid = 0;
+      size_t n = 0;
+      if (text == "b8")   return new vvp_darray_atom<uint8_t>(size);
+      if (text == "b16")  return new vvp_darray_atom<uint16_t>(size);
+      if (text == "b32")  return new vvp_darray_atom<uint32_t>(size);
+      if (text == "b64")  return new vvp_darray_atom<uint64_t>(size);
+      if (text == "sb8")  return new vvp_darray_atom<int8_t>(size);
+      if (text == "sb16") return new vvp_darray_atom<int16_t>(size);
+      if (text == "sb32") return new vvp_darray_atom<int32_t>(size);
+      if (text == "sb64") return new vvp_darray_atom<int64_t>(size);
+      if ((1 == sscanf(text.c_str(), "v%u%zn", &word_wid, &n))
+	  && n == text.size())
+	    return new vvp_darray_vec4(size, word_wid);
+      if ((1 == sscanf(text.c_str(), "sv%u%zn", &word_wid, &n))
+	  && n == text.size())
+	    return new vvp_darray_vec4(size, word_wid);
+      return new vvp_darray_vec4(size, 32);
+}
+
+/* Read the current bits of an array-property element (darray object or
+ * static array), for the satisfied-already pre-check and xor targets. */
+static uint64_t cobj_elem_bits(vvp_cobject* cobj, unsigned idx, unsigned elem)
+{
+      vvp_object_t propobj;
+      cobj->get_object(idx, propobj, 0);
+      if (vvp_darray*da = propobj.peek<vvp_darray>()) {
+	    if (elem >= da->get_size()) return 0;
+	    vvp_vector4_t vec;
+	    da->get_word(elem, vec);
+	    uint64_t bits = 0;
+	    unsigned wid = vec.size(); if (wid > 64) wid = 64;
+	    for (unsigned b = 0; b < wid; ++b)
+		  if (vec.value(b) == BIT4_1) bits |= (1ULL << b);
+	    return bits;
+      }
+      vvp_vector4_t vec;
+      cobj->get_vec4(idx, vec, elem);
+      uint64_t bits = 0;
+      unsigned wid = vec.size(); if (wid > 64) wid = 64;
+      for (unsigned b = 0; b < wid; ++b)
+	    if (vec.value(b) == BIT4_1) bits |= (1ULL << b);
+      return bits;
+}
+
+/* Write bits into an array-property element. */
+static void cobj_set_elem_bits(vvp_cobject* cobj, unsigned idx, unsigned elem,
+			       unsigned width, uint64_t bits)
+{
+      vvp_object_t propobj;
+      cobj->get_object(idx, propobj, 0);
+      if (vvp_darray*da = propobj.peek<vvp_darray>()) {
+	    if (elem >= da->get_size()) return;
+	    vvp_vector4_t vec(width ? width : 32, BIT4_0);
+	    for (unsigned b = 0; b < vec.size() && b < 64; ++b)
+		  vec.set_bit(b, ((bits >> b) & 1) ? BIT4_1 : BIT4_0);
+	    da->set_word(elem, vec);
+	    return;
+      }
+      vvp_vector4_t vec;
+      cobj->get_vec4(idx, vec, elem);
+      unsigned wid = vec.size();
+      if (wid == 0) return;
+      for (unsigned b = 0; b < wid; ++b)
+	    vec.set_bit(b, (b < 64 && ((bits >> b) & 1)) ? BIT4_1 : BIT4_0);
+      cobj->set_vec4(idx, vec, elem);
+}
+
+/* Current size of a dynamic-array property (0 when unallocated). */
+static uint64_t cobj_darray_size(vvp_cobject* cobj, unsigned idx)
+{
+      vvp_object_t propobj;
+      cobj->get_object(idx, propobj, 0);
+      if (vvp_darray*da = propobj.peek<vvp_darray>())
+	    return da->get_size();
+      return 0;
+}
+
 /* Substitute "v:N:W" value-slot tokens in an IR string with "c:V". */
 static string substitute_slots(const string& ir,
                                 const vector<uint64_t>& slot_vals)
@@ -531,6 +691,16 @@ bool vvp_z3_randomize(const class_type* defn, vvp_cobject* cobj,
 	    Z3_ast assertion = parse_constraint_ir(sub, builder);
 	    Z3_optimize_assert(ctx, opt, assertion);
       }
+      // Dynamic-array size variables are bounded by a pragmatic hard cap
+      // so an under-constrained `arr.size() > k` cannot demand a huge
+      // allocation. (IEEE places no bound; this is an implementation
+      // limit, matching typical simulator behavior.)
+      for (auto& sv : builder.size_vars) {
+	    Z3_sort s32 = Z3_mk_bv_sort(ctx, 32);
+	    Z3_ast cap = Z3_mk_unsigned_int64(ctx, 65536, s32);
+	    Z3_optimize_assert(ctx, opt, Z3_mk_bvule(ctx, sv.var, cap));
+      }
+
       // C7: apply queued soft asserts from dist branches.  Each carries a
       // weight; Z3_optimize_assert_soft prefers higher-weight branches when
       // multiple feasible solutions exist.
@@ -566,6 +736,18 @@ bool vvp_z3_randomize(const class_type* defn, vvp_cobject* cobj,
 		  Z3_ast cv = Z3_mk_unsigned_int64(ctx, bits, sort);
 		  Z3_solver_assert(ctx, chk, Z3_mk_eq(ctx, pv.var, cv));
 	    }
+	    for (auto& sv : builder.size_vars) {
+		  uint64_t cur = cobj_darray_size(cobj, sv.idx);
+		  Z3_sort sort = Z3_mk_bv_sort(ctx, 32);
+		  Z3_ast cv = Z3_mk_unsigned_int64(ctx, cur, sort);
+		  Z3_solver_assert(ctx, chk, Z3_mk_eq(ctx, sv.var, cv));
+	    }
+	    for (auto& ev : builder.elem_vars) {
+		  uint64_t bits = cobj_elem_bits(cobj, ev.idx, ev.elem);
+		  Z3_sort sort = Z3_mk_bv_sort(ctx, ev.width);
+		  Z3_ast cv = Z3_mk_unsigned_int64(ctx, bits, sort);
+		  Z3_solver_assert(ctx, chk, Z3_mk_eq(ctx, ev.var, cv));
+	    }
 	    Z3_lbool precheck = Z3_solver_check(ctx, chk);
 	    Z3_solver_dec_ref(ctx, chk);
 
@@ -595,6 +777,20 @@ bool vvp_z3_randomize(const class_type* defn, vvp_cobject* cobj,
 	    Z3_ast xor_expr = Z3_mk_bvxor(ctx, pv.var, rv);
 	    Z3_optimize_minimize(ctx, opt, xor_expr);
       }
+      for (auto& sv : builder.size_vars) {
+	      // Prefer small varied sizes when the constraints leave slack.
+	    Z3_sort sort = Z3_mk_bv_sort(ctx, 32);
+	    Z3_ast rv = Z3_mk_unsigned_int64(ctx, (uint64_t)(rand() & 0xF), sort);
+	    Z3_optimize_minimize(ctx, opt, Z3_mk_bvxor(ctx, sv.var, rv));
+      }
+      for (auto& ev : builder.elem_vars) {
+	    uint64_t rand_bits = 0;
+	    for (unsigned b = 0; b < ev.width && b < 64; ++b)
+		  if (rand() & 1) rand_bits |= (1ULL << b);
+	    Z3_sort sort = Z3_mk_bv_sort(ctx, ev.width);
+	    Z3_ast rv = Z3_mk_unsigned_int64(ctx, rand_bits, sort);
+	    Z3_optimize_minimize(ctx, opt, Z3_mk_bvxor(ctx, ev.var, rv));
+      }
 
       Z3_lbool result = Z3_optimize_check(ctx, opt, 0, nullptr);
       if (result != Z3_L_TRUE) {
@@ -613,6 +809,43 @@ bool vvp_z3_randomize(const class_type* defn, vvp_cobject* cobj,
 		  if (Z3_get_numeral_uint64(ctx, interp, &bits))
 			cobj_set_prop_bits(cobj, pv.idx, bits);
 	    }
+      }
+
+	// Apply solved dynamic-array sizes: create (or replace) the
+	// property's darray with the solved element count and fill the
+	// elements with random bits. Element constraints, when present,
+	// overwrite specific entries below.
+      for (auto& sv : builder.size_vars) {
+	    Z3_ast interp = nullptr;
+	    uint64_t new_size = 0;
+	    if (!(Z3_model_eval(ctx, model, sv.var, 1, &interp) && interp
+		  && Z3_get_numeral_uint64(ctx, interp, &new_size)))
+		  continue;
+	    if (new_size > 65536) new_size = 65536;
+
+	    vvp_darray*da = make_darray_for_type(sv.darray_type,
+						 (size_t)new_size);
+	    for (uint64_t adr = 0 ; adr < new_size ; adr += 1) {
+		  vvp_vector4_t word;
+		  da->get_word((unsigned)adr, word);
+		  unsigned wid = word.size();
+		  if (wid == 0) wid = 32;
+		  vvp_vector4_t nv(wid, BIT4_0);
+		  for (unsigned b = 0 ; b < wid ; b += 1)
+			nv.set_bit(b, (rand() & 1) ? BIT4_1 : BIT4_0);
+		  da->set_word((unsigned)adr, nv);
+	    }
+	    vvp_object_t obj(da);
+	    cobj->set_object(sv.idx, obj, 0);
+      }
+
+	// Apply solved array-element values.
+      for (auto& ev : builder.elem_vars) {
+	    Z3_ast interp = nullptr;
+	    uint64_t bits = 0;
+	    if (Z3_model_eval(ctx, model, ev.var, 1, &interp) && interp
+		&& Z3_get_numeral_uint64(ctx, interp, &bits))
+		  cobj_set_elem_bits(cobj, ev.idx, ev.elem, ev.width, bits);
       }
 
       Z3_model_dec_ref(ctx, model);

--- a/vvp/vvp_z3.cc
+++ b/vvp/vvp_z3.cc
@@ -200,6 +200,41 @@ static Z3_ast build_z3_expr(IRParser& par, Z3Builder& b)
 	    }
       }
 
+      /* Constraint implication A -> B (IEEE 1800-2017 18.5.6) and
+       * equivalence A <-> B. Both operands take their boolean views. */
+      if (op == "impl" || op == "iff") {
+	    Z3_ast left  = bv_to_bool(b.ctx, build_z3_atom(par, b));
+	    Z3_ast right = bv_to_bool(b.ctx, build_z3_atom(par, b));
+	    par.skip_ws(); par.expect(')');
+	    if (op == "impl")
+		  return Z3_mk_implies(b.ctx, left, right);
+	    return Z3_mk_iff(b.ctx, left, right);
+      }
+
+      /* Bitvector arithmetic. Widths are harmonized by zero-extension
+       * (same policy as the comparisons below). */
+      if (op == "add" || op == "sub" || op == "mul"
+	  || op == "div" || op == "mod") {
+	    Z3_ast left  = build_z3_atom(par, b);
+	    Z3_ast right = build_z3_atom(par, b);
+	    par.skip_ws(); par.expect(')');
+
+	    unsigned lw = bv_width(b.ctx, left);
+	    unsigned rw = bv_width(b.ctx, right);
+	    if (lw != rw) {
+		  if (rw < lw)
+			right = Z3_mk_zero_ext(b.ctx, lw - rw, right);
+		  else
+			left = Z3_mk_zero_ext(b.ctx, rw - lw, left);
+	    }
+
+	    if (op == "add") return Z3_mk_bvadd(b.ctx, left, right);
+	    if (op == "sub") return Z3_mk_bvsub(b.ctx, left, right);
+	    if (op == "mul") return Z3_mk_bvmul(b.ctx, left, right);
+	    if (op == "div") return Z3_mk_bvudiv(b.ctx, left, right);
+	    return Z3_mk_bvurem(b.ctx, left, right);
+      }
+
       if (op == "not") {
 	    /* SV `!x` returns a 1-bit value (1 if x==0 else 0).  Our IR
 	     * generator uses `(not x)` for this; downstream consumers


### PR DESCRIPTION
## Summary

Implements manifesto milestone **M3 (constraint solver semantics)** across three checkpoints, plus the governing-manifesto v2 adoption. Closes gap-audit entries **G15, G17, G18, G20, G21**, **G16 (static arrays)**, the implication half of **G11**, and adds **signed comparison semantics with negative constraint bounds**. Follows the merged PR #66 (M1 typed-expression dispatch + M2 whole-array assignment).

## Checkpoint 4 — constraint semantics (IEEE 1800-2017 §18.5.2/3/6/7)

1. **Implication dropped (G15/G11)** — no IR case for `->`; `A -> {set}` also lost its consequent in the grammar. Fixed via `PEConstraintIf` + `(impl …)` + `Z3_mk_implies`.
2. **if-else constraint sets dropped (G17)** — now lowered to dual implications.
3. **Enum literals dropped from sets (G18)** — now resolved through the class scope chain to constants.
4. **Constraint inheritance missing (G20)** — lazy base-class IR merge per §18.5.2 (same-name overrides); solver arithmetic (`add/sub/mul/div/mod`) implemented end-to-end.
5. One-shot warning when a constraint item cannot be represented (silent weakening violated manifesto principle 4).

## Checkpoint 5 — array-property constraints (IEEE 1800-2017 §18.4, §18.5.8)

1. **G21** — `arr.size()` lowers to a solver size variable `s:N:T`; the dynamic-array property is created/resized to the solved size (cap 65536) with randomized elements.
2. **G16 (static arrays)** — `foreach` constraint sets parse to `PEConstraintForeach`, unroll at elaboration with loop-variable shadowing; `arr[i]` becomes element variable `e:N:W:I`, solved and written back; `%randomize` now fills static-array rand elements at all.
3. **Hang fixed** — the solver's `inside`/`dist` range parser made no forward progress on unexpected input; now expression-capable with guaranteed progress, plus constant folding of unrolled index arithmetic.

## Checkpoint 6 — signed comparisons and negative bounds (IEEE 1800-2017 §11.8.1)

1. **Unary minus** in constraint expressions had no IR conversion — any item with a negative literal silently vanished. Literals now fold to two's complement; non-literals lower to `(sub 0 x)`.
2. **Signedness** — signed property/element types are marked `p:N:W:s` / `e:N:W:I:s`; comparisons and `inside`/`dist` ranges use the `bvslt` family with sign extension when a signed variable participates, so `y < 0` and `x inside {[-5:5]}` solve correctly.

## Also in this PR

- Governing manifesto updated to v2 (scheduler remediation program, semantic IR remediation program, Risks 1–9) with a recorded alignment review and architectural debt register in `CURRENT_WORK.md`.

## Tests

- `tests/m3_constraint_semantics_test.sv` — implication, if-else sets, enum-literal inside, inherited + arithmetic constraints, solve-before (×20 iterations).
- `tests/m3_constraint_array_test.sv` — dynamic-array size round trip, per-index foreach ranges (×10).
- `tests/m3_constraint_signed_test.sv` — negative inside-range and signed relational bounds (×20).

## Regression evidence

| Suite | Baseline (post-#66) | This branch |
|---|---|---|
| UVM regression (`.github/uvm_test.sh`) | 108/108 | **112/112** |
| ivtest vvp_reg.pl | 2961/3101 pass, 132 fail | **identical**, same failure list |
| ivtest vpi_reg.pl | 85/85 | **85/85** |
| ivtest vvp_reg.py | 284 ran, 12 fail | **identical**, same failure list |

Each WIP marker (`9d64dda`, `6f7e875`, `889d084`) is superseded by a regression-confirmation docs commit; the branch head is regression-clean.

## Known limitations (recorded in the gap audit / CURRENT_WORK)

- foreach over **dynamic** arrays (runtime-sized) not yet expanded; element addressing assumes 0-based one-dimensional ranges.
- `solve…before` ordering approximated by the xor-diversity objective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017kkDsUYVP7DtfaJLMQNgSC