### PR TITLE
M6 Reactive regions + G10 array methods + G68/G69 process.status & inside precedence (IEEE 1800-2017 4.4.2.5/24, 7.12, 9.7, 11.3)

### DIFF
--- a/docs/claude/uvm_ieee1800_gap_audit_2026_05.md
+++ b/docs/claude/uvm_ieee1800_gap_audit_2026_05.md
@@ -120,12 +120,21 @@ Iverilog under test: `Icarus Verilog version 13.0 (devel) (s20251012-102-g9b44d5
   eval_object_sfunc).  Tests `tests/g10_array_methods_test.sv` (29
   checks incl. all 7.12.3 LRM literal examples),
   `tests/negative/g10_reduction_non_integral.sv`.
+- **UPDATE 2026-07-13: class-property receivers FIXED** — the dominant
+  UVM shape (`this.q.sum()`, `cfg.st.q.max()`, nested chains, external
+  and paren-less forms).  Any non-signal object receiver is evaluated
+  once and its handle stored into a hidden container-typed net the
+  loop indexes through (extra trailing sfunc parm; tgt-vvp
+  `draw_array_method_recv_`).  The paren-less property tail path
+  (`return q.sum;`), which previously WARNED AND DROPPED the
+  expression, now routes to the same machinery.  Fixed-size-array
+  class properties get an explicit sorry (not object-valued).
 - Remaining tail (explicit diagnostics, no silent fallbacks): `sort`/
   `rsort`/`reverse`/`shuffle` (7.12.2); `unique`/`unique_index` on
   non-queue arrays; reductions/min/max on associative arrays (sorry) and
   multidimensional arrays (sorry); `min`/`max` on string/real elements
-  (sorry); `item.index` iterator method; class-property receivers reach
-  the older PEIdent property path, not the new machinery.
+  (sorry); `item.index` iterator method; fixed-size-array class
+  properties (sorry).
 - Symptom: `q.sum()` reports `error: Method sum is not a queue method.` Same for product. Probe got `Variable item does not have a field named: index.` for `with (item.index)`. The Phase-63b B-series only added some shapes.
 - Probe: p16_queue_with (VERIFIED-FAILS), p30_array_methods (VERIFIED-FAILS for .min/.max/.sort on non-queue), p87_unique_index (PASS for queue).
 - Location: elab_expr.cc:8857-8911 (sorry: cluster for non-queue array methods); also `with (item.index)` codepath separately broken in elab_expr.cc.

--- a/docs/claude/uvm_ieee1800_gap_audit_2026_05.md
+++ b/docs/claude/uvm_ieee1800_gap_audit_2026_05.md
@@ -129,12 +129,27 @@ Iverilog under test: `Icarus Verilog version 13.0 (devel) (s20251012-102-g9b44d5
   (`return q.sum;`), which previously WARNED AND DROPPED the
   expression, now routes to the same machinery.  Fixed-size-array
   class properties get an explicit sorry (not object-valued).
-- Remaining tail (explicit diagnostics, no silent fallbacks): `sort`/
-  `rsort`/`reverse`/`shuffle` (7.12.2); `unique`/`unique_index` on
-  non-queue arrays; reductions/min/max on associative arrays (sorry) and
-  multidimensional arrays (sorry); `min`/`max` on string/real elements
-  (sorry); `item.index` iterator method; fixed-size-array class
-  properties (sorry).
+- **UPDATE 2026-07-13b: 7.12.2 ordering methods completed** — three
+  defects in the Phase 63b sort/rsort/reverse/shuffle/unique statement
+  paths fixed: (1) instance-property receivers were a SILENT NO-OP
+  (explicit skip in tgt-vvp); now the receiver handle is stored into a
+  hidden container net the opcodes run against (in-place reorder
+  reaches the property because containers are held by handle);
+  (2) with-clause sort keys were always truncated to int32 — string
+  keys (the UVM `sort() with (item.get_full_name())` shape) silently
+  mis-sorted whenever keys shared a 4-byte prefix; keys queues are now
+  typed by the with expression (string / real / signed-32) end to end
+  (elaboration key-net type, codegen key-build, runtime extraction and
+  comparison); (3) the sort_with elaboration still used the shared
+  iterator-net scheme — now fresh per-call nets bound via
+  NetScope::set_signal_alias.  Test
+  `tests/g10_ordering_methods_test.sv` (28 checks).
+- Remaining tail (explicit diagnostics, no silent fallbacks):
+  `unique`/`unique_index` on non-queue arrays; reductions/min/max on
+  associative arrays (sorry) and multidimensional arrays (sorry);
+  `min`/`max` on string/real elements (sorry); `item.index` iterator
+  method; fixed-size-array class properties (sorry); ordering methods
+  on fixed-size arrays.
 - Symptom: `q.sum()` reports `error: Method sum is not a queue method.` Same for product. Probe got `Variable item does not have a field named: index.` for `with (item.index)`. The Phase-63b B-series only added some shapes.
 - Probe: p16_queue_with (VERIFIED-FAILS), p30_array_methods (VERIFIED-FAILS for .min/.max/.sort on non-queue), p87_unique_index (PASS for queue).
 - Location: elab_expr.cc:8857-8911 (sorry: cluster for non-queue array methods); also `with (item.index)` codepath separately broken in elab_expr.cc.

--- a/docs/claude/uvm_ieee1800_gap_audit_2026_05.md
+++ b/docs/claude/uvm_ieee1800_gap_audit_2026_05.md
@@ -100,6 +100,32 @@ Iverilog under test: `Icarus Verilog version 13.0 (devel) (s20251012-102-g9b44d5
 - Blocks: any pattern using nested assoc maps (UVM tracks several).
 
 ### G10 queue `.sum()`, `.product()`, `.min()`, `.max()`, `.unique()`, `.unique_index()`, `.and()`, `.or()`, `.xor()`, `.find()`, `.find_index()` — context-sensitive; some forms emit `not a queue method` errors
+- **STATUS 2026-07-12: FIXED (reductions + min/max + non-queue locators)**.
+  IEEE 1800-2017 7.12.3 reductions (`sum`/`product`/`and`/`or`/`xor`) and
+  7.12.1 `min()`/`max()` now implemented over queues, dynamic arrays and
+  one-dimensional fixed-size unpacked arrays, in all four source forms
+  (call, call+with, paren-less, paren-less+with), including the
+  keyword-named methods via new grammar rules (`.and()`/`.or()`/`.xor()`
+  + with variants; +6 documented s/r conflicts, 453→459).  Result
+  width/signedness follow the with expression per 7.12.3.  `find*`
+  locators extended from queues to dynamic and fixed arrays.  Per-call
+  iterator binding via new `NetScope::set_signal_alias` (7.12: "The
+  scope for the iterator_argument is the with expression") — this also
+  fixed a pre-existing find_with poisoning bug where sibling calls with
+  different element types shared one hidden `item` net (wrong
+  signedness/width -> wrong compares or a vvp width assertion).  Runtime
+  is an inline vvp loop (existing opcodes only;
+  `$ivl_darray_method$reduce|` lowered in
+  tgt-vvp/eval_object.c:draw_array_reduce_vec4, `minmax|` in
+  eval_object_sfunc).  Tests `tests/g10_array_methods_test.sv` (29
+  checks incl. all 7.12.3 LRM literal examples),
+  `tests/negative/g10_reduction_non_integral.sv`.
+- Remaining tail (explicit diagnostics, no silent fallbacks): `sort`/
+  `rsort`/`reverse`/`shuffle` (7.12.2); `unique`/`unique_index` on
+  non-queue arrays; reductions/min/max on associative arrays (sorry) and
+  multidimensional arrays (sorry); `min`/`max` on string/real elements
+  (sorry); `item.index` iterator method; class-property receivers reach
+  the older PEIdent property path, not the new machinery.
 - Symptom: `q.sum()` reports `error: Method sum is not a queue method.` Same for product. Probe got `Variable item does not have a field named: index.` for `with (item.index)`. The Phase-63b B-series only added some shapes.
 - Probe: p16_queue_with (VERIFIED-FAILS), p30_array_methods (VERIFIED-FAILS for .min/.max/.sort on non-queue), p87_unique_index (PASS for queue).
 - Location: elab_expr.cc:8857-8911 (sorry: cluster for non-queue array methods); also `with (item.index)` codepath separately broken in elab_expr.cc.

--- a/docs/claude/uvm_ieee1800_gap_audit_2026_05.md
+++ b/docs/claude/uvm_ieee1800_gap_audit_2026_05.md
@@ -142,6 +142,42 @@ Iverilog under test: `Icarus Verilog version 13.0 (devel) (s20251012-102-g9b44d5
 - Complexity: medium (each is its own bytecode template; pattern is established in B1).
 - Blocks: standard idioms in scoreboard reductions, RAL frontdoor.
 
+### G68 `process::status()` read a dead property slot — always 0 (=FINISHED)
+- **STATUS 2026-07-13: FIXED.**  The built-in process class declared
+  `status` as a stored property nothing ever wrote, so it read 0 —
+  which is FINISHED in the 9.7 state enum.  Now lowered to a live
+  runtime query: new vvp opcode `%process/status` maps the owning
+  thread's state through `vvp_process::status()` (nil handle pushes
+  x); elaboration routes both the call form (`p.status()`) and the
+  paren-less property-chain form (`item.process_id.status`, the UVM
+  sequencer zombie predicate) to `$ivl_process$status`, and the
+  compile-progress method-stub classifier exempts process.status
+  (it previously constant-folded it to 0).  `process::FINISHED/
+  RUNNING/WAITING/SUSPENDED/KILLED` also now bind in module scope
+  (previously unresolved-reference warnings + dropped expr).
+  Exposed by the G10 property-receiver work: the UVM zombie check
+  `find ... with (request==LOCK && process_id.status inside
+  {KILLED,FINISHED})` previously never ran (receiver fallback), then
+  mis-evaluated (see G69) and killed every arbitration entry at t0
+  (seq_trace_test/vif_smoke/vif_smoke_v2 PH_TIMEOUT@9200).
+  Test `tests/g68_process_status_test.sv`.
+- Known approximation: a delay-suspended process reads RUNNING (the
+  thread wait flags don't distinguish delays); suspend()/resume()
+  are not implemented so SUSPENDED is never reported.
+
+### G69 `inside` operator precedence was at ternary level (Table 11-2 violation)
+- **STATUS 2026-07-13: FIXED.**  parse.y placed K_inside in the
+  `%right '?' ':'` precedence group, so `a && b inside {c,d}` parsed
+  as `(a && b) inside {c,d}`.  IEEE 1800-2017 Table 11-2 puts inside
+  at the RELATIONAL level (with < <= > >=), tighter than equality,
+  &&, || and ?:.  Moved K_inside to the relational `%left` group
+  (grammar conflict counts unchanged: 459 s/r / 1060 r/r).  This
+  latent mis-parse made the UVM sequencer zombie predicate
+  `(request==LOCK && status)` compare against FINISHED=0 — true for
+  every non-lock entry — as soon as the G10 property-receiver work
+  made the predicate actually execute.
+  Test `tests/g69_inside_precedence_test.sv`.
+
 ### G11 `solve…before` partially works, but `a -> b == K` implication is dropped
 - **UPDATE 2026-07-12**: signed comparisons and negative constraint bounds now supported (checkpoint 6): unary minus folds to two's complement; signed properties marked `p:N:W:s`; bvslt-family predicates and sign extension applied per IEEE 1800-2017 11.8.1. Test `tests/m3_constraint_signed_test.sv`.
 - **STATUS 2026-07-11: FIXED (implication part)**. `->` implications now emitted as `(impl ...)` IR and enforced by Z3 (M3 checkpoint). `solve...before` ordering is still parsed-and-ignored (distribution handled by the xor-diversity objective; staged ordering semantics deferred). Test `tests/m3_constraint_semantics_test.sv` (SolveC).

--- a/docs/conformance/CURRENT_WORK.md
+++ b/docs/conformance/CURRENT_WORK.md
@@ -3,6 +3,37 @@
 Keep this accurate enough that another session can resume without repeating
 the investigation. Update at every meaningful checkpoint.
 
+## State as of 2026-07-12e (session: G10 array reduction methods)
+
+- **Branch**: `claude/ieee1800-systemverilog-uvm-tqk5qy` (PR #69 open,
+  draft — this checkpoint stacks onto it; head before this checkpoint
+  was 9f7c918, the ivl.def Windows export fix).
+- **This checkpoint**: G10 — IEEE 1800-2017 7.12.3 array reduction
+  methods (`sum`/`product`/`and`/`or`/`xor`) and 7.12.1
+  `min()`/`max()` implemented over queues, dynamic arrays and 1-D
+  fixed-size unpacked arrays, in all four source forms (call,
+  call+with, paren-less, paren-less+with) including the keyword-named
+  `.and()/.or()/.xor()` (new grammar rules, +6 documented s/r
+  conflicts 453→459).  `find*` locators extended to dynamic/fixed
+  arrays.  Result width/signedness follow the with expression
+  (7.12.3).  New `NetScope::set_signal_alias` gives each call its own
+  iterator binding (7.12 "scope for the iterator_argument is the with
+  expression") — also fixes a pre-existing find_with bug where sibling
+  calls with different element types shared one hidden `item` net
+  (signed/width poisoning; could trip a vvp store assertion).  Runtime
+  is inline vvp loops from EXISTING opcodes only
+  (`$ivl_darray_method$reduce|`/`minmax|` lowered in tgt-vvp).
+  Explicit `sorry` diagnostics (no silent fallbacks) for assoc-array
+  and multidimensional receivers and string/real min/max.
+  Details: `session_logs/2026-07-12_g10_array_reduction_methods.md`.
+- **Tests**: `tests/g10_array_methods_test.sv` (29 checks incl. all
+  7.12.3 LRM literal examples);
+  `tests/negative/g10_reduction_non_integral.sv` (negative suite now
+  6/6).
+- **G10 tail remaining**: sort/rsort/reverse/shuffle (7.12.2); unique
+  on non-queue receivers; assoc/multidim receivers; `item.index`;
+  class-property receivers (still on the older PEIdent property path).
+
 ## State as of 2026-07-12d (session: M6 item 2 — Reactive region)
 
 - **Branch**: `claude/ieee1800-systemverilog-uvm-tqk5qy`, restarted from

--- a/docs/conformance/CURRENT_WORK.md
+++ b/docs/conformance/CURRENT_WORK.md
@@ -3,6 +3,28 @@
 Keep this accurate enough that another session can resume without repeating
 the investigation. Update at every meaningful checkpoint.
 
+## State as of 2026-07-13c (session: 7.12.2 ordering methods)
+
+- **Branch**: `claude/ieee1800-systemverilog-uvm-tqk5qy` (PR #69 open,
+  draft).
+- **This checkpoint**: three defects in the sort/rsort/reverse/
+  shuffle/unique statement paths (IEEE 1800-2017 7.12.2): instance-
+  property receivers silently NO-OP'd (explicit skip in
+  tgt-vvp/vvp_process.c — now hidden-recv-net pattern, matching the
+  expression-side G10 work); with-clause sort keys always truncated
+  to int32 (string keys — the UVM `sort() with (item.get_full_name())`
+  shape in uvm_cmdline_report/uvm_root/uvm_phase_hopper — silently
+  mis-sorted past a shared 4-byte prefix; keys now typed
+  string/real/sb32 end to end); shared iterator-net poisoning in the
+  sort_with elaboration (now fresh nets + set_signal_alias).
+  Runtime: qsort/qunique keys helpers generalized over key type — no
+  new opcodes.
+  Details: `session_logs/2026-07-13_g10_ordering_methods.md`.
+- **Tests**: `tests/g10_ordering_methods_test.sv` (28 checks).
+- **Remaining 7.12 tail**: unique on non-queue receivers;
+  assoc/multidim receivers; `item.index`; fixed-array class
+  properties; ordering methods on fixed-size arrays.
+
 ## State as of 2026-07-13b (session: G68 process.status + G69 inside precedence)
 
 - **Branch**: `claude/ieee1800-systemverilog-uvm-tqk5qy` (PR #69 open,

--- a/docs/conformance/CURRENT_WORK.md
+++ b/docs/conformance/CURRENT_WORK.md
@@ -3,6 +3,31 @@
 Keep this accurate enough that another session can resume without repeating
 the investigation. Update at every meaningful checkpoint.
 
+## State as of 2026-07-13 (session: G10 tail — class-property receivers)
+
+- **Branch**: `claude/ieee1800-systemverilog-uvm-tqk5qy` (PR #69 open,
+  draft; CI green on all 6 platforms at def4cf7 before this
+  checkpoint).
+- **This checkpoint**: array reduction/min-max/find* methods now work
+  on CLASS-PROPERTY receivers — the dominant UVM shape
+  (`this.q.sum()` in scoreboards, `cfg.st.q.max()` nested chains,
+  external `obj.q.sum()`, paren-less `return q.sum;`).  Mechanism: a
+  non-signal object receiver is evaluated once and its handle stored
+  into a hidden container-typed net that the existing inline loop
+  indexes through (extra trailing sfunc parm; tgt-vvp
+  `draw_array_method_recv_`).  The PEIdent class-property tail path
+  that previously WARNED AND SILENTLY DROPPED the expression
+  (`Array method 'sum' on class-property darray/queue not yet
+  supported ... expression dropped`) now routes to the same
+  machinery.  Fixed-size-array class properties: explicit sorry.
+  Details: `session_logs/2026-07-13_g10_property_receivers.md`.
+- **Tests**: `tests/g10_array_methods_test.sv` extended to 43 checks
+  (class-property section: method-internal, external, nested-chain,
+  paren-less, with-clause, locators, empties).
+- **G10 tail remaining**: sort/rsort/reverse/shuffle (7.12.2); unique
+  on non-queue receivers; assoc/multidim receivers; `item.index`;
+  fixed-size-array class properties.
+
 ## State as of 2026-07-12e (session: G10 array reduction methods)
 
 - **Branch**: `claude/ieee1800-systemverilog-uvm-tqk5qy` (PR #69 open,

--- a/docs/conformance/CURRENT_WORK.md
+++ b/docs/conformance/CURRENT_WORK.md
@@ -3,6 +3,31 @@
 Keep this accurate enough that another session can resume without repeating
 the investigation. Update at every meaningful checkpoint.
 
+## State as of 2026-07-13b (session: G68 process.status + G69 inside precedence)
+
+- **Branch**: `claude/ieee1800-systemverilog-uvm-tqk5qy` (PR #69 open,
+  draft).
+- **Regression alert resolved**: checkpoint c6e8206 (property
+  receivers) turned seq_trace_test / vif_smoke / vif_smoke_v2 red
+  (SEQLCKZMB@0 + PH_TIMEOUT@9200) by making the UVM sequencer zombie
+  predicate execute for the first time, exposing TWO pre-existing
+  latent defects, both now fixed:
+  - **G68**: `process::status()` read a dead stored property (always
+    0 = FINISHED per 9.7) — now a live query via new vvp opcode
+    `%process/status` (call form + paren-less property-chain form +
+    stub-classifier exemption + module-scope process:: enum
+    constants).
+  - **G69**: `inside` sat at ternary precedence; Table 11-2 puts it
+    at the relational level — `a && b inside {c,d}` mis-parsed as
+    `(a && b) inside {c,d}`, so `(0) inside {KILLED, FINISHED=0}`
+    matched every non-lock arbitration entry.  K_inside moved to the
+    relational %left group (conflicts unchanged 459/1060).
+  Details: `session_logs/2026-07-13_g68_g69_process_status_inside_precedence.md`.
+- **Tests**: `tests/g68_process_status_test.sv`,
+  `tests/g69_inside_precedence_test.sv`.
+- **Known approximation**: delay-suspended processes read RUNNING;
+  SUSPENDED never reported (no suspend()/resume()).
+
 ## State as of 2026-07-13 (session: G10 tail — class-property receivers)
 
 - **Branch**: `claude/ieee1800-systemverilog-uvm-tqk5qy` (PR #69 open,

--- a/docs/conformance/CURRENT_WORK.md
+++ b/docs/conformance/CURRENT_WORK.md
@@ -3,6 +3,32 @@
 Keep this accurate enough that another session can resume without repeating
 the investigation. Update at every meaningful checkpoint.
 
+## State as of 2026-07-12d (session: M6 item 2 — Reactive region)
+
+- **Branch**: `claude/ieee1800-systemverilog-uvm-tqk5qy`, restarted from
+  merged main (PR #68 merged with G67 + G12 static/dynamic streaming —
+  do not reopen; this checkpoint gets a NEW draft PR).
+- **This checkpoint**: M6 scheduler remediation item 2 — program-block
+  processes now schedule in the Reactive region set (IEEE 1800-2017
+  4.4.2.5/.6/.7, clause 24): new vvp slot queues reactive/re-inactive/
+  re-nbassign with LRM promotion order; per-thread reactive flag from
+  the new `.scope program` type (plumbed via new ivl_scope_program API),
+  inherited by spawned children; program #0 → Re-Inactive; program NBAs
+  → Re-NBA; event wake chains PARTITIONED by region (a shared functor
+  previously dragged all waiters into one region).  Both elaborate.cc
+  program-scheduling compile-progress warnings retired.  Programs now
+  sample post-NBA design state race-free.
+  Details: `session_logs/2026-07-12_m6_reactive_region.md`.
+- **Tests**: `tests/m6_reactive_region_test.sv` (4 region orderings).
+- **Regressions**: UVM 118/118 (+1 new test); ivtest 2961/3101 with the
+  same 132 pre-existing fails (baseline-identical).
+- **Known approximation** (recorded in scheduler audit): wholesale
+  queue promotion (pre-existing model) — exact region-priority popping
+  is item 1's region-tagging work.
+- **Next options**: M6 items 1 (region tagging + trace) / 4
+  (Preponed/Observed stubs) / 5 (scheduled-call protocol); G12 tail
+  (struct operand flattening, with[range]); M3 tail; G66; G09/G10.
+
 ## State as of 2026-07-12c (session: G12 tail — dynamic-size streaming)
 
 - **Branch**: `claude/ieee1800-systemverilog-uvm-tqk5qy` (PR #68 open,

--- a/docs/conformance/scheduler_audit_2026_07.md
+++ b/docs/conformance/scheduler_audit_2026_07.md
@@ -40,7 +40,7 @@ Slot sequencing (main loop, `schedule_simulate`): on time advance →
 | NBA | `nbassign` | present |
 | Post-NBA | — | absent |
 | Observed | — | **ABSENT** (no SVA evaluation region) |
-| Reactive / Re-Inactive / Re-NBA | — | **ABSENT** — program-block code runs in Active (elaborate.cc already warns: "Program blocking assignments are not currently scheduled in the Reactive region") |
+| Reactive / Re-Inactive / Re-NBA | `reactive` / `re_inactive` / `re_nbassign` | **PRESENT** (2026-07-12, remediation item 2): program-block processes carry a per-thread reactive flag (scope-chain `vpiProgram` + inheritance to spawned children); event wake chains are partitioned by region; program #0 → Re-Inactive; program NBAs → Re-NBA. Promotion order: active ← inactive ← nbassign ← reactive ← re-inactive ← re-nba ← rwsync. Test: `tests/m6_reactive_region_test.sv` |
 | Pre-Postponed (cbReadWriteSynch) | `rwsync` | present; correctly re-promotes into active so writes re-trigger evaluation |
 | Postponed (cbReadOnlySynch) | `rosync` | present with rosync write guard |
 
@@ -119,10 +119,19 @@ restructuring.
 
 1. Introduce region tagging on events (enum already exists:
    `event_queue_e`) + optional trace hook (time, delta, region, event).
-2. Add Reactive/Re-Inactive/Re-NBA queues and route program-block
-   processes there (unblocks 1800-2017 24.x program semantics and the
-   existing elaborate.cc warning).
+2. **DONE 2026-07-12**: Reactive/Re-Inactive/Re-NBA queues added and
+   program-block processes routed there (per-thread reactive flag from
+   the vpiProgram scope chain, inherited by spawned children; wake
+   chains partitioned by region in vthread_schedule_list; program #0
+   and NBAs land in Re-Inactive/Re-NBA).  The two elaborate.cc
+   compile-progress warnings are retired.  Known approximation: the
+   wholesale queue-promotion model (as with inactive/nbassign) means
+   Active-region events created DURING reactive execution drain in the
+   same promoted queue rather than strictly before the remaining
+   reactive events; exact region-priority popping is item 1's tagging
+   work.  Test: `tests/m6_reactive_region_test.sv`.
 3. Add slot-persistent `event.triggered` state (fixes G08) — 15.5.3.
+   **DONE 2026-07-12** (see gap audit G08).
 4. Add Preponed sampling + Observed evaluation stubs as the SVA/clocking
    foundation (M8/M9 prerequisite).
 5. Replace callf synchronous-drain assumptions with an explicit

--- a/docs/conformance/session_logs/2026-07-12_g10_array_reduction_methods.md
+++ b/docs/conformance/session_logs/2026-07-12_g10_array_reduction_methods.md
@@ -1,0 +1,123 @@
+# Session log — 2026-07-12 (fifth target): G10 array reduction methods
+
+Engineering target: IEEE 1800-2017 7.12.3 array reduction methods
+(`sum`, `product`, `and`, `or`, `xor`) and the 7.12.1 `min()`/`max()`
+locators, over queues, dynamic arrays and fixed-size unpacked arrays,
+with with-clause support — the G10 gap-audit cluster ("blocks
+scoreboard reductions, RAL frontdoor").
+
+## Starting evidence (reduced probe)
+
+- `q.sum()` → `error: Method sum is not a queue method.`
+- `d.sum()/product()/max()/min()` → `error: Method ... is not a
+  dynamic array method.`
+- `f.sum()` on a fixed array → silent "no method" compile-progress
+  fallback returning 0.
+- `q.and()` → syntax error (`and`/`or`/`xor` are keywords; no grammar
+  rule for the call form).
+- `q.xor with (item)` → parsed, but the `expr_primary K_with` fallback
+  silently DROPPED the with clause, then the PEIdent path emitted
+  `sorry: 'xor()' array reduction method is not currently implemented.`
+- `q.find_index() with (...)` already worked (Phase 63b B1) on queues
+  only.
+
+## LRM grounding (1800-2017 PDF, clause 7.12, spec pp. 165-168)
+
+- 7.12.3: reductions apply to "any unpacked array of integral
+  values"; result type = element type, or the with expression's type;
+  "the width of the reduction method result shall be the same as the
+  width of the expression in the with clause" (the `bit_arr.sum with
+  (int'(item))` example).
+- 7.12.1: `min()`/`max()` return a QUEUE holding the best element
+  (empty queue for an empty array); the with clause is optional.
+- 7.12: "The scope for the iterator_argument is the with expression."
+
+## Implementation
+
+- **Elaboration** (elab_expr.cc): two new helpers next to the Phase
+  63b locator builder — `make_array_reduction_expr_` (sfunc
+  `$ivl_darray_method$reduce|<kind>`, parms: array, iter, idx, acc,
+  value-expr; result type is a `netvector_t` with the with
+  expression's width/signedness, else the element type's) and
+  `make_array_minmax_expr_` (sfunc `$ivl_darray_method$minmax|<kind>`,
+  parms: array, iter, result queue, idx, best, bestitem, value-expr).
+  Dispatched from all three receiver branches of
+  `elaborate_method_dispatch_` (queue — with an explicit `sorry` for
+  assoc-compat receivers; dynamic array; fixed unpacked array — with
+  an explicit `sorry` for multidimensional receivers).  `find*`
+  locators now also route for dynamic and fixed arrays.  Non-integral
+  elements are an error citing 7.12.3.
+- **Receiver typing fix**: for `f.sum` on a fixed array,
+  symbol_search reports the ELEMENT type (`net_type()`); the method
+  receiver is the array itself, so `elaborate_expr_method_` now
+  retargets `target_type` to `net->array_type()` when the reference
+  is unindexed and the array is a `netuarray_t`.
+- **Paren-less forms** (`y = b.sum;` — the LRM's own example syntax):
+  these parse as plain member paths (PEIdent); an early hook in
+  `PEIdent::elaborate_expr_` routes single-component
+  reduction/min/max tails on integral-element array receivers to the
+  same helpers.
+- **Grammar** (parse.y): `and`/`or`/`xor` are keywords, so the
+  generic call and with-clause rules cannot match them.  New rules
+  per keyword: `.and()` call form, `.and() with (expr)`, and
+  paren-less `.and with (expr)` (ditto or/xor), built by a new
+  `pform_keyword_method_call` helper that fills
+  `PECallFunction::with_constraints_`.  +6 shift/reduce conflicts
+  (453→459), r/r unchanged at 1060; the conflicts are the intended
+  shift-over-reduce at `K_with` after a keyword method name.
+- **Per-call iterator binding** (the subtle one): the Phase 63b
+  scheme created ONE hidden net named `item` per scope and reused it
+  across sibling calls.  With mixed element types in one scope this
+  poisons later calls: a signed 8-bit `item` from `byte b[]` made
+  `u.max()` on `logic [7:0] u[$]` compare SIGNED (returned 0F instead
+  of F0), and a 1-bit `bit` element store into the stale 8-bit net
+  tripped `of_STORE_VEC4: val_size >= wid`.  Per 7.12 the iterator is
+  scoped to the with expression, so each call now allocates a fresh,
+  uniquely named iterator net and binds the user-visible name to it
+  only while its with expression elaborates, via new
+  `NetScope::set_signal_alias`/`restore_signal_alias` (netlist.h,
+  net_scope.cc).  The same fix was applied to the pre-existing
+  find_with locator builder.  Nested with-expressions bind correctly
+  (innermost alias restored first).
+- **tgt-vvp** (eval_object.c + eval_vec4.c dispatch + vvp_priv.h):
+  `draw_array_reduce_vec4` emits an inline loop — accumulator
+  initialized to the operator identity (0; 1 for product; ~0 via
+  `%inv` for and), `%cmp/s` bound check, per-element load, value
+  evaluation, fold with `%add/%mul/%and/%or/%xor` — leaving the
+  result on the vec4 stack.  The minmax lowering tracks best value +
+  best element with `%cmp/s` or `%cmp/u` chosen by the value
+  expression's signedness (first element always taken; ties keep the
+  earliest; x-flagged compares keep the current best) and pushes the
+  best element into a fresh result queue (empty for an empty array).
+  Receiver differences are hidden behind two helpers:
+  queues/dynamic arrays use `%qsize` + `%load/dar/vec4`; fixed-size
+  arrays use the compile-time word count + `%load/vec4a` (whole-array
+  references arrive as IVL_EX_ARRAY, accepted alongside
+  IVL_EX_SIGNAL).  The find_with loop shares the helpers, extending
+  the locators to fixed arrays (vector elements only; explicit
+  warning otherwise).  NO new vvp opcodes — existing bytecode only.
+
+## Verified (permanent test `tests/g10_array_methods_test.sv`, 29 checks)
+
+All three 7.12.3 LRM literal examples (`b.sum`=10, `b.product`=24,
+`b.xor with (item+4)`=12, `bit_arr.sum with (int'(item))`);
+queue/dynamic/fixed receivers; all four source forms; keyword methods;
+signed (`min`=-7) and unsigned (`max`=F0) comparisons; with-clause
+value remapping (`max() with (-item)` returns -7); empty-array
+identities (sum 0, product 1, `max()` empty queue); custom iterator
+names (`sum(x) with (x*3)`); fixed-array `find_index`; per-call
+iterator binding regression (bit after byte in one scope).
+Negative test `tests/negative/g10_reduction_non_integral.sv` (real
+elements rejected citing 7.12.3).
+
+## Remaining tail (explicit diagnostics, recorded in the gap audit)
+
+sort/rsort/reverse/shuffle (7.12.2); unique on non-queue receivers;
+assoc-array and multidimensional receivers (sorry); min/max on
+string/real elements (sorry); `item.index`; class-property receivers
+still take the older PEIdent property path.
+
+## Regression evidence
+
+Recorded in the checkpoint commit message (UVM suite, bundled ivtest,
+negative suite 6/6, focused m6/g12 re-runs all PASS).

--- a/docs/conformance/session_logs/2026-07-12_m6_reactive_region.md
+++ b/docs/conformance/session_logs/2026-07-12_m6_reactive_region.md
@@ -1,0 +1,73 @@
+# Session log — 2026-07-12 (fourth target): Reactive region for programs
+
+Engineering target: M6 scheduler remediation item 2 — schedule
+program-block processes in the Reactive region set (IEEE 1800-2017
+4.4.2.5 Reactive, 4.4.2.6 Re-Inactive, 4.4.2.7 Re-NBA; clause 24).
+
+## Starting evidence
+
+Reduced probe (module DUT increments a counter with an NBA on posedge;
+program samples at the same edge): the program deterministically read
+the PRE-NBA value — program threads ran in the Active region, racing
+the design.  The compiler carried two standing compile-progress
+warnings admitting this ("Program (non-)blocking assignments are not
+currently scheduled in the Reactive(-NBA) region").
+
+## Implementation
+
+- **ivl_target API**: new `ivl_scope_program(ivl_scope_t)` — the
+  NetScope program flag now crosses into code generators (t-dll.h
+  `is_program`, both scope-construction sites, t-dll-api.cc getter).
+- **tgt-vvp**: program instance scopes emit `.scope program` (was
+  `module`).
+- **vvp scope**: new `vpiScopeProgram` (type code `vpiProgram`) parsed
+  from the new scope-type string.
+- **vvp threads**: `vthread_s::is_reactive_process` (initialized —
+  G67's lesson — and set at `vthread_new` by walking the scope parent
+  chain for `vpiProgram`); inherited by all spawned children
+  (fork/callf/chunk-continuation sites), so tasks and class methods
+  called FROM a program execute as program code.  Accessor
+  `vthread_is_reactive()` for the scheduler.
+- **vvp scheduler** (schedule.cc): three new per-slot queues
+  `reactive`, `re_inactive`, `re_nbassign`; enum + schedule_event_
+  cases; promotion order per 4.4.2:
+  active ← inactive ← nbassign ← reactive ← re-inactive ← re-nba ←
+  rwsync (rosync unchanged at slot teardown).  Entry routing:
+  `schedule_vthread` and `schedule_inactive` consult the thread's
+  reactive flag; the thread NBA entry points
+  (`schedule_assign_vector`, both `schedule_assign_array_word`
+  overloads) gain a `reactive` parameter passed from the %assign
+  opcode family in vthread.cc.  Net/force/propagate scheduling is
+  untouched (design semantics).
+- **Wake-chain partitioning** (the subtle one): a single edge/event
+  functor can hold both design and program waiters in one wake chain;
+  `vthread_schedule_list` previously scheduled the whole chain as one
+  event in one region.  It now partitions the chain by the reactive
+  flag (preserving relative order within each partition) and schedules
+  the partitions separately.  Without this, a shared `@(posedge clk)`
+  functor dragged program threads into Active (or design threads into
+  Reactive) depending on chain order.
+- **elaborate.cc**: both program-scheduling warnings and the
+  now-unused `lval_not_program_variable` helper removed.
+
+## Known approximation (recorded in the scheduler audit)
+
+The wholesale queue-promotion model (pre-existing for
+inactive/nbassign) means Active events created DURING reactive
+execution drain in the same promoted queue rather than strictly before
+the remaining reactive events.  Exact region-priority event popping is
+remediation item 1's region-tagging work.
+
+## Verified orderings (permanent test `tests/m6_reactive_region_test.sv`)
+
+(a) program sampling at a clock edge sees the design's post-NBA state
+for that same edge (both edges checked); (b) program #0 (Re-Inactive)
+runs before the program's own NBA (Re-NBA); (c) the Re-NBA update is
+observable via @(x) within the same slot; (d) a design process
+triggered by a program's blocking write runs in Active (iterative
+loopback) before the program's next #0 continuation.
+
+## Regression evidence
+
+Recorded in the checkpoint commit message (UVM suite + ivtest run in
+this session); all prior m6/g12 focused tests re-verified PASS.

--- a/docs/conformance/session_logs/2026-07-13_g10_ordering_methods.md
+++ b/docs/conformance/session_logs/2026-07-13_g10_ordering_methods.md
@@ -1,0 +1,75 @@
+# Session log — 2026-07-13 (third target): 7.12.2 ordering methods
+
+Engineering target: the IEEE 1800-2017 7.12.2 array ordering methods
+(sort, rsort, reverse, shuffle; plus the unique statement forms that
+share their machinery).  UVM calls `.sort()` in six places —
+uvm_phase_hopper (`succ_q.sort with (item.get_full_name())`),
+uvm_root (`m_time_settings.sort() with (item.offset)`),
+uvm_cmdline_report (3× `sort() with (item.get_full_name())`),
+uvm_registry (`m__type_aliases.sort()`).
+
+## Starting evidence (reduced probes)
+
+The Phase 63b implementation covered signal receivers, but had three
+latent defects, all SILENT:
+
+1. **Instance-property receivers no-op'd**: `r.iq.sort()` left the
+   queue unmodified — tgt-vvp/vvp_process.c had an explicit
+   "silently skip rather than warning" branch for non-signal
+   receivers.  (Statics and locals worked, which is why UVM's own six
+   sites appeared fine.)
+2. **String sort keys truncated to 32 bits**: the with-clause key
+   build always evaluated the predicate as vec4 and stored 32-bit
+   keys; `qsort_with_keys_dispatch_` extracted `int32_t`.  Keys
+   sharing a 4-byte prefix compared equal — the exact
+   `sort() with (item.get_full_name())` shape mis-sorted
+   ("uvm_test_top.env.zebra/alpha/mike" kept insertion order).
+   Real keys were similarly collapsed through vector4_to_value.
+3. **Shared iterator nets**: the sort_with elaboration still used the
+   find_signal-and-reuse iterator scheme whose type-poisoning was
+   fixed on the expression side a session earlier.
+
+## Implemented
+
+- **Runtime** (vvp/vthread.cc, no new opcodes):
+  `qsort_with_keys_helper_` and `qunique_keys_helper_` generalized
+  over the key type (`<ELEM, KEY>`); the dispatchers inspect the KEYS
+  array's runtime type and extract `vector<string>`,
+  `vector<double>`, or `vector<int32_t>` accordingly (7.12.2: "the
+  relational operators shall be defined for the type of the
+  expression").  rsort uses `keys[b] < keys[a]` so only operator< is
+  required.
+- **Elaboration** (elaborate.cc PCallTask::elaborate_method_):
+  - all four emit sites (reverse, plain sort/rsort/unique, sort_with
+    family, shuffle) allocate a hidden container-typed receiver net
+    when obj_expr is not a NetESignal and append it as a trailing
+    argument (`make_ordering_method_recv_net_`);
+  - the keys queue element type now follows the elaborated with
+    expression (string / real / signed-32);
+  - fresh uniquely-named iterator net per call, bound to the
+    user-visible name only during predicate elaboration via
+    `NetScope::set_signal_alias`.
+- **Codegen** (tgt-vvp/vvp_process.c): the silent-skip branch is
+  replaced by the hidden-recv-net pattern (evaluate receiver object
+  once, `%store/obj` the handle, run `%qsort`/`%qsort/keys`/... on
+  the hidden net — in-place reorder reaches the property because
+  containers are held by handle); the key-build loop emits
+  `draw_eval_string` + `%store/qb/str` or `draw_eval_real` +
+  `%store/qb/r` for string/real predicates, and the keys queue is
+  created with the matching element encoding.  A remaining
+  unsupported receiver shape now warns once instead of silently
+  skipping.
+
+## Verified (permanent test `tests/g10_ordering_methods_test.sv`, 28 checks)
+
+LRM 7.12.2 examples (int sort/rsort/reverse/shuffle, string-element
+sort/reverse); dynamic-array receivers; instance-property receivers
+for all five methods (internal, external); string keys longer than 32
+bits with a common prefix, both sort and rsort; real keys; int keys
+on object elements in the paren-less-with form; iterator isolation
+across element types in one scope.
+
+## Regression evidence
+
+Recorded in the checkpoint commit message (UVM suite, bundled ivtest,
+negative 6/6, focused g10/g68/g69/m6/g12 re-runs).

--- a/docs/conformance/session_logs/2026-07-13_g10_property_receivers.md
+++ b/docs/conformance/session_logs/2026-07-13_g10_property_receivers.md
@@ -1,0 +1,67 @@
+# Session log — 2026-07-13: G10 tail — class-property receivers
+
+Engineering target: array reduction/min-max/find* methods (IEEE
+1800-2017 7.12) on CLASS-PROPERTY receivers — the dominant UVM shape
+(scoreboard `this.q.sum()`, nested config chains `cfg.st.q.max()`).
+The 2026-07-12e checkpoint covered receivers that symbol_search
+resolves to a plain signal; UVM code is class-based, so property
+receivers are what RAL/scoreboard idioms actually use.
+
+## Starting evidence (reduced probes)
+
+- `q.sum()` inside a class method, `sb.q.sum()` externally,
+  `cfg.st.q.sum()` nested: elaboration routed them to the new G10
+  dispatch (sub_expr is a NetEProperty), but the tgt-vvp loops index
+  the receiver through a SIGNAL label (`%qsize v<sig>`,
+  `%load/dar/vec4 v<sig>`) — shape check failed, 0/empty fallback.
+- Paren-less property forms (`return q.sum;`, `c.q.sum`) took a
+  different path entirely: the PEIdent class-property tail walker
+  warned `Array method 'sum' on class-property darray/queue not yet
+  supported (compile-progress: expression dropped)` and returned
+  nullptr — the assignment silently evaporated (probe showed the
+  TARGET VARIABLE keeping its previous value).
+
+## Implementation
+
+- **Elaboration** (elab_expr.cc): new `make_array_method_recv_net_` —
+  when the receiver expression is not a NetESignal, allocate a hidden
+  net of the CONTAINER type (netqueue/netdarray).  Only dynamic
+  containers are object-valued, so fixed-size-array class properties
+  get an explicit sorry.  All three builders
+  (`make_array_reduction_expr_`, `make_array_minmax_expr_`,
+  `make_queue_locator_with_expr_`) take the container type and pass
+  the hidden net as an extra TRAILING sfunc parameter (parm 5 / 7 / 5)
+  only when the receiver is indirect, so signal-receiver bytecode is
+  unchanged.  The PEIdent class-property tail walker now routes final
+  `sum/product/and/or/xor/min/max` components on non-assoc
+  darray/queue properties to the same helpers instead of
+  warn-and-drop.
+- **tgt-vvp** (eval_object.c): new `draw_array_method_recv_` — a
+  signal/whole-array receiver is used directly (old path); any other
+  object-valued receiver is evaluated once with `draw_eval_object`
+  and its HANDLE stored (`%store/obj`) into the hidden net, which the
+  existing loop then indexes.  vvp queue/darray stores are by
+  reference, so no copy is made.  Used by all three lowerings
+  (reduce, minmax, find_with).
+
+## Verified
+
+`tests/g10_array_methods_test.sv` extended to 43 checks; the new
+class-property section covers: method-internal call / paren-less /
+with-clause / max / find_index-with; external `sb.q.sum()` and
+paren-less `sb.q.sum`; nested chains (`cfg.st.q.sum()`,
+`cfg.st.d.sum() with`, `cfg.st.q.and()`, `cfg.st.q.max()`,
+`cfg.st.q.find() with`); empty property containers (sum 0, min empty
+queue).  Reduced probes additionally verified byte-darray properties
+and keyword methods on nested chains.
+
+## Remaining G10 tail (gap audit updated)
+
+sort/rsort/reverse/shuffle (7.12.2); unique on non-queue receivers;
+assoc/multidim receivers (sorry); `item.index`; fixed-size-array
+class properties (sorry).
+
+## Regression evidence
+
+Recorded in the checkpoint commit message (UVM suite, bundled ivtest,
+negative suite, focused m6/g12/m3 re-runs).

--- a/docs/conformance/session_logs/2026-07-13_g68_g69_process_status_inside_precedence.md
+++ b/docs/conformance/session_logs/2026-07-13_g68_g69_process_status_inside_precedence.md
@@ -1,0 +1,72 @@
+# Session log — 2026-07-13 (second target): G68 process.status + G69 inside precedence
+
+Engineering target (forced by regression): the class-property receiver
+checkpoint (c6e8206) turned three UVM tests red on a quiet machine —
+seq_trace_test / vif_smoke / vif_smoke_v2, all SEQLCKZMB@0 +
+PH_TIMEOUT@9200.  Root-caused to TWO pre-existing latent defects that
+the receiver work exposed by making the sequencer's zombie predicate
+actually execute for the first time.
+
+## Root-cause chain (evidence)
+
+1. Structural image diff (pointer-normalized) between def4cf7 and
+   c6e8206: 8 `find_with: bad arg shape` fallbacks became real loops —
+   including `uvm_default_factory.m_resolve_type_name_by_inst` and
+   `uvm_sequencer_base.grant_queued_locks` (the function that emits
+   SEQLCKZMB).
+2. grant_queued_locks zombie predicate:
+   `arb_sequence_q.find(item) with (item.request==SEQ_TYPE_LOCK &&
+   item.process_id.status inside {process::KILLED,process::FINISHED})`.
+3. **G68**: `status` was declared as a stored property on the built-in
+   process class (elab_type.cc) that nothing ever wrote — and the
+   compile-progress method-stub classifier ALSO listed `status` →
+   constant 0.  0 == FINISHED in the 9.7 enum.
+4. **G69**: `%right '?' ':' K_inside` put inside at ternary precedence,
+   so the predicate parsed as `((request==LOCK && status) inside
+   {KILLED, FINISHED})` — for any non-lock entry the short-circuit
+   yields 0, and `0 inside {4, 0}` is TRUE.  Confirmed by reading the
+   emitted bytecode (the `%cmpi/e 4` / `%cmpi/e 0` comparisons applied
+   to the padded && result).  An env-gated runtime trace
+   (IVL_PROC_TRACE) proved `%process/status` never even executed —
+   every zombie match came from the short-circuit path.
+5. Every arbitration entry became a "zombie" at t0; lock sequences
+   were removed; the phase never advanced; PH_TIMEOUT@9200.
+
+## Implemented
+
+- **G68** (IEEE 1800-2017 9.7): new vvp opcode `%process/status` —
+  pops a process handle, pushes the live state via
+  `vvp_process::status()` (FINISHED=0, RUNNING=1, WAITING=2,
+  SUSPENDED=3, KILLED=4; nil handle pushes x).  Elaboration lowers
+  both the call form (`p.status()`, elab_expr.cc method dispatch) and
+  the paren-less property-chain form (`item.process_id.status`, the
+  class-property tail walker) to `$ivl_process$status`; the
+  compile-progress stub classifier exempts process.status; tgt-vvp
+  dispatches it in draw_sfunc_vec4 (draw_eval_object + opcode).
+  `process::FINISHED/RUNNING/WAITING/SUSPENDED/KILLED` now also bind
+  in module scope (route added before the unbindable-identifier
+  fallback, which WARNED AND DROPPED the expression).
+  Known approximation (recorded in the audit): delay-suspended
+  processes read RUNNING; SUSPENDED is never reported (no
+  suspend()/resume()).
+- **G69** (IEEE 1800-2017 Table 11-2): K_inside moved from the
+  ternary `%right` group to the relational `%left` group in parse.y.
+  Grammar conflicts unchanged (459 s/r, 1060 r/r).
+- Env-gated `IVL_PROC_TRACE` diagnostics kept in of_PROCESS_SELF /
+  of_PROCESS_STATUS (matches the project's IVL_*_TRACE pattern).
+
+## Tests
+
+- `tests/g68_process_status_test.sv` — enum constants, self RUNNING,
+  live/killed/finished children, and the exact UVM zombie-predicate
+  shape (live req not zombie, dead req is zombie, non-lock dead-proc
+  req not zombie — the case the && guard must protect).
+- `tests/g69_inside_precedence_test.sv` — inside vs && (both truth
+  values plus the short-circuit case that distinguishes the
+  mis-parse), inside vs ==, inside vs || and ?:.
+
+## Regression evidence
+
+Recorded in the checkpoint commit message (UVM suite incl. the three
+previously-red tests, bundled ivtest, negative 6/6, focused
+m6/g12/m3 re-runs, all G10 probes).

--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -119,14 +119,28 @@ static bool warned_multi_index_array_prop_fallback = false;
  *
  * Returns nullptr if the predicate fails to elaborate.
  */
+static NetNet* make_array_method_recv_net_(
+      const LineInfo*li, Design*des, NetScope*scope,
+      NetExpr*array_expr, ivl_type_t container_type, const char*kind);
+
 static NetExpr* make_queue_locator_with_expr_(
       const PECallFunction*call,
       Design*des, NetScope*scope,
       NetExpr*queue_expr,
+      ivl_type_t container_type,
       ivl_type_t element_type,
       const char*kind /* "find" / "find_index" / ... */,
       const std::vector<named_pexpr_t>&parms)
 {
+      NetNet*recv_net = 0;
+      if (!dynamic_cast<NetESignal*>(queue_expr)) {
+	    recv_net = make_array_method_recv_net_(call, des, scope,
+						   queue_expr,
+						   container_type, kind);
+	    if (!recv_net)
+		  return nullptr;
+      }
+
       if (call->with_constraints().empty())
             return nullptr;
 
@@ -192,7 +206,8 @@ static NetExpr* make_queue_locator_with_expr_(
        *   3: idx NetESignal
        *   4: predicate */
       string mangled = string("$ivl_queue_method$find_with|") + kind;
-      NetESFunc*fn = new NetESFunc(mangled.c_str(), IVL_VT_QUEUE, 1, 5);
+      NetESFunc*fn = new NetESFunc(mangled.c_str(), IVL_VT_QUEUE, 1,
+				   recv_net ? 6 : 5);
       fn->parm(0, queue_expr);
       NetESignal*iter_ref = new NetESignal(iter_net);
       iter_ref->set_line(*call);
@@ -204,6 +219,11 @@ static NetExpr* make_queue_locator_with_expr_(
       idx_ref->set_line(*call);
       fn->parm(3, idx_ref);
       fn->parm(4, pred_expr);
+      if (recv_net) {
+	    NetESignal*recv_ref = new NetESignal(recv_net);
+	    recv_ref->set_line(*call);
+	    fn->parm(5, recv_ref);
+      }
       fn->set_line(*call);
       return fn;
 }
@@ -234,6 +254,38 @@ static NetNet* make_array_method_iter_net_(
       iter_net->set_line(*li);
       iter_net->local_flag(true);
       return iter_net;
+}
+
+/* The tgt-vvp array-method loops index the receiver through a
+ * signal label.  When the receiver is not a plain signal (a class
+ * property, a nested property chain, a call result), allocate a
+ * hidden net of the container type; the code generator evaluates the
+ * receiver expression once, stores the object handle into the hidden
+ * net, and runs the loop against it.  Only dynamic containers are
+ * object-valued, so fixed-size-array properties cannot take this
+ * path.  Returns nil (with a diagnostic) for such receivers. */
+static NetNet* make_array_method_recv_net_(
+      const LineInfo*li, Design*des, NetScope*scope,
+      NetExpr*array_expr, ivl_type_t container_type, const char*kind)
+{
+      if (dynamic_cast<NetESignal*>(array_expr))
+	    return 0; /* plain signal: no copy needed */
+
+      ivl_variable_type_t cbase = container_type
+	    ? container_type->base_type() : IVL_VT_NO_TYPE;
+      if (cbase != IVL_VT_QUEUE && cbase != IVL_VT_DARRAY) {
+	    cerr << li->get_fileline() << ": sorry: " << kind
+		 << "() on a fixed-size array class property is not yet "
+		    "implemented." << endl;
+	    des->errors += 1;
+	    return 0;
+      }
+
+      NetNet*recv_net = new NetNet(scope, scope->local_symbol(),
+				   NetNet::REG, container_type);
+      recv_net->set_line(*li);
+      recv_net->local_flag(true);
+      return recv_net;
 }
 
 /* Elaborate a with expression with the iterator name bound to the
@@ -267,7 +319,8 @@ static NetExpr* elab_array_method_with_expr_(
  */
 static NetExpr* make_array_reduction_expr_(
       const LineInfo*li, Design*des, NetScope*scope,
-      NetExpr*array_expr, ivl_type_t element_type, const char*kind,
+      NetExpr*array_expr, ivl_type_t container_type,
+      ivl_type_t element_type, const char*kind,
       const std::vector<named_pexpr_t>&parms,
       const std::vector<PExpr*>&with_exprs)
 {
@@ -280,6 +333,17 @@ static NetExpr* make_array_reduction_expr_(
 	    des->errors += 1;
 	    delete array_expr;
 	    return 0;
+      }
+
+      NetNet*recv_net = 0;
+      if (!dynamic_cast<NetESignal*>(array_expr)) {
+	    recv_net = make_array_method_recv_net_(li, des, scope,
+						   array_expr,
+						   container_type, kind);
+	    if (!recv_net) {
+		  delete array_expr;
+		  return 0;
+	    }
       }
 
       perm_string iter_name;
@@ -331,7 +395,8 @@ static NetExpr* make_array_reduction_expr_(
       acc_net->local_flag(true);
 
       string mangled = string("$ivl_darray_method$reduce|") + kind;
-      NetESFunc*fn = new NetESFunc(mangled.c_str(), res_type, 5);
+      NetESFunc*fn = new NetESFunc(mangled.c_str(), res_type,
+				   recv_net ? 6 : 5);
       fn->parm(0, array_expr);
       NetESignal*iter_ref = new NetESignal(iter_net);
       iter_ref->set_line(*li);
@@ -343,6 +408,11 @@ static NetExpr* make_array_reduction_expr_(
       acc_ref->set_line(*li);
       fn->parm(3, acc_ref);
       fn->parm(4, val_expr);
+      if (recv_net) {
+	    NetESignal*recv_ref = new NetESignal(recv_net);
+	    recv_ref->set_line(*li);
+	    fn->parm(5, recv_ref);
+      }
       fn->set_line(*li);
       return fn;
 }
@@ -362,7 +432,8 @@ static NetExpr* make_array_reduction_expr_(
  */
 static NetExpr* make_array_minmax_expr_(
       const LineInfo*li, Design*des, NetScope*scope,
-      NetExpr*array_expr, ivl_type_t element_type, const char*kind,
+      NetExpr*array_expr, ivl_type_t container_type,
+      ivl_type_t element_type, const char*kind,
       const std::vector<named_pexpr_t>&parms,
       const std::vector<PExpr*>&with_exprs)
 {
@@ -375,6 +446,17 @@ static NetExpr* make_array_minmax_expr_(
 	    des->errors += 1;
 	    delete array_expr;
 	    return 0;
+      }
+
+      NetNet*recv_net = 0;
+      if (!dynamic_cast<NetESignal*>(array_expr)) {
+	    recv_net = make_array_method_recv_net_(li, des, scope,
+						   array_expr,
+						   container_type, kind);
+	    if (!recv_net) {
+		  delete array_expr;
+		  return 0;
+	    }
       }
 
       perm_string iter_name;
@@ -433,7 +515,8 @@ static NetExpr* make_array_minmax_expr_(
       result_net->local_flag(true);
 
       string mangled = string("$ivl_darray_method$minmax|") + kind;
-      NetESFunc*fn = new NetESFunc(mangled.c_str(), IVL_VT_QUEUE, 1, 7);
+      NetESFunc*fn = new NetESFunc(mangled.c_str(), IVL_VT_QUEUE, 1,
+				   recv_net ? 8 : 7);
       fn->parm(0, array_expr);
       NetESignal*iter_ref = new NetESignal(iter_net);
       iter_ref->set_line(*li);
@@ -451,6 +534,11 @@ static NetExpr* make_array_minmax_expr_(
       bitem_ref->set_line(*li);
       fn->parm(5, bitem_ref);
       fn->parm(6, val_expr);
+      if (recv_net) {
+	    NetESignal*recv_ref = new NetESignal(recv_net);
+	    recv_ref->set_line(*li);
+	    fn->parm(7, recv_ref);
+      }
       fn->set_line(*li);
       return fn;
 }
@@ -5810,6 +5898,37 @@ NetExpr* PEIdent::elaborate_expr_class_field_(Design*des, NetScope*scope,
 		      cur_type = &netvector_t::atom2u32;
 		      continue;
 		}
+		// IEEE 1800-2017 7.12 reduction and min/max methods in
+		// paren-less form on a class-property darray/queue tail
+		// (e.g. `return q.sum;`): route to the shared array
+		// method machinery.  Only for the final path component
+		// and non-assoc containers; the with forms parse as
+		// calls and never reach this path.
+		if (&tail_comp == &sr.path_tail.back()
+		    && tail_comp.index.empty()
+		    && (is_array_reduction_name_(tail_comp.name)
+			|| tail_comp.name == "min"
+			|| tail_comp.name == "max")) {
+		      const netqueue_t*qt =
+			    dynamic_cast<const netqueue_t*>(cur_type);
+		      const netdarray_t*darr =
+			    dynamic_cast<const netdarray_t*>(cur_type);
+		      if (!(qt && qt->assoc_compat())) {
+			    static const std::vector<named_pexpr_t> no_parms;
+			    static const std::vector<PExpr*> no_with;
+			    if (is_array_reduction_name_(tail_comp.name))
+				  return make_array_reduction_expr_(
+					this, des, scope, base_expr,
+					cur_type, darr->element_type(),
+					tail_comp.name.str(),
+					no_parms, no_with);
+			    return make_array_minmax_expr_(
+				  this, des, scope, base_expr,
+				  cur_type, darr->element_type(),
+				  tail_comp.name.str(),
+				  no_parms, no_with);
+		      }
+		}
 		// compile-progress: other methods (find_first_index, shuffle, etc.)
 		cerr << get_fileline() << ": warning: "
 		     << "Array method `" << tail_comp.name
@@ -7106,12 +7225,14 @@ NetExpr* PECallFunction::elaborate_method_dispatch_(Design*des, NetScope*scope,
 
 	    if (is_array_reduction_name_(method_name))
 		  return make_array_reduction_expr_(this, des, scope,
-						    sub_expr, element_type,
+						    sub_expr, target_type,
+						    element_type,
 						    method_name.str(), parms_,
 						    with_constraints());
 	    if (method_name == "min" || method_name == "max")
 		  return make_array_minmax_expr_(this, des, scope,
-						 sub_expr, element_type,
+						 sub_expr, target_type,
+						 element_type,
 						 method_name.str(), parms_,
 						 with_constraints());
 
@@ -7126,7 +7247,8 @@ NetExpr* PECallFunction::elaborate_method_dispatch_(Design*des, NetScope*scope,
 		    // unpacked array).
 		  if (!with_constraints().empty()) {
 			NetExpr*loc = make_queue_locator_with_expr_(
-			      this, des, scope, sub_expr, element_type,
+			      this, des, scope, sub_expr, target_type,
+			      element_type,
 			      method_name.str(), parms_);
 			if (loc) return loc;
 		  }
@@ -7184,12 +7306,14 @@ NetExpr* PECallFunction::elaborate_method_dispatch_(Design*des, NetScope*scope,
 
 	    if (is_array_reduction_name_(method_name))
 		  return make_array_reduction_expr_(this, des, scope,
-						    sub_expr, element_type,
+						    sub_expr, target_type,
+						    element_type,
 						    method_name.str(), parms_,
 						    with_constraints());
 	    if (method_name == "min" || method_name == "max")
 		  return make_array_minmax_expr_(this, des, scope,
-						 sub_expr, element_type,
+						 sub_expr, target_type,
+						 element_type,
 						 method_name.str(), parms_,
 						 with_constraints());
 
@@ -7201,7 +7325,8 @@ NetExpr* PECallFunction::elaborate_method_dispatch_(Design*des, NetScope*scope,
 		 || method_name == "find_last_index")
 		&& !with_constraints().empty()) {
 		  NetExpr*loc = make_queue_locator_with_expr_(
-			this, des, scope, sub_expr, element_type,
+			this, des, scope, sub_expr, target_type,
+			element_type,
 			method_name.str(), parms_);
 		  if (loc) return loc;
 	    }
@@ -7277,7 +7402,8 @@ NetExpr* PECallFunction::elaborate_method_dispatch_(Design*des, NetScope*scope,
 		  // code uses one), fall back to null-empty.
 		  if (!with_constraints().empty()) {
 			NetExpr*loc = make_queue_locator_with_expr_(
-			      this, des, scope, sub_expr, element_type,
+			      this, des, scope, sub_expr, target_type,
+			      element_type,
 			      method_name.str(), parms_);
 			if (getenv("IVL_FIND_TRACE"))
 			      cerr << get_fileline() << ": [find-trace] make_locator="
@@ -7327,11 +7453,13 @@ NetExpr* PECallFunction::elaborate_method_dispatch_(Design*des, NetScope*scope,
 		  if (is_array_reduction_name_(method_name))
 			return make_array_reduction_expr_(this, des, scope,
 							  sub_expr,
+							  target_type,
 							  element_type,
 							  method_name.str(),
 							  parms_,
 							  with_constraints());
 		  return make_array_minmax_expr_(this, des, scope, sub_expr,
+						 target_type,
 						 element_type,
 						 method_name.str(), parms_,
 						 with_constraints());
@@ -9474,14 +9602,19 @@ NetExpr* PEIdent::elaborate_expr_(Design*des, NetScope*scope,
 		  bool is_mm = (mname == "min" || mname == "max");
 		  if (is_red || is_mm) {
 			ivl_type_t etype = 0;
+			ivl_type_t ctype = 0;
 			if (const netqueue_t*qt = sr.net->queue_type()) {
-			      if (!qt->assoc_compat())
+			      if (!qt->assoc_compat()) {
 				    etype = qt->element_type();
+				    ctype = qt;
+			      }
 			} else if (const netdarray_t*dt = sr.net->darray_type()) {
 			      etype = dt->element_type();
+			      ctype = dt;
 			} else if (sr.net->unpacked_dimensions() == 1
 				   && dynamic_cast<const netuarray_t*>(sr.net->array_type())) {
 			      etype = sr.net->array_type()->element_type();
+			      ctype = sr.net->array_type();
 			}
 			if (etype && (etype->base_type() == IVL_VT_BOOL
 				      || etype->base_type() == IVL_VT_LOGIC)) {
@@ -9491,10 +9624,11 @@ NetExpr* PEIdent::elaborate_expr_(Design*des, NetScope*scope,
 			      static const std::vector<PExpr*> no_with;
 			      if (is_red)
 				    return make_array_reduction_expr_(
-					  this, des, scope, recv, etype,
+					  this, des, scope, recv, ctype,
+					  etype,
 					  mname.str(), no_parms, no_with);
 			      return make_array_minmax_expr_(
-				    this, des, scope, recv, etype,
+				    this, des, scope, recv, ctype, etype,
 				    mname.str(), no_parms, no_with);
 			}
 		  }

--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -140,14 +140,15 @@ static NetExpr* make_queue_locator_with_expr_(
             }
       }
 
-      /* Allocate a hidden iter NetNet.  Reuse if a same-named NetNet
-       * already exists in the scope (sibling find calls). */
-      NetNet*iter_net = scope->find_signal(iter_name);
-      if (!iter_net) {
-            iter_net = new NetNet(scope, iter_name, NetNet::REG, element_type);
-            iter_net->set_line(*call);
-            iter_net->local_flag(true);
-      }
+      /* Allocate a fresh, uniquely named hidden iter NetNet.  The
+       * iterator is scoped to the with expression (7.12), so sibling
+       * calls on arrays of different element types must not share a
+       * binding; the name is aliased to this net only while the
+       * predicate elaborates. */
+      NetNet*iter_net = new NetNet(scope, scope->local_symbol(),
+                                   NetNet::REG, element_type);
+      iter_net->set_line(*call);
+      iter_net->local_flag(true);
 
       /* Allocate a hidden result NetNet of queue type.  Use
        * scope->local_symbol() for a unique name. */
@@ -178,7 +179,9 @@ static NetExpr* make_queue_locator_with_expr_(
       PExpr*pred_pe = call->with_constraints().front();
       if (!pred_pe)
             return nullptr;
+      NetNet*prev_bind = scope->set_signal_alias(iter_name, iter_net);
       NetExpr*pred_expr = elab_and_eval(des, scope, pred_pe, -1, false);
+      scope->restore_signal_alias(iter_name, prev_bind);
       if (!pred_expr)
             return nullptr;
 
@@ -203,6 +206,260 @@ static NetExpr* make_queue_locator_with_expr_(
       fn->parm(4, pred_expr);
       fn->set_line(*call);
       return fn;
+}
+
+/* Shared setup for the 7.12 array method helpers below: resolve the
+ * iterator name (first call argument if present, else the LRM default
+ * "item") and create a fresh, uniquely named hidden iterator NetNet
+ * of the element type.  Each call gets its own net — the iterator is
+ * scoped to the with expression (7.12), so sibling calls on arrays of
+ * different element types must not share a binding.  While the with
+ * expression elaborates, the caller aliases the user-visible iterator
+ * name to this net with NetScope::set_signal_alias. */
+static NetNet* make_array_method_iter_net_(
+      const LineInfo*li, NetScope*scope,
+      ivl_type_t element_type,
+      const std::vector<named_pexpr_t>&parms,
+      perm_string&iter_name)
+{
+      iter_name = perm_string::literal("item");
+      if (!parms.empty() && parms[0].parm) {
+	    const PEIdent*ip = dynamic_cast<const PEIdent*>(parms[0].parm);
+	    if (ip && ip->path().size() == 1)
+		  iter_name = ip->path().back().name;
+      }
+
+      NetNet*iter_net = new NetNet(scope, scope->local_symbol(),
+				   NetNet::REG, element_type);
+      iter_net->set_line(*li);
+      iter_net->local_flag(true);
+      return iter_net;
+}
+
+/* Elaborate a with expression with the iterator name bound to the
+ * hidden iterator net (self-determined width, as for the locator
+ * predicates). */
+static NetExpr* elab_array_method_with_expr_(
+      Design*des, NetScope*scope, PExpr*wpe,
+      perm_string iter_name, NetNet*iter_net)
+{
+      NetNet*prev = scope->set_signal_alias(iter_name, iter_net);
+      NetExpr*val_expr = elab_and_eval(des, scope, wpe, -1, false);
+      scope->restore_signal_alias(iter_name, prev);
+      return val_expr;
+}
+
+/* IEEE 1800-2017 7.12.3 array reduction methods (sum, product, and,
+ * or, xor) over queues, dynamic arrays and fixed-size unpacked
+ * arrays.  Same hidden-net scheme as the locator methods above; the
+ * tgt-vvp side lowers the sfunc to an inline loop that accumulates
+ * the per-element value on a hidden accumulator net.
+ *   parm 0: array (signal reference)
+ *   parm 1: iter NetESignal (element type)
+ *   parm 2: idx NetESignal (s32 loop counter)
+ *   parm 3: acc NetESignal (accumulator, result width)
+ *   parm 4: value expression (the with expression, or the iter
+ *           signal itself when no with clause is given)
+ * Result type: the element type without a with clause; with one, the
+ * type of the with expression ("the width of the reduction method
+ * result shall be the same as the width of the expression in the
+ * with clause").
+ */
+static NetExpr* make_array_reduction_expr_(
+      const LineInfo*li, Design*des, NetScope*scope,
+      NetExpr*array_expr, ivl_type_t element_type, const char*kind,
+      const std::vector<named_pexpr_t>&parms,
+      const std::vector<PExpr*>&with_exprs)
+{
+      ivl_variable_type_t ebase = element_type
+	    ? element_type->base_type() : IVL_VT_NO_TYPE;
+      if (ebase != IVL_VT_BOOL && ebase != IVL_VT_LOGIC) {
+	    cerr << li->get_fileline() << ": error: Array reduction "
+		    "method " << kind << "() requires an array of "
+		    "integral elements (IEEE 1800-2017 7.12.3)." << endl;
+	    des->errors += 1;
+	    delete array_expr;
+	    return 0;
+      }
+
+      perm_string iter_name;
+      NetNet*iter_net = make_array_method_iter_net_(li, scope, element_type,
+						    parms, iter_name);
+
+      NetNet*idx_net = new NetNet(scope, scope->local_symbol(),
+				  NetNet::REG, &netvector_t::atom2s32);
+      idx_net->set_line(*li);
+      idx_net->local_flag(true);
+
+	/* The per-element value: the with expression (evaluated with
+	 * the iterator bound to the hidden net), or the element
+	 * itself.  Self-determined context, as for the locators. */
+      NetExpr*val_expr = 0;
+      if (!with_exprs.empty() && with_exprs.front()) {
+	    val_expr = elab_array_method_with_expr_(des, scope,
+						    with_exprs.front(),
+						    iter_name, iter_net);
+	    if (!val_expr) {
+		  delete array_expr;
+		  return 0;
+	    }
+	    if (val_expr->expr_type() != IVL_VT_BOOL
+		&& val_expr->expr_type() != IVL_VT_LOGIC) {
+		  cerr << li->get_fileline() << ": error: The with "
+			  "expression of the " << kind << "() reduction "
+			  "must be integral (IEEE 1800-2017 7.12.3)." << endl;
+		  des->errors += 1;
+		  delete array_expr;
+		  delete val_expr;
+		  return 0;
+	    }
+      } else {
+	    NetESignal*es = new NetESignal(iter_net);
+	    es->set_line(*li);
+	    val_expr = es;
+      }
+
+      unsigned wid = val_expr->expr_width();
+      if (wid == 0)
+	    wid = 32;
+      netvector_t*res_type = new netvector_t(val_expr->expr_type(),
+					     wid-1, 0, val_expr->has_sign());
+
+      NetNet*acc_net = new NetNet(scope, scope->local_symbol(),
+				  NetNet::REG, res_type);
+      acc_net->set_line(*li);
+      acc_net->local_flag(true);
+
+      string mangled = string("$ivl_darray_method$reduce|") + kind;
+      NetESFunc*fn = new NetESFunc(mangled.c_str(), res_type, 5);
+      fn->parm(0, array_expr);
+      NetESignal*iter_ref = new NetESignal(iter_net);
+      iter_ref->set_line(*li);
+      fn->parm(1, iter_ref);
+      NetESignal*idx_ref = new NetESignal(idx_net);
+      idx_ref->set_line(*li);
+      fn->parm(2, idx_ref);
+      NetESignal*acc_ref = new NetESignal(acc_net);
+      acc_ref->set_line(*li);
+      fn->parm(3, acc_ref);
+      fn->parm(4, val_expr);
+      fn->set_line(*li);
+      return fn;
+}
+
+/* IEEE 1800-2017 7.12.1 min()/max() locator methods over queues,
+ * dynamic arrays and fixed-size unpacked arrays.  They return a
+ * queue holding the single element with the minimum/maximum value
+ * (or whose with expression evaluates to the minimum/maximum), or an
+ * empty queue for an empty array.  The with clause is optional.
+ *   parm 0: array (signal reference)
+ *   parm 1: iter NetESignal (element type)
+ *   parm 2: result NetESignal (queue of element type)
+ *   parm 3: idx NetESignal (s32 loop counter)
+ *   parm 4: best NetESignal (best value so far, value width)
+ *   parm 5: bestitem NetESignal (element with the best value)
+ *   parm 6: value expression
+ */
+static NetExpr* make_array_minmax_expr_(
+      const LineInfo*li, Design*des, NetScope*scope,
+      NetExpr*array_expr, ivl_type_t element_type, const char*kind,
+      const std::vector<named_pexpr_t>&parms,
+      const std::vector<PExpr*>&with_exprs)
+{
+      ivl_variable_type_t ebase = element_type
+	    ? element_type->base_type() : IVL_VT_NO_TYPE;
+      if (ebase != IVL_VT_BOOL && ebase != IVL_VT_LOGIC) {
+	    cerr << li->get_fileline() << ": sorry: " << kind
+		 << "() on arrays of non-integral elements is not yet "
+		    "implemented." << endl;
+	    des->errors += 1;
+	    delete array_expr;
+	    return 0;
+      }
+
+      perm_string iter_name;
+      NetNet*iter_net = make_array_method_iter_net_(li, scope, element_type,
+						    parms, iter_name);
+
+      NetNet*idx_net = new NetNet(scope, scope->local_symbol(),
+				  NetNet::REG, &netvector_t::atom2s32);
+      idx_net->set_line(*li);
+      idx_net->local_flag(true);
+
+      NetExpr*val_expr = 0;
+      if (!with_exprs.empty() && with_exprs.front()) {
+	    val_expr = elab_array_method_with_expr_(des, scope,
+						    with_exprs.front(),
+						    iter_name, iter_net);
+	    if (!val_expr) {
+		  delete array_expr;
+		  return 0;
+	    }
+	    if (val_expr->expr_type() != IVL_VT_BOOL
+		&& val_expr->expr_type() != IVL_VT_LOGIC) {
+		  cerr << li->get_fileline() << ": sorry: " << kind
+		       << "() with a non-integral with expression is "
+			  "not yet implemented." << endl;
+		  des->errors += 1;
+		  delete array_expr;
+		  delete val_expr;
+		  return 0;
+	    }
+      } else {
+	    NetESignal*es = new NetESignal(iter_net);
+	    es->set_line(*li);
+	    val_expr = es;
+      }
+
+      unsigned vwid = val_expr->expr_width();
+      if (vwid == 0)
+	    vwid = 32;
+      netvector_t*best_type = new netvector_t(val_expr->expr_type(),
+					      vwid-1, 0, val_expr->has_sign());
+      NetNet*best_net = new NetNet(scope, scope->local_symbol(),
+				   NetNet::REG, best_type);
+      best_net->set_line(*li);
+      best_net->local_flag(true);
+
+      NetNet*bitem_net = new NetNet(scope, scope->local_symbol(),
+				    NetNet::REG, element_type);
+      bitem_net->set_line(*li);
+      bitem_net->local_flag(true);
+
+      netqueue_t*result_qtype = new netqueue_t(element_type, -1, false);
+      NetNet*result_net = new NetNet(scope, scope->local_symbol(),
+				     NetNet::REG, result_qtype);
+      result_net->set_line(*li);
+      result_net->local_flag(true);
+
+      string mangled = string("$ivl_darray_method$minmax|") + kind;
+      NetESFunc*fn = new NetESFunc(mangled.c_str(), IVL_VT_QUEUE, 1, 7);
+      fn->parm(0, array_expr);
+      NetESignal*iter_ref = new NetESignal(iter_net);
+      iter_ref->set_line(*li);
+      fn->parm(1, iter_ref);
+      NetESignal*result_ref = new NetESignal(result_net);
+      result_ref->set_line(*li);
+      fn->parm(2, result_ref);
+      NetESignal*idx_ref = new NetESignal(idx_net);
+      idx_ref->set_line(*li);
+      fn->parm(3, idx_ref);
+      NetESignal*best_ref = new NetESignal(best_net);
+      best_ref->set_line(*li);
+      fn->parm(4, best_ref);
+      NetESignal*bitem_ref = new NetESignal(bitem_net);
+      bitem_ref->set_line(*li);
+      fn->parm(5, bitem_ref);
+      fn->parm(6, val_expr);
+      fn->set_line(*li);
+      return fn;
+}
+
+static inline bool is_array_reduction_name_(perm_string method_name)
+{
+      return method_name == "sum" || method_name == "product"
+	  || method_name == "and" || method_name == "or"
+	  || method_name == "xor";
 }
 
 static int number_elab_trace_enabled_(void)
@@ -6653,6 +6910,17 @@ NetExpr* PECallFunction::elaborate_expr_method_(Design*des, NetScope*scope,
 	    sub_expr = tmp;
 	    if (!target_type)
 		  target_type = search_results.net->net_type();
+	      // A fixed-size unpacked array referenced without an
+	      // index: the method receiver is the array itself
+	      // (IEEE 1800-2017 7.12), not the element type that
+	      // net_type() reports (and that symbol_search copies
+	      // into search_results.type).
+	    if (!target_indexed
+		&& (!search_results.type
+		    || search_results.type == search_results.net->net_type())
+		&& dynamic_cast<const netuarray_t*>(
+			search_results.net->array_type()))
+		  target_type = search_results.net->array_type();
       }
 
       bool applied_root_queue_select = false;
@@ -6831,21 +7099,45 @@ NetExpr* PECallFunction::elaborate_method_dispatch_(Design*des, NetScope*scope,
 	    }
 	    if (NetExpr*tmp = elaborate_assoc_array_compat_method_(des, scope, this, sub_expr, method_name, parms_))
 		  return tmp;
-	    if (method_name == "find") {
-		  // Compile-progress fallback: return null (empty result) rather
-		  // than the whole source queue, to avoid type-mismatch crashes.
+
+	    const netdarray_t*darray =
+		  dynamic_cast<const netdarray_t*>(target_type);
+	    ivl_type_t element_type = darray->element_type();
+
+	    if (is_array_reduction_name_(method_name))
+		  return make_array_reduction_expr_(this, des, scope,
+						    sub_expr, element_type,
+						    method_name.str(), parms_,
+						    with_constraints());
+	    if (method_name == "min" || method_name == "max")
+		  return make_array_minmax_expr_(this, des, scope,
+						 sub_expr, element_type,
+						 method_name.str(), parms_,
+						 with_constraints());
+
+	    if (method_name == "find"
+		|| method_name == "find_index"
+		|| method_name == "find_first"
+		|| method_name == "find_first_index"
+		|| method_name == "find_last"
+		|| method_name == "find_last_index") {
+		    // The locator loop is receiver-agnostic across
+		    // queues and dynamic arrays (7.12.1 applies to any
+		    // unpacked array).
+		  if (!with_constraints().empty()) {
+			NetExpr*loc = make_queue_locator_with_expr_(
+			      this, des, scope, sub_expr, element_type,
+			      method_name.str(), parms_);
+			if (loc) return loc;
+		  }
+		  // Compile-progress fallback: return null (empty result).
 		  delete sub_expr;
 		  NetENull*tmp = new NetENull();
 		  tmp->set_line(*this);
 		  return tmp;
 	    }
       if (method_name == "unique"
-		|| method_name == "unique_index"
-		|| method_name == "find_first"
-		|| method_name == "find_last"
-		|| method_name == "find_index"
-		|| method_name == "find_first_index"
-		|| method_name == "find_last_index") {
+		|| method_name == "unique_index") {
 		  // Compile-progress fallback: return null (empty result).
 		  delete sub_expr;
 		  NetENull*tmp = new NetENull();
@@ -6868,6 +7160,51 @@ NetExpr* PECallFunction::elaborate_method_dispatch_(Design*des, NetScope*scope,
 	  && !target_indexed) {
 	    if (NetExpr*tmp = elaborate_assoc_array_compat_method_(des, scope, this, sub_expr, method_name, parms_))
 		  return tmp;
+
+	      // IEEE 1800-2017 7.12 array manipulation methods apply
+	      // to fixed-size unpacked arrays too; the tgt-vvp loop
+	      // uses the compile-time word count as the bound.  A
+	      // multidimensional receiver iterates sub-arrays (the
+	      // LRM nested-with idiom), which the flat element loop
+	      // cannot model — diagnose instead of mis-iterating.
+	    const netuarray_t*uarray =
+		  dynamic_cast<const netuarray_t*>(target_type);
+	    ivl_type_t element_type = uarray->element_type();
+
+	    if (uarray->static_dimensions().size() > 1
+		&& (is_array_reduction_name_(method_name)
+		    || method_name == "min" || method_name == "max")) {
+		  cerr << get_fileline() << ": sorry: " << method_name
+		       << "() on multidimensional arrays is not yet "
+			  "implemented." << endl;
+		  des->errors += 1;
+		  delete sub_expr;
+		  return 0;
+	    }
+
+	    if (is_array_reduction_name_(method_name))
+		  return make_array_reduction_expr_(this, des, scope,
+						    sub_expr, element_type,
+						    method_name.str(), parms_,
+						    with_constraints());
+	    if (method_name == "min" || method_name == "max")
+		  return make_array_minmax_expr_(this, des, scope,
+						 sub_expr, element_type,
+						 method_name.str(), parms_,
+						 with_constraints());
+
+	    if ((method_name == "find"
+		 || method_name == "find_index"
+		 || method_name == "find_first"
+		 || method_name == "find_first_index"
+		 || method_name == "find_last"
+		 || method_name == "find_last_index")
+		&& !with_constraints().empty()) {
+		  NetExpr*loc = make_queue_locator_with_expr_(
+			this, des, scope, sub_expr, element_type,
+			method_name.str(), parms_);
+		  if (loc) return loc;
+	    }
       }
 
       if (getenv("IVL_FIND_TRACE"))
@@ -6972,6 +7309,32 @@ NetExpr* PECallFunction::elaborate_method_dispatch_(Design*des, NetScope*scope,
 		  NetENull*tmp = new NetENull();
 		  tmp->set_line(*this);
 		  return tmp;
+	    }
+
+	    if (is_array_reduction_name_(method_name)
+		|| method_name == "min" || method_name == "max") {
+		    // Associative arrays are modeled as assoc-compat
+		    // queues, but the runtime loop indexes elements
+		    // positionally, which has no meaning for an AA.
+		  if (queue->assoc_compat()) {
+			cerr << get_fileline() << ": sorry: " << method_name
+			     << "() on associative arrays is not yet "
+				"implemented." << endl;
+			des->errors += 1;
+			delete sub_expr;
+			return 0;
+		  }
+		  if (is_array_reduction_name_(method_name))
+			return make_array_reduction_expr_(this, des, scope,
+							  sub_expr,
+							  element_type,
+							  method_name.str(),
+							  parms_,
+							  with_constraints());
+		  return make_array_minmax_expr_(this, des, scope, sub_expr,
+						 element_type,
+						 method_name.str(), parms_,
+						 with_constraints());
 	    }
 
 	    cerr << get_fileline() << ": error: Method " << method_name
@@ -9095,6 +9458,47 @@ NetExpr* PEIdent::elaborate_expr_(Design*des, NetScope*scope,
                   }
                   scope->is_const_func(false);
             }
+
+	      // IEEE 1800-2017 7.12 array reduction and min/max methods
+	      // in the paren-less form (y = b.sum;) parse as a plain
+	      // member path rather than a call; route them to the same
+	      // machinery as the call forms.  Only hijack the name
+	      // when the receiver really is an array of integral
+	      // elements, so struct/class member paths are untouched.
+	    if (sr.path_tail.size() == 1
+		&& sr.path_tail.front().index.empty()
+		&& !sr.path_head.empty()
+		&& sr.path_head.back().index.empty()) {
+		  perm_string mname = sr.path_tail.front().name;
+		  bool is_red = is_array_reduction_name_(mname);
+		  bool is_mm = (mname == "min" || mname == "max");
+		  if (is_red || is_mm) {
+			ivl_type_t etype = 0;
+			if (const netqueue_t*qt = sr.net->queue_type()) {
+			      if (!qt->assoc_compat())
+				    etype = qt->element_type();
+			} else if (const netdarray_t*dt = sr.net->darray_type()) {
+			      etype = dt->element_type();
+			} else if (sr.net->unpacked_dimensions() == 1
+				   && dynamic_cast<const netuarray_t*>(sr.net->array_type())) {
+			      etype = sr.net->array_type()->element_type();
+			}
+			if (etype && (etype->base_type() == IVL_VT_BOOL
+				      || etype->base_type() == IVL_VT_LOGIC)) {
+			      NetESignal*recv = new NetESignal(sr.net);
+			      recv->set_line(*this);
+			      static const std::vector<named_pexpr_t> no_parms;
+			      static const std::vector<PExpr*> no_with;
+			      if (is_red)
+				    return make_array_reduction_expr_(
+					  this, des, scope, recv, etype,
+					  mname.str(), no_parms, no_with);
+			      return make_array_minmax_expr_(
+				    this, des, scope, recv, etype,
+				    mname.str(), no_parms, no_with);
+			}
+		  }
+	    }
 
 	      // If this is a struct, and there are members in the
 	      // member_path, then generate an expression that

--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -3485,6 +3485,12 @@ classify_compile_progress_expr_method_stub_(const pform_name_t&use_path,
 		  return CP_EXPR_METHOD_STUB_INT0;
 
 	    perm_string class_name = class_type->get_name();
+	      // The built-in process class has a REAL status()
+	      // implementation ($ivl_process$status, IEEE 1800-2017
+	      // 9.7) — never stub it to a constant.
+	    if (class_name == perm_string::literal("process")
+		&& method_name == perm_string::literal("status"))
+		  return CP_EXPR_METHOD_STUB_NONE;
 	    if (class_name == perm_string::literal("mailbox")) {
 		  if (method_name == perm_string::literal("num"))
 			return CP_EXPR_METHOD_STUB_INT0;
@@ -5829,6 +5835,25 @@ NetExpr* PEIdent::elaborate_expr_class_field_(Design*des, NetScope*scope,
 		  const netclass_t*cur_class = dynamic_cast<const netclass_t*>(cur_type);
 		  const netstruct_t*cur_struct = dynamic_cast<const netstruct_t*>(cur_type);
 		  
+		    // IEEE 1800-2017 9.7: process.status in paren-less
+		    // form queries the live process state (used inside
+		    // array-method with predicates, e.g. the UVM
+		    // sequencer zombie check).  It must not read the
+		    // placeholder property slot, which nothing writes.
+		  if (cur_class && gn_system_verilog()
+		      && tail_comp.index.empty()
+		      && tail_comp.name == perm_string::literal("status")
+		      && cur_class->get_name() == perm_string::literal("process")
+		      && cur_class->method_from_name(tail_comp.name) == 0) {
+			NetESFunc*sfunc = new NetESFunc("$ivl_process$status",
+							&netvector_t::atom2s32, 1);
+			sfunc->set_line(*this);
+			sfunc->parm(0, base_expr);
+			base_expr = sfunc;
+			cur_type = &netvector_t::atom2s32;
+			continue;
+		  }
+
 		  if (cur_struct && gn_system_verilog()) {
 			    // Handle struct member access after array indexing
 			if (!tail_comp.index.empty()) {
@@ -7609,10 +7634,13 @@ NetExpr* PECallFunction::elaborate_method_dispatch_(Design*des, NetScope*scope,
 				delete sub_expr;
 				return 0;
 			  }
-			  int pidx = class_type->property_idx_from_name(method_name);
-			  ivl_assert(*this, pidx >= 0);
-			  NetEProperty*tmp = new NetEProperty(sub_expr, pidx, 0);
+			    // IEEE 1800-2017 9.7: status() queries the
+			    // live process state; it is not a stored
+			    // property.
+			  NetESFunc*tmp = new NetESFunc("$ivl_process$status",
+							&netvector_t::atom2s32, 1);
 			  tmp->set_line(*this);
+			  tmp->parm(0, sub_expr);
 			  return tmp;
 		    }
 		    if (method_name == perm_string::literal("get_randstate")
@@ -10424,6 +10452,26 @@ NetExpr* PEIdent::elaborate_expr_(Design*des, NetScope*scope,
 	    if (rewrite_interface_clocking_member_path_via_scope_(this, sr, rewritten)) {
 		  PEIdent mapped(rewritten, lexical_pos_);
 		  return mapped.elaborate_expr(des, scope, expr_wid, flags);
+	    }
+      }
+
+	// Built-in process state enum constants (IEEE 1800-2017 9.7)
+	// that arrive as an unresolved two-component reference
+	// (process::KILLED parses the same as process.KILLED here).
+      if (gn_system_verilog() && path_.size() == 2
+	  && path_.name.front().index.empty()
+	  && path_.name.back().index.empty()
+	  && peek_head_name(path_) == perm_string::literal("process")) {
+	    perm_string state_name = path_.name.back().name;
+	    if (state_name == perm_string::literal("FINISHED")
+		|| state_name == perm_string::literal("RUNNING")
+		|| state_name == perm_string::literal("WAITING")
+		|| state_name == perm_string::literal("SUSPENDED")
+		|| state_name == perm_string::literal("KILLED")) {
+		  NetEConst*tmp = make_const_val(
+			builtin_process_state_value_(state_name));
+		  tmp->set_line(*this);
+		  return tmp;
 	    }
       }
 

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -5607,6 +5607,26 @@ NetProc* PCallTask::elaborate_receiver_method_(Design*des, NetScope*scope) const
       return elaborate_build_call_(des, scope, task, sub_expr);
 }
 
+/* IEEE 1800-2017 7.12.2 ordering methods on non-signal object
+ * receivers (class properties, nested chains): the runtime opcodes
+ * take a signal label, so the code generator first stores the
+ * receiver handle into a hidden container-typed net.  Mutation
+ * through the alias reaches the property because queue/darray
+ * variables hold the container by handle. */
+static NetNet* make_ordering_method_recv_net_(const LineInfo*li,
+					      NetScope*scope,
+					      NetExpr*obj_expr,
+					      ivl_type_t obj_type)
+{
+      if (dynamic_cast<NetESignal*>(obj_expr))
+	    return 0;
+      NetNet*recv = new NetNet(scope, scope->local_symbol(),
+			       NetNet::REG, obj_type);
+      recv->set_line(*li);
+      recv->local_flag(true);
+      return recv;
+}
+
 NetProc* PCallTask::elaborate_method_(Design*des, NetScope*scope,
 				      bool add_this_flag) const
 {
@@ -5848,8 +5868,15 @@ NetProc* PCallTask::elaborate_method_(Design*des, NetScope*scope,
 			    } else if (method_name == "reverse") {
 				  if (gn_system_verilog()) {
 					/* Phase 63b/Q-methods (gap close): wire to %qreverse. */
-					vector<NetExpr*> argv(1);
+					NetNet*recv_net = make_ordering_method_recv_net_(
+					      this, scope, obj_expr, obj_type);
+					vector<NetExpr*> argv(recv_net ? 2 : 1);
 					argv[0] = obj_expr;
+					if (recv_net) {
+					      NetESignal*recv_e = new NetESignal(recv_net);
+					      recv_e->set_line(*this);
+					      argv[1] = recv_e;
+					}
 					NetSTask*sys = new NetSTask("$ivl_queue_method$reverse",
 								    IVL_SFUNC_AS_TASK_IGNORE, argv);
 					sys->set_line(*this);
@@ -5886,32 +5913,45 @@ NetProc* PCallTask::elaborate_method_(Design*des, NetScope*scope,
 								if (ip->path().size() == 1)
 								      iter_name = ip->path().back().name;
 						    }
-						    NetNet*iter_net = scope->find_signal(iter_name);
-						    if (!iter_net) {
-							  iter_net = new NetNet(scope, iter_name,
-										NetNet::REG, element_type);
-							  iter_net->set_line(*this);
-							  iter_net->local_flag(true);
-						    }
-						    /* Allocate a keys queue (vec4 32-bit) — predicate
-						       result is stored here for paired sort. */
-						    netqueue_t*keys_qtype = new netqueue_t(
-							  &netvector_t::atom2s32, -1, false);
-						    NetNet*keys_net = new NetNet(scope, scope->local_symbol(),
-										 NetNet::REG, keys_qtype);
-						    keys_net->set_line(*this);
-						    keys_net->local_flag(true);
+						    /* Fresh, uniquely named iterator net per call,
+						       bound to the user-visible name only while the
+						       with expression elaborates (7.12: the iterator
+						       is scoped to the with expression). */
+						    NetNet*iter_net = new NetNet(scope, scope->local_symbol(),
+										 NetNet::REG, element_type);
+						    iter_net->set_line(*this);
+						    iter_net->local_flag(true);
 						    /* Loop-counter NetNet (s32) for the inline key-build loop. */
 						    NetNet*idx_net = new NetNet(scope, scope->local_symbol(),
 										NetNet::REG, &netvector_t::atom2s32);
 						    idx_net->set_line(*this);
 						    idx_net->local_flag(true);
 						    PExpr*pred_pe = with_constraints().front();
-						    NetExpr*pred_expr = pred_pe
-							  ? elab_and_eval(des, scope, pred_pe, -1, false)
-							  : nullptr;
+						    NetExpr*pred_expr = nullptr;
+						    if (pred_pe) {
+							  NetNet*prev_bind =
+								scope->set_signal_alias(iter_name, iter_net);
+							  pred_expr = elab_and_eval(des, scope, pred_pe, -1, false);
+							  scope->restore_signal_alias(iter_name, prev_bind);
+						    }
 						    if (pred_expr) {
-							  vector<NetExpr*> argv(5);
+							  /* Keys queue typed by the with expression
+							     (7.12.2: the relational operators shall be
+							     defined for the type of the expression). */
+							  ivl_type_t key_elem = &netvector_t::atom2s32;
+							  if (pred_expr->expr_type() == IVL_VT_STRING)
+								key_elem = &netstring_t::type_string;
+							  else if (pred_expr->expr_type() == IVL_VT_REAL)
+								key_elem = &netreal_t::type_real;
+							  netqueue_t*keys_qtype = new netqueue_t(
+								key_elem, -1, false);
+							  NetNet*keys_net = new NetNet(scope, scope->local_symbol(),
+										       NetNet::REG, keys_qtype);
+							  keys_net->set_line(*this);
+							  keys_net->local_flag(true);
+							  NetNet*recv_net = make_ordering_method_recv_net_(
+								this, scope, obj_expr, obj_type);
+							  vector<NetExpr*> argv(recv_net ? 6 : 5);
 							  argv[0] = obj_expr;
 							  NetESignal*iter_e = new NetESignal(iter_net);
 							  iter_e->set_line(*this);
@@ -5923,6 +5963,11 @@ NetProc* PCallTask::elaborate_method_(Design*des, NetScope*scope,
 							  idx_e->set_line(*this);
 							  argv[3] = idx_e;
 							  argv[4] = pred_expr;
+							  if (recv_net) {
+								NetESignal*recv_e = new NetESignal(recv_net);
+								recv_e->set_line(*this);
+								argv[5] = recv_e;
+							  }
 							  string sys_name = string("$ivl_queue_method$") +
 								(method_name == "sort"  ? "sort_with"
 								 : method_name == "rsort" ? "rsort_with"
@@ -5936,8 +5981,15 @@ NetProc* PCallTask::elaborate_method_(Design*des, NetScope*scope,
 					      }
 					}
 					/* No with-clause (or fallback): default compare. */
-					vector<NetExpr*> argv(1);
+					NetNet*recv_net = make_ordering_method_recv_net_(
+					      this, scope, obj_expr, obj_type);
+					vector<NetExpr*> argv(recv_net ? 2 : 1);
 					argv[0] = obj_expr;
+					if (recv_net) {
+					      NetESignal*recv_e = new NetESignal(recv_net);
+					      recv_e->set_line(*this);
+					      argv[1] = recv_e;
+					}
 					const char*sys_name =
 					      (method_name == "sort")  ? "$ivl_queue_method$sort"  :
 					      (method_name == "rsort") ? "$ivl_queue_method$rsort" :
@@ -5958,8 +6010,15 @@ NetProc* PCallTask::elaborate_method_(Design*des, NetScope*scope,
 			    } else if (method_name=="shuffle") {
 				  if (gn_system_verilog()) {
 					/* Phase 63b/Q-methods (gap close): wire to %qshuffle. */
-					vector<NetExpr*> argv(1);
+					NetNet*recv_net = make_ordering_method_recv_net_(
+					      this, scope, obj_expr, obj_type);
+					vector<NetExpr*> argv(recv_net ? 2 : 1);
 					argv[0] = obj_expr;
+					if (recv_net) {
+					      NetESignal*recv_e = new NetESignal(recv_net);
+					      recv_e->set_line(*this);
+					      argv[1] = recv_e;
+					}
 					NetSTask*sys = new NetSTask("$ivl_queue_method$shuffle",
 								    IVL_SFUNC_AS_TASK_IGNORE, argv);
 					sys->set_line(*this);

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -3394,22 +3394,6 @@ NetProc* PAssign::elaborate_compressed_(Design*des, NetScope*scope) const
       return cur;
 }
 
-/*
- * Assignments within program blocks are supposed to be run
- * in the Reactive region, but that is currently not supported
- * so find out if we are assigning to something outside a
- * program block and print a warning for that.
- */
-static bool lval_not_program_variable(const NetAssign_*lv)
-{
-      while (lv) {
-	    const NetScope*sig_scope = lv->scope();
-	    if (! sig_scope->program_block()) return true;
-	    lv = lv->more;
-      }
-      return false;
-}
-
 /* Phase 63b/B7 (gap close): when assigning a tagged-union constructor
  * `u = '{TAG: val}` (or equivalently `u = tagged TAG val`), build a
  * NetAssign that updates the companion tag NetNet to the member index.
@@ -3593,12 +3577,7 @@ NetProc* PAssign::elaborate(Design*des, NetScope*scope) const
       NetAssign_*lv = elaborate_lval(des, scope);
       if (lv == 0) return 0;
 
-      if (scope->program_block() && lval_not_program_variable(lv)) {
-	    cerr << get_fileline() << ": warning: Program blocking "
-	            "assignments are not currently scheduled in the "
-	            "Reactive region."
-	         << endl;
-      }
+
 
 	/* If there is an internal delay expression, elaborate it. */
       NetExpr*delay = 0;
@@ -3923,12 +3902,6 @@ NetProc* PAssignNB::elaborate(Design*des, NetScope*scope) const
       NetAssign_*lv = elaborate_lval(des, scope);
       if (lv == 0) return 0;
 
-      if (scope->program_block() && lval_not_program_variable(lv)) {
-	    cerr << get_fileline() << ": warning: Program non-blocking "
-	            "assignments are not currently scheduled in the "
-	            "Reactive-NBA region."
-	         << endl;
-      }
 
       NetExpr*rv = elaborate_rval_(des, scope, lv->net_type(), lv->expr_type(), count_lval_width(lv));
       if (rv == 0) return 0;

--- a/ivl.def
+++ b/ivl.def
@@ -222,6 +222,7 @@ ivl_scope_func_signed
 ivl_scope_func_width
 ivl_scope_is_auto
 ivl_scope_is_cell
+ivl_scope_program
 ivl_scope_lineno
 ivl_scope_logs
 ivl_scope_log

--- a/ivl_target.h
+++ b/ivl_target.h
@@ -1903,6 +1903,10 @@ extern unsigned     ivl_scope_events(ivl_scope_t net);
 extern ivl_event_t  ivl_scope_event(ivl_scope_t net, unsigned idx);
 extern const char* ivl_scope_file(ivl_scope_t net);
 extern unsigned ivl_scope_is_auto(ivl_scope_t net);
+  /* Return true if the scope is (or is inside) a program block
+     (IEEE 1800-2017 clause 24); program processes schedule in the
+     Reactive region set. */
+extern unsigned ivl_scope_program(ivl_scope_t net);
 extern unsigned ivl_scope_is_cell(ivl_scope_t net);
 extern unsigned ivl_scope_lineno(ivl_scope_t net);
 extern unsigned     ivl_scope_logs(ivl_scope_t net);

--- a/net_scope.cc
+++ b/net_scope.cc
@@ -905,6 +905,21 @@ NetNet* NetScope::find_signal(perm_string key)
       return it != signals_map_.end()? it->second : 0;
 }
 
+NetNet* NetScope::set_signal_alias(perm_string name, NetNet*net)
+{
+      NetNet*prev = find_signal(name);
+      signals_map_[name] = net;
+      return prev;
+}
+
+void NetScope::restore_signal_alias(perm_string name, NetNet*prev)
+{
+      if (prev)
+	    signals_map_[name] = prev;
+      else
+	    signals_map_.erase(name);
+}
+
 typedef_t* NetScope::find_typedef(const Design*des, perm_string name)
 {
       map<perm_string,typedef_t*>::const_iterator cache_td = typedef_search_cache_.find(name);

--- a/netlist.h
+++ b/netlist.h
@@ -1044,6 +1044,15 @@ class NetScope : public Definitions, public Attrib {
       void rem_signal(NetNet*);
       NetNet* find_signal(perm_string name);
 
+	// Temporarily bind `name' to a differently-named signal, so
+	// that find_signal (and thus symbol_search) resolves the name
+	// to it.  Used for the iterator binding of array-method with
+	// expressions (IEEE 1800-2017 7.12: "The scope for the
+	// iterator_argument is the with expression").  Returns the
+	// previously bound signal (or nil) for restore_signal_alias.
+      NetNet* set_signal_alias(perm_string name, NetNet*net);
+      void restore_signal_alias(perm_string name, NetNet*prev);
+
       // I2 (Phase 62m): post-elab fix-up pass.  Iterates signals_map_
       // and replaces the net_type of NetNets that were emitted with a
       // logic-vector fallback (because their typeref'd class had not

--- a/parse.y
+++ b/parse.y
@@ -1376,14 +1376,17 @@ Module::port_t *module_declare_port(const YYLTYPE&loc, char *id,
 %nonassoc K_PLUS_EQ K_MINUS_EQ K_MUL_EQ K_DIV_EQ K_MOD_EQ K_AND_EQ K_OR_EQ
 %nonassoc K_XOR_EQ K_LS_EQ K_RS_EQ K_RSS_EQ K_NB_TRIGGER
 %right K_TRIGGER K_LEQUIV
-%right '?' ':' K_inside
+%right '?' ':'
 %left K_LOR
 %left K_LAND
 %left '|'
 %left '^' K_NXOR K_NOR
 %left '&' K_NAND
 %left K_EQ K_NE K_CEQ K_CNE K_WEQ K_WNE
-%left K_GE K_LE '<' '>'
+  /* IEEE 1800-2017 Table 11-2: inside sits at the relational level,
+     binding tighter than equality/&&/|| (a && b inside {c,d} parses
+     as a && (b inside {c,d})). */
+%left K_GE K_LE '<' '>' K_inside
 %left K_LS K_RS K_RSS
 %left '+' '-'
 %left '*' '/' '%'

--- a/parse.y
+++ b/parse.y
@@ -86,6 +86,35 @@ static stack<PBlock*> current_block_stack;
    specified. */
 static LexicalScope::lifetime_t var_lifetime;
 
+/* IEEE 1800-2017 7.12: build a method-call expression for the
+   keyword-named array methods (and/or/xor), which the generic
+   function-call and with-clause rules cannot match.  args may be
+   null (the paren-less with form); with_expr may be null (the plain
+   call form).  Consumes path and args. */
+static PECallFunction* pform_keyword_method_call(const struct vlltype&loc,
+                                                 pform_name_t*path,
+                                                 const char*method,
+                                                 std::list<named_pexpr_t>*args,
+                                                 PExpr*with_expr)
+{
+      path->push_back(name_component_t(lex_strings.make(method)));
+      PECallFunction*tmp;
+      if (args) {
+            tmp = pform_make_call_function(loc, *path, *args);
+            delete args;
+      } else {
+            std::list<named_pexpr_t> empty_args;
+            tmp = pform_make_call_function(loc, *path, empty_args);
+      }
+      if (with_expr) {
+            std::vector<PExpr*> wc;
+            wc.push_back(with_expr);
+            tmp->set_with_constraints(std::move(wc));
+      }
+      delete path;
+      return tmp;
+}
+
 /* Streaming concatenation (IEEE 1800-2017 11.4.14): the operand list
    {e1, e2, ...} concatenates left-to-right into one bit stream, so a
    multi-operand stream is represented as an ordinary concatenation.
@@ -7049,6 +7078,20 @@ expr_primary
 	$$ = tmp;
 	delete nm;
       }
+  /* IEEE 1800-2017 7.12.3: the and()/or()/xor() reduction methods are
+     keywords, so the generic function-call and with-clause rules
+     cannot match them.  Each keyword gets a call form, a call+with
+     form and a paren-less with form. */
+  | hierarchy_identifier '.' K_and argument_list_parens
+      { $$ = pform_keyword_method_call(@1, $1, "and", $4, 0); }
+  | hierarchy_identifier '.' K_and argument_list_parens K_with '(' expression ')'
+      { pform_requires_sv(@5, "Method with-clause");
+	$$ = pform_keyword_method_call(@1, $1, "and", $4, $7);
+      }
+  | hierarchy_identifier '.' K_and K_with '(' expression ')'
+      { pform_requires_sv(@4, "Method with-clause (no args)");
+	$$ = pform_keyword_method_call(@1, $1, "and", 0, $6);
+      }
   | hierarchy_identifier '.' K_or
       { pform_name_t * nm = $1;
 	nm->push_back(name_component_t(lex_strings.make("or")));
@@ -7056,6 +7099,16 @@ expr_primary
 	FILE_NAME(tmp, @1);
 	$$ = tmp;
 	delete nm;
+      }
+  | hierarchy_identifier '.' K_or argument_list_parens
+      { $$ = pform_keyword_method_call(@1, $1, "or", $4, 0); }
+  | hierarchy_identifier '.' K_or argument_list_parens K_with '(' expression ')'
+      { pform_requires_sv(@5, "Method with-clause");
+	$$ = pform_keyword_method_call(@1, $1, "or", $4, $7);
+      }
+  | hierarchy_identifier '.' K_or K_with '(' expression ')'
+      { pform_requires_sv(@4, "Method with-clause (no args)");
+	$$ = pform_keyword_method_call(@1, $1, "or", 0, $6);
       }
   | hierarchy_identifier '.' K_unique argument_list_parens
       { pform_name_t *nm = $1;
@@ -7092,6 +7145,16 @@ expr_primary
 	FILE_NAME(tmp, @1);
 	$$ = tmp;
 	delete nm;
+      }
+  | hierarchy_identifier '.' K_xor argument_list_parens
+      { $$ = pform_keyword_method_call(@1, $1, "xor", $4, 0); }
+  | hierarchy_identifier '.' K_xor argument_list_parens K_with '(' expression ')'
+      { pform_requires_sv(@5, "Method with-clause");
+	$$ = pform_keyword_method_call(@1, $1, "xor", $4, $7);
+      }
+  | hierarchy_identifier '.' K_xor K_with '(' expression ')'
+      { pform_requires_sv(@4, "Method with-clause (no args)");
+	$$ = pform_keyword_method_call(@1, $1, "xor", 0, $6);
       }
 
   | package_scope hierarchy_identifier

--- a/t-dll-api.cc
+++ b/t-dll-api.cc
@@ -2249,6 +2249,12 @@ extern "C" unsigned ivl_scope_is_auto(ivl_scope_t net)
       return net->is_auto;
 }
 
+extern "C" unsigned ivl_scope_program(ivl_scope_t net)
+{
+      assert(net);
+      return net->is_program;
+}
+
 extern "C" int ivl_scope_is_dpi_import(ivl_scope_t net)
 {
       assert(net);

--- a/t-dll.cc
+++ b/t-dll.cc
@@ -654,6 +654,7 @@ void dll_target::add_root(const NetScope *s)
       root_->nattr = s->attr_cnt();
       root_->attr  = fill_in_attributes(s);
       root_->is_auto = 0;
+      root_->is_program = s->program_block();
       root_->is_cell = s->is_cell();
       switch (s->type()) {
 	  case NetScope::PACKAGE:
@@ -2576,6 +2577,7 @@ void dll_target::scope(const NetScope*net)
 	    scop->nattr = net->attr_cnt();
 	    scop->attr = fill_in_attributes(net);
 	    scop->is_auto = net->is_auto();
+	    scop->is_program = net->program_block();
 	    scop->is_cell = net->is_cell();
 	    scop->is_virtual_method = net->is_virtual_method();
 

--- a/t-dll.h
+++ b/t-dll.h
@@ -714,6 +714,7 @@ struct ivl_scope_s {
 	/* Scopes that are tasks/functions have a definition. */
       ivl_statement_t def;
       unsigned is_auto;
+      unsigned is_program;
       ivl_variable_type_t func_type;
       bool func_signed;
       unsigned func_width;

--- a/tests/g10_array_methods_test.sv
+++ b/tests/g10_array_methods_test.sv
@@ -5,6 +5,36 @@
 // forms, including the keyword-named methods (and/or/xor) and
 // per-call iterator binding ("The scope for the iterator_argument is
 // the with expression").
+// Class-property receivers (the dominant UVM shape): the loop cannot
+// index a property directly, so the code generator evaluates the
+// receiver object once into a hidden container net.
+class g10_stats;
+  int q[$];
+  byte d[];
+endclass
+
+class g10_cfg;
+  g10_stats st;
+  function new; st = new; endfunction
+endclass
+
+class g10_scoreboard;
+  int q[$];
+  function int get_sum(); return q.sum(); endfunction
+  function int get_sum_parenless(); return q.sum; endfunction
+  function int get_sumw(); return q.sum() with (item * 2); endfunction
+  function int get_max();
+    int mq[$];
+    mq = q.max();
+    return mq[0];
+  endfunction
+  function int get_fidx_count();
+    int idxq[$];
+    idxq = q.find_index() with (item > 1);
+    return idxq.size();
+  endfunction
+endclass
+
 module g10_array_methods_test;
   int errors = 0;
 
@@ -99,6 +129,34 @@ module g10_array_methods_test;
       check("shadowed item sum", y, 50);
       check("user item preserved", item, 99);
       qe.delete();
+    end
+
+    // class-property receivers: method-internal, external, nested
+    // chains, paren-less, with-clause, locators, empties
+    begin
+      automatic g10_scoreboard sb = new;
+      automatic g10_cfg cfg = new;
+      automatic int mq2[$];
+      sb.q.push_back(3); sb.q.push_back(1); sb.q.push_back(2);
+      check("prop q.sum()", sb.get_sum(), 6);
+      check("prop q.sum parenless", sb.get_sum_parenless(), 6);
+      check("prop q.sum with", sb.get_sumw(), 12);
+      check("prop q.max", sb.get_max(), 3);
+      check("prop find_index with", sb.get_fidx_count(), 2);
+      check("ext prop sum", sb.q.sum(), 6);
+      check("ext prop sum parenless", sb.q.sum, 6);
+
+      cfg.st.q.push_back(4); cfg.st.q.push_back(5);
+      cfg.st.d = new[3];
+      cfg.st.d[0] = 1; cfg.st.d[1] = 2; cfg.st.d[2] = 3;
+      check("nested prop q.sum", cfg.st.q.sum(), 9);
+      check("nested prop d.sum with", cfg.st.d.sum() with (item * 2), 12);
+      check("nested prop q.and", cfg.st.q.and(), 4);
+      mq2 = cfg.st.q.max();
+      check("nested prop q.max", mq2[0], 5);
+      mq2 = cfg.st.q.find() with (item > 4);
+      check("nested prop find size", mq2.size(), 1);
+      check("nested prop find val", mq2[0], 5);
     end
 
     if (errors == 0) $display("PASS");

--- a/tests/g10_array_methods_test.sv
+++ b/tests/g10_array_methods_test.sv
@@ -1,0 +1,108 @@
+// G10: array manipulation methods (IEEE 1800-2017 7.12) — reduction
+// methods (7.12.3: sum, product, and, or, xor) and the min()/max()
+// locators (7.12.1) over queues, dynamic arrays and fixed-size
+// unpacked arrays, in call, call-with, paren-less and paren-less-with
+// forms, including the keyword-named methods (and/or/xor) and
+// per-call iterator binding ("The scope for the iterator_argument is
+// the with expression").
+module g10_array_methods_test;
+  int errors = 0;
+
+  byte b[];
+  int q[$];
+  int d[];
+  int f[5];
+  logic [7:0] u[$];
+  int d2[];       // stays empty
+  int qe[$];      // stays empty
+  int mq[$];
+  logic [7:0] uq[$];
+  int idxq[$];
+  bit bit_arr [10];
+  int y;
+
+  task check(string what, int got, int exp);
+    if (got !== exp) begin
+      $display("FAIL %s: got %0d expect %0d", what, got, exp);
+      errors++;
+    end
+  endtask
+
+  initial begin
+    // LRM 7.12.3 literal examples: byte b[] = { 1, 2, 3, 4 };
+    b = new[4]; b[0] = 1; b[1] = 2; b[2] = 3; b[3] = 4;
+    y = b.sum;                    check("b.sum", y, 10);
+    y = b.product;                check("b.product", y, 24);
+    y = b.xor with (item + 4);    check("b.xor with", y, 12); // 5^6^7^8
+
+    // queue reductions, call and with forms
+    q.push_back(3); q.push_back(1); q.push_back(2);
+    y = q.sum();                  check("q.sum()", y, 6);
+    y = q.sum() with (item * 2);  check("q.sum() with", y, 12);
+    y = q.sum(x) with (x * 3);    check("q.sum(x) with", y, 18);
+
+    // keyword-named methods: call, call-with, paren-less-with
+    q.delete(); q.push_back(12); q.push_back(10);
+    y = q.and();                  check("q.and()", y, 8);
+    y = q.or();                   check("q.or()", y, 14);
+    y = q.xor();                  check("q.xor()", y, 6);
+    y = q.and() with (item | 1);  check("q.and() with", y, 9);
+    y = q.xor with (item);        check("q.xor with", y, 6);
+
+    // dynamic array reductions
+    d = new[3]; d[0] = 3; d[1] = 1; d[2] = 2;
+    y = d.sum();                  check("d.sum()", y, 6);
+    y = d.product();              check("d.product()", y, 6);
+    y = d.sum() with (item * 2);  check("d.sum() with", y, 12);
+
+    // fixed-size array reductions and locators
+    f[0] = 3; f[1] = 1; f[2] = 2; f[3] = 5; f[4] = 4;
+    y = f.sum();                  check("f.sum()", y, 15);
+    y = f.sum;                    check("f.sum", y, 15);
+    mq = f.max();                 check("f.max()", mq[0], 5);
+    mq = f.min();                 check("f.min()", mq[0], 1);
+    idxq = f.find_index() with (item > 2);
+    check("f.find_index size", idxq.size(), 3);
+    check("f.find_index [0]", idxq[0], 0);
+
+    // min/max: signed elements, empty arrays, with-clause remap
+    q.delete(); q.push_back(-5); q.push_back(3); q.push_back(-7);
+    mq = q.min();                 check("q.min signed", mq[0], -7);
+    mq = q.max();                 check("q.max signed", mq[0], 3);
+    y = q.sum();                  check("q.sum signed", y, -9);
+    mq = q.max() with (-item);    check("q.max with -item", mq[0], -7);
+    mq = d.max();                 check("d.max()", mq[0], 3);
+    mq = d.min();                 check("d.min()", mq[0], 1);
+
+    // unsigned element comparison (F0 > 0F unsigned; -16 < 15 signed)
+    u.push_back(8'hF0); u.push_back(8'h0F);
+    uq = u.max();                 check("u.max unsigned", uq[0], 8'hF0);
+
+    // empty arrays: sum identity 0, product identity 1, empty queue
+    y = d2.sum();                 check("empty d.sum", y, 0);
+    y = qe.product();             check("empty q.product", y, 1);
+    mq = qe.max();                check("empty q.max size", mq.size(), 0);
+
+    // per-call iterator binding: bit elements after byte elements in
+    // the same scope must not reuse the byte-typed hidden iterator
+    // (LRM: the iterator argument is scoped to the with expression).
+    bit_arr[1] = 1; bit_arr[3] = 1; bit_arr[7] = 1;
+    y = bit_arr.sum with (int'(item));
+    check("bit_arr.sum with cast", y, 3);
+
+    // a user variable named `item` is shadowed by the iterator inside
+    // the with expression and must survive the loop unmodified
+    begin
+      automatic int item = 99;
+      qe.push_back(2); qe.push_back(3);
+      y = qe.sum() with (item * 10);
+      check("shadowed item sum", y, 50);
+      check("user item preserved", item, 99);
+      qe.delete();
+    end
+
+    if (errors == 0) $display("PASS");
+    else $display("%0d checks failed", errors);
+    $finish;
+  end
+endmodule

--- a/tests/g10_ordering_methods_test.sv
+++ b/tests/g10_ordering_methods_test.sv
@@ -1,0 +1,116 @@
+// G10 (7.12.2): array ordering methods — sort, rsort, reverse,
+// shuffle — including the shapes UVM depends on: class-property
+// receivers (previously a SILENT NO-OP), string sort keys from with
+// expressions (previously truncated to 32 bits, so long keys with a
+// common prefix like get_full_name() paths mis-sorted silently), real
+// keys, and per-call iterator binding.
+class g10_comp;
+  string nm;
+  int id;
+  real w;
+  function new(string s, int i, real r); nm = s; id = i; w = r; endfunction
+  function string get_full_name(); return nm; endfunction
+endclass
+
+class g10_env;
+  g10_comp cq[$];
+  int iq[$];
+  function void isort(); iq.sort(); endfunction
+endclass
+
+module g10_ordering_methods_test;
+  int errors = 0;
+  int q[$];
+  string sq[$];
+  byte d[];
+  g10_env e;
+  g10_comp t;
+
+  task check(string what, int got, int exp);
+    if (got !== exp) begin
+      $display("FAIL %s: got %0d expect %0d", what, got, exp);
+      errors++;
+    end
+  endtask
+  task scheck(string what, string got, string exp);
+    if (got != exp) begin
+      $display("FAIL %s: got %s expect %s", what, got, exp);
+      errors++;
+    end
+  endtask
+
+  initial begin
+    // LRM 7.12.2 examples: plain sort ascending, queue of int
+    q.push_back(4); q.push_back(5); q.push_back(3); q.push_back(1);
+    q.sort;
+    check("q.sort[0]", q[0], 1); check("q.sort[3]", q[3], 5);
+    q.rsort();
+    check("q.rsort[0]", q[0], 5); check("q.rsort[3]", q[3], 1);
+    q.reverse();
+    check("q.reverse[0]", q[0], 1); check("q.reverse[3]", q[3], 5);
+    q.shuffle();
+    check("q.shuffle size", q.size(), 4);
+    check("q.shuffle sum", q.sum(), 13);
+
+    // LRM string example: s.reverse / sort on string elements
+    sq.push_back("world"); sq.push_back("sad"); sq.push_back("hello");
+    sq.sort;
+    scheck("sq.sort[0]", sq[0], "hello");
+    scheck("sq.sort[2]", sq[2], "world");
+    sq.reverse();
+    scheck("sq.reverse[0]", sq[0], "world");
+
+    // dynamic array receiver
+    d = new[3]; d[0] = 9; d[1] = 2; d[2] = 5;
+    d.sort;
+    check("d.sort[0]", d[0], 2); check("d.sort[2]", d[2], 9);
+
+    // class-property receivers (previously silently unsorted)
+    e = new;
+    e.iq.push_back(3); e.iq.push_back(1); e.iq.push_back(2);
+    e.isort();
+    check("prop sort internal", e.iq[0], 1);
+    e.iq.push_back(0);
+    e.iq.sort();
+    check("prop sort external", e.iq[0], 0);
+    e.iq.rsort();
+    check("prop rsort", e.iq[0], 3);
+    e.iq.reverse();
+    check("prop reverse", e.iq[0], 0);
+    e.iq.shuffle();
+    check("prop shuffle sum", e.iq.sum(), 6);
+
+    // string keys longer than 32 bits with a common prefix (the
+    // get_full_name() shape) — previously mis-sorted silently
+    t = new("uvm_test_top.env.zebra", 3, 0.5); e.cq.push_back(t);
+    t = new("uvm_test_top.env.alpha", 1, 2.5); e.cq.push_back(t);
+    t = new("uvm_test_top.env.mike",  2, 1.5); e.cq.push_back(t);
+    e.cq.sort() with (item.get_full_name());
+    check("strkey sort", e.cq[0].id, 1);
+    check("strkey sort last", e.cq[2].id, 3);
+    e.cq.rsort() with (item.nm);
+    check("strkey rsort", e.cq[0].id, 3);
+
+    // real keys
+    e.cq.sort() with (item.w);
+    check("realkey sort", e.cq[0].id, 3);   // w=0.5
+    check("realkey sort last", e.cq[2].id, 1); // w=2.5
+
+    // int key on object elements, paren-less with form
+    e.cq.rsort with (item.id);
+    check("intkey rsort", e.cq[0].id, 3);
+
+    // iterator net must not be poisoned across element types in one
+    // scope (class elements above, byte elements here)
+    begin
+      byte bq[$];
+      bq.push_back(9); bq.push_back(2);
+      bq.sort() with (item);
+      check("byte after class iter", bq[0], 2);
+    end
+
+    if (errors == 0) $display("PASS");
+    else $display("%0d checks failed", errors);
+    $finish;
+  end
+endmodule

--- a/tests/g68_process_status_test.sv
+++ b/tests/g68_process_status_test.sv
@@ -1,0 +1,96 @@
+// G68: process::status() must query the LIVE process state (IEEE
+// 1800-2017 9.7), not a placeholder property slot.  Also checks the
+// process state enum constants (FINISHED=0, RUNNING=1, WAITING=2,
+// SUSPENDED=3, KILLED=4) and the UVM sequencer zombie-predicate shape
+// that exposed the defect (find ... with (... && status inside
+// {KILLED, FINISHED})).
+class g68_req;
+  int request;
+  process process_id;
+endclass
+
+module g68_process_status_test;
+  int errors = 0;
+  process p_self, p_child, p_killed;
+  g68_req rq;
+  g68_req q[$];
+  g68_req zombies[$];
+
+  task check(string what, int got, int exp);
+    if (got !== exp) begin
+      $display("FAIL %s: got %0d expect %0d", what, got, exp);
+      errors++;
+    end
+  endtask
+
+  initial begin
+    // enum constants per 9.7
+    check("FINISHED", process::FINISHED, 0);
+    check("RUNNING", process::RUNNING, 1);
+    check("WAITING", process::WAITING, 2);
+    check("SUSPENDED", process::SUSPENDED, 3);
+    check("KILLED", process::KILLED, 4);
+
+    // the running process observes itself RUNNING
+    p_self = process::self();
+    check("self RUNNING", p_self.status(), process::RUNNING);
+
+    // a live forked child is not FINISHED/KILLED
+    fork begin
+      p_child = process::self();
+      #10;
+    end join_none
+    #1;
+    if (p_child.status() inside {process::KILLED, process::FINISHED}) begin
+      $display("FAIL live child reads dead (status=%0d)", p_child.status());
+      errors++;
+    end
+
+    // a killed child reads KILLED
+    fork begin
+      p_killed = process::self();
+      #100;
+    end join_none
+    #1;
+    p_killed.kill();
+    check("killed child", p_killed.status(), process::KILLED);
+
+    // a completed child reads FINISHED
+    #20;
+    check("finished child", p_child.status(), process::FINISHED);
+
+    // the UVM sequencer zombie-predicate shape: a live lock request
+    // must NOT match (this deadlocked seq_trace_test/vif_smoke when
+    // status was a dead property and inside bound looser than &&)
+    rq = new;
+    rq.request = 1;
+    rq.process_id = p_self;
+    q.push_back(rq);
+    zombies = q.find(item) with (item.request == 1
+        && item.process_id.status inside {process::KILLED, process::FINISHED});
+    check("live req not zombie", zombies.size(), 0);
+
+    // ... and a dead one must match
+    rq = new;
+    rq.request = 1;
+    rq.process_id = p_killed;
+    q.push_back(rq);
+    zombies = q.find(item) with (item.request == 1
+        && item.process_id.status inside {process::KILLED, process::FINISHED});
+    check("dead req is zombie", zombies.size(), 1);
+
+    // a non-lock dead-process request must not match (the && guard)
+    q.delete();
+    rq = new;
+    rq.request = 0;
+    rq.process_id = p_killed;
+    q.push_back(rq);
+    zombies = q.find(item) with (item.request == 1
+        && item.process_id.status inside {process::KILLED, process::FINISHED});
+    check("non-lock not zombie", zombies.size(), 0);
+
+    if (errors == 0) $display("PASS");
+    else $display("%0d checks failed", errors);
+    $finish;
+  end
+endmodule

--- a/tests/g69_inside_precedence_test.sv
+++ b/tests/g69_inside_precedence_test.sv
@@ -1,0 +1,52 @@
+// G69: the inside operator binds at the relational level (IEEE
+// 1800-2017 Table 11-2) — tighter than equality, &&, || and ?:.
+// Previously it sat at ternary precedence, so
+//   a && b inside {c, d}
+// parsed as (a && b) inside {c, d}, which made the UVM sequencer
+// zombie predicate match every arbitration entry ((0) inside
+// {KILLED, FINISHED=0}).
+module g69_inside_precedence_test;
+  int errors = 0;
+  int status = 1;       // "RUNNING"
+  int request = 1;
+  bit b;
+
+  task check(string what, bit got, bit exp);
+    if (got !== exp) begin
+      $display("FAIL %s: got %0d expect %0d", what, got, exp);
+      errors++;
+    end
+  endtask
+
+  initial begin
+    // a && b inside {..}  ==  a && (b inside {..})
+    b = (request == 1 && status inside {4, 0});
+    check("and-inside false", b, 0);
+    b = (request == 1 && status inside {1, 2});
+    check("and-inside true", b, 1);
+    // mis-parse ((request==1 && status) inside {4,0}) would give 0
+    // here too, so pin the case that distinguishes: request!=1 makes
+    // the mis-parse evaluate (0 inside {4,0}) == 1.
+    request = 0;
+    b = (request == 1 && status inside {4, 0});
+    check("short-circuit not inside", b, 0);
+    request = 1;
+
+    // a == b inside {..}  ==  a == (b inside {..})   (inside binds
+    // tighter than equality per Table 11-2)
+    b = (1 == status inside {1});      // 1 == (1 inside {1}) = 1
+    check("eq-inside", b, 1);
+    b = (0 == status inside {2});      // 0 == (1 inside {2}) = 1
+    check("eq-not-inside", b, 1);
+
+    // || and ?: still bind looser
+    b = (0 || status inside {1});
+    check("or-inside", b, 1);
+    b = (status inside {1} ? 1 : 0);
+    check("ternary-inside", b, 1);
+
+    if (errors == 0) $display("PASS");
+    else $display("%0d checks failed", errors);
+    $finish;
+  end
+endmodule

--- a/tests/m6_reactive_region_test.sv
+++ b/tests/m6_reactive_region_test.sv
@@ -1,0 +1,82 @@
+// M6 item 2: program-block processes schedule in the Reactive region
+// set (IEEE 1800-2017 4.4.2.5 Reactive, 4.4.2.6 Re-Inactive, 4.4.2.7
+// Re-NBA; clause 24 programs).  Characterizes the required orderings:
+//
+//  (a) A program process woken by a clock edge observes the design's
+//      post-NBA state for that same edge, race-free (the reactive
+//      TB-vs-DUT sampling guarantee that motivates programs).
+//  (b) #0 in a program defers to Re-Inactive, which runs BEFORE the
+//      program's own nonblocking updates (Re-NBA).
+//  (c) A program's nonblocking update is observable within the same
+//      time slot after the Re-NBA region runs.
+//  (d) A design process triggered by a program's blocking write runs
+//      in the Active region (iterative loopback) before the program's
+//      next #0 continuation.
+module m6_reactive_region_test;
+  logic clk = 0;
+  logic [7:0] count = 0;
+  int errors = 0;
+
+  always #5 clk = ~clk;
+  always @(posedge clk) count <= count + 1;
+
+  // (d) design reaction to a program's blocking write
+  logic pv = 0;
+  int seen = 0;
+  always @(posedge pv) seen = seen + 1;
+
+  initial begin
+    #100;
+    $display("FAIL (timeout)");
+    $finish;
+  end
+endmodule
+
+program m6_reactive_tb;
+  int errors = 0;
+  logic [7:0] x = 0;
+
+  initial begin
+    // (a) post-NBA sampling at the clock edge
+    @(posedge m6_reactive_region_test.clk);
+    if (m6_reactive_region_test.count !== 8'd1) begin
+      $display("FAIL a: count=%0d at first edge (expect post-NBA 1)",
+               m6_reactive_region_test.count);
+      errors++;
+    end
+    @(posedge m6_reactive_region_test.clk);
+    if (m6_reactive_region_test.count !== 8'd2) begin
+      $display("FAIL a2: count=%0d at second edge (expect 2)",
+               m6_reactive_region_test.count);
+      errors++;
+    end
+
+    // (b) #0 (Re-Inactive) runs before the program's NBA (Re-NBA)
+    x <= 8'hAA;
+    #0;
+    if (x !== 8'h00) begin
+      $display("FAIL b: x=%h after #0 (Re-Inactive must precede Re-NBA)", x);
+      errors++;
+    end
+
+    // (c) the Re-NBA update is observable in the same time slot
+    @(x);
+    if (x !== 8'hAA) begin
+      $display("FAIL c: x=%h after @(x) (expect Re-NBA value AA)", x);
+      errors++;
+    end
+
+    // (d) program blocking write -> design Active loopback -> program
+    //     #0 continuation sees the design's reaction
+    m6_reactive_region_test.pv = 1;
+    #0;
+    if (m6_reactive_region_test.seen !== 1) begin
+      $display("FAIL d: seen=%0d (design loopback must run before program #0)",
+               m6_reactive_region_test.seen);
+      errors++;
+    end
+
+    if (errors == 0) $display("PASS");
+    $finish;
+  end
+endprogram

--- a/tests/negative/g10_reduction_non_integral.sv
+++ b/tests/negative/g10_reduction_non_integral.sv
@@ -1,0 +1,12 @@
+// IEEE 1800-2017 7.12.3: array reduction methods apply to unpacked
+// arrays of INTEGRAL values. A real-element queue must be rejected
+// with a diagnostic, not silently accepted.
+module g10_reduction_non_integral;
+  real rq[$];
+  real y;
+  initial begin
+    rq.push_back(1.5);
+    y = rq.sum();
+    $display("%f", y);
+  end
+endmodule

--- a/tgt-vvp/eval_object.c
+++ b/tgt-vvp/eval_object.c
@@ -697,6 +697,144 @@ static int eval_object_ternary(ivl_expr_t expr)
 }
 
 /* Handle system-function expressions in object context. */
+/* IEEE 1800-2017 7.12: the array method loops below run over queues
+ * and dynamic arrays (both held in object variables) as well as
+ * fixed-size unpacked arrays (vvp .array labels with a compile-time
+ * word count).  These helpers hide the receiver difference: push the
+ * element count as a 32-bit vec4, and load element [ix3] as a vec4. */
+static int array_receiver_is_dynamic_(ivl_signal_t sig)
+{
+      ivl_variable_type_t dt = ivl_signal_data_type(sig);
+      return dt == IVL_VT_DARRAY || dt == IVL_VT_QUEUE;
+}
+
+static void draw_array_size_push_(ivl_signal_t sig)
+{
+      if (array_receiver_is_dynamic_(sig))
+	    fprintf(vvp_out, "    %%qsize v%p_0;\n", sig);
+      else
+	    fprintf(vvp_out, "    %%pushi/vec4 %u, 0, 32;\n",
+		    ivl_signal_array_count(sig));
+}
+
+static void draw_array_elem_load_vec4_(ivl_signal_t sig)
+{
+	/* Index register 3 holds the canonical element address. */
+      if (array_receiver_is_dynamic_(sig))
+	    fprintf(vvp_out, "    %%load/dar/vec4 v%p_0;\n", sig);
+      else
+	    fprintf(vvp_out, "    %%load/vec4a v%p, 3;\n", sig);
+}
+
+/* IEEE 1800-2017 7.12.3 array reduction methods:
+ *   $ivl_darray_method$reduce|<kind>(array, iter, idx, acc, val)
+ * kind is one of sum/product/and/or/xor.  Emit an inline loop that
+ * walks the array, stores each element into the hidden iter signal,
+ * evaluates the value expression (the with expression, or the iter
+ * signal itself), and folds it into the hidden accumulator with the
+ * corresponding operator.  The result is left on the vec4 stack.
+ * Called from draw_sfunc_vec4 (the result is a vector, not an
+ * object). */
+int draw_array_reduce_vec4(ivl_expr_t expr)
+{
+      const char*name = ivl_expr_name(expr);
+      const char*kind = name + 26;
+      unsigned parm_count = ivl_expr_parms(expr);
+      unsigned wid = ivl_expr_width(expr);
+      static int warned_reduce_shape = 0;
+
+      ivl_expr_t a_arg = (parm_count > 4) ? ivl_expr_parm(expr, 0) : 0;
+      ivl_expr_t iter_arg = (parm_count > 4) ? ivl_expr_parm(expr, 1) : 0;
+      ivl_expr_t idx_arg = (parm_count > 4) ? ivl_expr_parm(expr, 2) : 0;
+      ivl_expr_t acc_arg = (parm_count > 4) ? ivl_expr_parm(expr, 3) : 0;
+      ivl_expr_t val = (parm_count > 4) ? ivl_expr_parm(expr, 4) : 0;
+
+	/* A whole-array receiver is IVL_EX_SIGNAL for queue/darray
+	 * object variables, IVL_EX_ARRAY for fixed-size arrays. */
+      if (!a_arg || (ivl_expr_type(a_arg) != IVL_EX_SIGNAL
+		     && ivl_expr_type(a_arg) != IVL_EX_ARRAY)
+	  || !ivl_expr_signal(a_arg)
+	  || !iter_arg || ivl_expr_type(iter_arg) != IVL_EX_SIGNAL
+	  || !ivl_expr_signal(iter_arg)
+	  || !idx_arg || ivl_expr_type(idx_arg) != IVL_EX_SIGNAL
+	  || !ivl_expr_signal(idx_arg)
+	  || !acc_arg || ivl_expr_type(acc_arg) != IVL_EX_SIGNAL
+	  || !ivl_expr_signal(acc_arg)
+	  || !val) {
+	    if (!warned_reduce_shape) {
+		  fprintf(stderr, "Warning: %s requires a simple array"
+			  " variable receiver; emitting 0 fallback"
+			  " (further similar warnings suppressed)\n", name);
+		  warned_reduce_shape = 1;
+	    }
+	    fprintf(vvp_out, "    %%pushi/vec4 0, 0, %u; ; reduce fallback\n",
+			  wid);
+	    return 0;
+      }
+
+      ivl_signal_t a_sig = ivl_expr_signal(a_arg);
+      ivl_signal_t iter_sig = ivl_expr_signal(iter_arg);
+      ivl_signal_t idx_sig = ivl_expr_signal(idx_arg);
+      ivl_signal_t acc_sig = ivl_expr_signal(acc_arg);
+
+      unsigned iter_wid = ivl_type_packed_width(ivl_signal_net_type(iter_sig));
+      if (iter_wid == 0) iter_wid = 32;
+
+      const char*op;
+      int acc_ones = 0;
+      if (strcmp(kind, "sum") == 0)          op = "%add";
+      else if (strcmp(kind, "product") == 0) op = "%mul";
+      else if (strcmp(kind, "and") == 0)     { op = "%and"; acc_ones = 1; }
+      else if (strcmp(kind, "or") == 0)      op = "%or";
+      else                                   op = "%xor";
+
+      unsigned lab_top = local_count++;
+      unsigned lab_end = local_count++;
+
+	/* acc = identity element (0; 1 for product; ~0 for and) */
+      fprintf(vvp_out, "    %%pushi/vec4 %d, 0, %u;\n",
+	      (strcmp(kind, "product") == 0) ? 1 : 0, wid);
+      if (acc_ones)
+	    fprintf(vvp_out, "    %%inv;\n");
+      fprintf(vvp_out, "    %%store/vec4 v%p_0, 0, %u;\n", acc_sig, wid);
+
+	/* idx = 0 */
+      fprintf(vvp_out, "    %%pushi/vec4 0, 0, 32;\n");
+      fprintf(vvp_out, "    %%store/vec4 v%p_0, 0, 32;\n", idx_sig);
+
+      fprintf(vvp_out, "T_%u.%u ;\n", thread_count, lab_top);
+	/* if (!(idx < count)) goto end */
+      fprintf(vvp_out, "    %%load/vec4 v%p_0;\n", idx_sig);
+      draw_array_size_push_(a_sig);
+      fprintf(vvp_out, "    %%cmp/s;\n");
+      fprintf(vvp_out, "    %%jmp/0xz T_%u.%u, 5;\n", thread_count, lab_end);
+
+	/* iter = a[idx] */
+      fprintf(vvp_out, "    %%ix/getv/s 3, v%p_0;\n", idx_sig);
+      draw_array_elem_load_vec4_(a_sig);
+      fprintf(vvp_out, "    %%store/vec4 v%p_0, 0, %u;\n", iter_sig, iter_wid);
+
+	/* acc = acc OP value(iter) */
+      draw_eval_vec4(val);
+      if (ivl_expr_width(val) != wid)
+	    fprintf(vvp_out, "    %%pad/%c %u;\n",
+		    ivl_expr_signed(val) ? 's' : 'u', wid);
+      fprintf(vvp_out, "    %%load/vec4 v%p_0;\n", acc_sig);
+      fprintf(vvp_out, "    %s;\n", op);
+      fprintf(vvp_out, "    %%store/vec4 v%p_0, 0, %u;\n", acc_sig, wid);
+
+	/* idx += 1 */
+      fprintf(vvp_out, "    %%load/vec4 v%p_0;\n", idx_sig);
+      fprintf(vvp_out, "    %%pushi/vec4 1, 0, 32;\n");
+      fprintf(vvp_out, "    %%add;\n");
+      fprintf(vvp_out, "    %%store/vec4 v%p_0, 0, 32;\n", idx_sig);
+      fprintf(vvp_out, "    %%jmp T_%u.%u;\n", thread_count, lab_top);
+
+      fprintf(vvp_out, "T_%u.%u ;\n", thread_count, lab_end);
+      fprintf(vvp_out, "    %%load/vec4 v%p_0;\n", acc_sig);
+      return 0;
+}
+
 static int eval_object_sfunc(ivl_expr_t expr)
 {
       const char*name = ivl_expr_name(expr);
@@ -816,6 +954,166 @@ static int eval_object_sfunc(ivl_expr_t expr)
 	    return 0;
       }
 
+      /* IEEE 1800-2017 7.12.1 min()/max():
+       *   $ivl_darray_method$minmax|<kind>(array, iter, result, idx,
+       *                                    best, bestitem, val)
+       * Walk the array tracking the best per-element value (the with
+       * expression, or the element itself) and return a queue holding
+       * the single best element — or an empty queue for an empty
+       * array.  Ties keep the earliest element.  Comparisons whose
+       * flags evaluate to x (x/z bits in the values) keep the current
+       * best. */
+      if (strncmp(name, "$ivl_darray_method$minmax|", 26) == 0) {
+	    const char*kind = name + 26;
+	    int is_min = (strcmp(kind, "min") == 0);
+
+	    if (parm_count < 7) {
+		  fprintf(vvp_out, "    %%null; ; minmax: bad parm count\n");
+		  return 0;
+	    }
+	    ivl_expr_t a_arg = ivl_expr_parm(expr, 0);
+	    ivl_expr_t iter_arg = ivl_expr_parm(expr, 1);
+	    ivl_expr_t result_arg = ivl_expr_parm(expr, 2);
+	    ivl_expr_t idx_arg = ivl_expr_parm(expr, 3);
+	    ivl_expr_t best_arg = ivl_expr_parm(expr, 4);
+	    ivl_expr_t bitem_arg = ivl_expr_parm(expr, 5);
+	    ivl_expr_t val = ivl_expr_parm(expr, 6);
+
+	    if (!a_arg || (ivl_expr_type(a_arg) != IVL_EX_SIGNAL
+			   && ivl_expr_type(a_arg) != IVL_EX_ARRAY)
+		|| !ivl_expr_signal(a_arg)
+		|| !iter_arg || ivl_expr_type(iter_arg) != IVL_EX_SIGNAL
+		|| !ivl_expr_signal(iter_arg)
+		|| !result_arg || ivl_expr_type(result_arg) != IVL_EX_SIGNAL
+		|| !ivl_expr_signal(result_arg)
+		|| !idx_arg || ivl_expr_type(idx_arg) != IVL_EX_SIGNAL
+		|| !ivl_expr_signal(idx_arg)
+		|| !best_arg || ivl_expr_type(best_arg) != IVL_EX_SIGNAL
+		|| !ivl_expr_signal(best_arg)
+		|| !bitem_arg || ivl_expr_type(bitem_arg) != IVL_EX_SIGNAL
+		|| !ivl_expr_signal(bitem_arg)
+		|| !val) {
+		  fprintf(vvp_out, "    %%null; ; minmax: bad arg shape\n");
+		  return 0;
+	    }
+	    ivl_signal_t a_sig = ivl_expr_signal(a_arg);
+	    ivl_signal_t iter_sig = ivl_expr_signal(iter_arg);
+	    ivl_signal_t result_sig = ivl_expr_signal(result_arg);
+	    ivl_signal_t idx_sig = ivl_expr_signal(idx_arg);
+	    ivl_signal_t best_sig = ivl_expr_signal(best_arg);
+	    ivl_signal_t bitem_sig = ivl_expr_signal(bitem_arg);
+
+	    ivl_type_t iter_type = ivl_signal_net_type(iter_sig);
+	    unsigned iter_wid = ivl_type_packed_width(iter_type);
+	    if (iter_wid == 0) iter_wid = 32;
+	    unsigned val_wid = ivl_expr_width(val);
+	    if (val_wid == 0) val_wid = 32;
+	    const char*cmp_op = ivl_expr_signed(val) ? "%cmp/s" : "%cmp/u";
+
+	    char elem_enc[32];
+	    snprintf(elem_enc, sizeof elem_enc, "%s%s%u",
+		     ivl_type_signed(iter_type) ? "s" : "",
+		     (ivl_type_base(iter_type) == IVL_VT_BOOL) ? "b" : "v",
+		     iter_wid);
+
+	    unsigned lab_top = local_count++;
+	    unsigned lab_end = local_count++;
+	    unsigned lab_take = local_count++;
+	    unsigned lab_skip = local_count++;
+	    unsigned lab_next = local_count++;
+	    unsigned lab_done = local_count++;
+
+	      /* result = empty queue of the element type; ix5 = 0 is
+	       * the (unbounded) max-size operand for %store/qb/v. */
+	    fprintf(vvp_out, "    %%ix/load 5, 0, 0;\n");
+	    fprintf(vvp_out, "    %%new/queue \"%s\";\n", elem_enc);
+	    fprintf(vvp_out, "    %%store/obj v%p_0;\n", result_sig);
+
+	      /* idx = 0 */
+	    fprintf(vvp_out, "    %%pushi/vec4 0, 0, 32;\n");
+	    fprintf(vvp_out, "    %%store/vec4 v%p_0, 0, 32;\n", idx_sig);
+
+	    fprintf(vvp_out, "T_%u.%u ;\n", thread_count, lab_top);
+	      /* if (!(idx < count)) goto end */
+	    fprintf(vvp_out, "    %%load/vec4 v%p_0;\n", idx_sig);
+	    draw_array_size_push_(a_sig);
+	    fprintf(vvp_out, "    %%cmp/s;\n");
+	    fprintf(vvp_out, "    %%jmp/0xz T_%u.%u, 5;\n",
+		    thread_count, lab_end);
+
+	      /* iter = a[idx] */
+	    fprintf(vvp_out, "    %%ix/getv/s 3, v%p_0;\n", idx_sig);
+	    draw_array_elem_load_vec4_(a_sig);
+	    fprintf(vvp_out, "    %%store/vec4 v%p_0, 0, %u;\n",
+		    iter_sig, iter_wid);
+
+	      /* value on the stack; the first element is always taken */
+	    draw_eval_vec4(val);
+	    fprintf(vvp_out, "    %%load/vec4 v%p_0;\n", idx_sig);
+	    fprintf(vvp_out, "    %%pushi/vec4 0, 0, 32;\n");
+	    fprintf(vvp_out, "    %%cmp/u;\n");
+	    fprintf(vvp_out, "    %%jmp/1 T_%u.%u, 4;\n",
+		    thread_count, lab_take);
+
+	      /* compare val (deeper) vs best: flag5 = val < best */
+	    fprintf(vvp_out, "    %%dup/vec4;\n");
+	    fprintf(vvp_out, "    %%load/vec4 v%p_0;\n", best_sig);
+	    fprintf(vvp_out, "    %s;\n", cmp_op);
+	    if (is_min) {
+		    /* take if val < best */
+		  fprintf(vvp_out, "    %%jmp/1 T_%u.%u, 5;\n",
+			  thread_count, lab_take);
+		  fprintf(vvp_out, "    %%jmp T_%u.%u;\n",
+			  thread_count, lab_skip);
+	    } else {
+		    /* take if best < val, i.e. !(val < best) && !(val == best) */
+		  fprintf(vvp_out, "    %%jmp/1 T_%u.%u, 5;\n",
+			  thread_count, lab_skip);
+		  fprintf(vvp_out, "    %%jmp/1 T_%u.%u, 4;\n",
+			  thread_count, lab_skip);
+		  fprintf(vvp_out, "    %%jmp/0 T_%u.%u, 5;\n",
+			  thread_count, lab_take);
+		  fprintf(vvp_out, "    %%jmp T_%u.%u;\n",
+			  thread_count, lab_skip);
+	    }
+
+	    fprintf(vvp_out, "T_%u.%u ;\n", thread_count, lab_take);
+	      /* stack: val — becomes the new best; remember the element */
+	    fprintf(vvp_out, "    %%store/vec4 v%p_0, 0, %u;\n",
+		    best_sig, val_wid);
+	    fprintf(vvp_out, "    %%load/vec4 v%p_0;\n", iter_sig);
+	    fprintf(vvp_out, "    %%store/vec4 v%p_0, 0, %u;\n",
+		    bitem_sig, iter_wid);
+	    fprintf(vvp_out, "    %%jmp T_%u.%u;\n", thread_count, lab_next);
+
+	    fprintf(vvp_out, "T_%u.%u ;\n", thread_count, lab_skip);
+	      /* stack: val — discard */
+	    fprintf(vvp_out, "    %%pop/vec4 1;\n");
+
+	    fprintf(vvp_out, "T_%u.%u ;\n", thread_count, lab_next);
+	      /* idx += 1 */
+	    fprintf(vvp_out, "    %%load/vec4 v%p_0;\n", idx_sig);
+	    fprintf(vvp_out, "    %%pushi/vec4 1, 0, 32;\n");
+	    fprintf(vvp_out, "    %%add;\n");
+	    fprintf(vvp_out, "    %%store/vec4 v%p_0, 0, 32;\n", idx_sig);
+	    fprintf(vvp_out, "    %%jmp T_%u.%u;\n", thread_count, lab_top);
+
+	    fprintf(vvp_out, "T_%u.%u ;\n", thread_count, lab_end);
+	      /* if (0 < count) result.push_back(bestitem) */
+	    fprintf(vvp_out, "    %%pushi/vec4 0, 0, 32;\n");
+	    draw_array_size_push_(a_sig);
+	    fprintf(vvp_out, "    %%cmp/u;\n");
+	    fprintf(vvp_out, "    %%jmp/0xz T_%u.%u, 5;\n",
+		    thread_count, lab_done);
+	    fprintf(vvp_out, "    %%load/vec4 v%p_0;\n", bitem_sig);
+	    fprintf(vvp_out, "    %%store/qb/v v%p_0, 5, %u;\n",
+		    result_sig, iter_wid);
+
+	    fprintf(vvp_out, "T_%u.%u ;\n", thread_count, lab_done);
+	    fprintf(vvp_out, "    %%load/obj v%p_0;\n", result_sig);
+	    return 0;
+      }
+
       if (strncmp(name, "$ivl_queue_method$find_with|", 28) == 0) {
 	    const char*kind = name + 28;
 	    int is_index = (strstr(kind, "index") != NULL);
@@ -832,7 +1130,8 @@ static int eval_object_sfunc(ivl_expr_t expr)
 	    ivl_expr_t idx_arg = ivl_expr_parm(expr, 3);
 	    ivl_expr_t pred = ivl_expr_parm(expr, 4);
 
-	    if (!q_arg || ivl_expr_type(q_arg) != IVL_EX_SIGNAL
+	    if (!q_arg || (ivl_expr_type(q_arg) != IVL_EX_SIGNAL
+			   && ivl_expr_type(q_arg) != IVL_EX_ARRAY)
 		|| !ivl_expr_signal(q_arg)
 		|| !iter_arg || ivl_expr_type(iter_arg) != IVL_EX_SIGNAL
 		|| !ivl_expr_signal(iter_arg)
@@ -853,6 +1152,23 @@ static int eval_object_sfunc(ivl_expr_t expr)
 	    unsigned iter_wid = ivl_type_packed_width(iter_type);
 	    if (iter_wid == 0) iter_wid = 32;
 	    ivl_variable_type_t bt = ivl_type_base(iter_type);
+
+	      /* Fixed-size unpacked array receivers (7.12.1 locators
+	       * apply to any unpacked array) only support vector
+	       * element loads via %load/vec4a. */
+	    if (!array_receiver_is_dynamic_(q_sig)
+		&& bt != IVL_VT_BOOL && bt != IVL_VT_LOGIC) {
+		  static int warned_fixed_elem = 0;
+		  if (!warned_fixed_elem) {
+			fprintf(stderr, "Warning: %s on a fixed-size array"
+				" of non-vector elements (compile-progress:"
+				" empty result; further similar warnings"
+				" suppressed)\n", name);
+			warned_fixed_elem = 1;
+		  }
+		  fprintf(vvp_out, "    %%null; ; find_with: fixed non-vec\n");
+		  return 0;
+	    }
 
 	    /* Per-element-type bytecode shape:
 	     *   load_elem    — fetch q[idx] onto the appropriate stack
@@ -909,9 +1225,9 @@ static int eval_object_sfunc(ivl_expr_t expr)
 	    fprintf(vvp_out, "    %%store/vec4 v%p_0, 0, 32;\n", idx_sig);
 
 	    fprintf(vvp_out, "T_%u.%u ;\n", thread_count, lab_top);
-	    /* if (!(idx < qsize)) goto end */
+	    /* if (!(idx < size)) goto end */
 	    fprintf(vvp_out, "    %%load/vec4 v%p_0;\n", idx_sig);
-	    fprintf(vvp_out, "    %%qsize v%p_0;\n", q_sig);
+	    draw_array_size_push_(q_sig);
 	    fprintf(vvp_out, "    %%cmp/s;\n");
 	    /* %cmp/s sets flag 5 = lt; jump to end if NOT lt */
 	    fprintf(vvp_out, "    %%jmp/0xz T_%u.%u, 5;\n",
@@ -920,7 +1236,7 @@ static int eval_object_sfunc(ivl_expr_t expr)
 	    /* iter_sig = q[idx_sig] — type-specific load/store pair */
 	    fprintf(vvp_out, "    %%ix/getv/s 3, v%p_0;\n", idx_sig);
 	    if (bt == IVL_VT_BOOL || bt == IVL_VT_LOGIC) {
-		  fprintf(vvp_out, "    %%load/dar/vec4 v%p_0;\n", q_sig);
+		  draw_array_elem_load_vec4_(q_sig);
 		  fprintf(vvp_out, "    %%store/vec4 v%p_0, 0, %u;\n",
 			  iter_sig, iter_wid);
 	    } else if (bt == IVL_VT_REAL) {
@@ -949,7 +1265,7 @@ static int eval_object_sfunc(ivl_expr_t expr)
 		  fprintf(vvp_out, "    %%store/qb/v v%p_0, 5, 32;\n", result_sig);
 	    } else if (bt == IVL_VT_BOOL || bt == IVL_VT_LOGIC) {
 		  fprintf(vvp_out, "    %%ix/getv/s 3, v%p_0;\n", idx_sig);
-		  fprintf(vvp_out, "    %%load/dar/vec4 v%p_0;\n", q_sig);
+		  draw_array_elem_load_vec4_(q_sig);
 		  fprintf(vvp_out, "    %%store/qb/v v%p_0, 5, %u;\n",
 			  result_sig, iter_wid);
 	    } else if (bt == IVL_VT_REAL) {

--- a/tgt-vvp/eval_object.c
+++ b/tgt-vvp/eval_object.c
@@ -726,6 +726,32 @@ static void draw_array_elem_load_vec4_(ivl_signal_t sig)
 	    fprintf(vvp_out, "    %%load/vec4a v%p, 3;\n", sig);
 }
 
+/* Resolve the signal the array-method loop indexes through.  A plain
+ * signal (or whole-array) receiver is used directly.  Any other
+ * object-valued receiver (class property, nested property chain, call
+ * result) is evaluated once onto the object stack and its handle
+ * stored into the hidden net that elaboration passed as the sfunc's
+ * trailing parameter (recv_parm).  Returns nil if the shapes are
+ * unusable. */
+static ivl_signal_t draw_array_method_recv_(ivl_expr_t a_arg,
+					    ivl_expr_t recv_parm)
+{
+      if (a_arg && (ivl_expr_type(a_arg) == IVL_EX_SIGNAL
+		    || ivl_expr_type(a_arg) == IVL_EX_ARRAY)
+	  && ivl_expr_signal(a_arg))
+	    return ivl_expr_signal(a_arg);
+
+      if (!a_arg || !recv_parm
+	  || ivl_expr_type(recv_parm) != IVL_EX_SIGNAL
+	  || !ivl_expr_signal(recv_parm))
+	    return 0;
+
+      ivl_signal_t recv_sig = ivl_expr_signal(recv_parm);
+      draw_eval_object(a_arg);
+      fprintf(vvp_out, "    %%store/obj v%p_0;\n", recv_sig);
+      return recv_sig;
+}
+
 /* IEEE 1800-2017 7.12.3 array reduction methods:
  *   $ivl_darray_method$reduce|<kind>(array, iter, idx, acc, val)
  * kind is one of sum/product/and/or/xor.  Emit an inline loop that
@@ -748,12 +774,14 @@ int draw_array_reduce_vec4(ivl_expr_t expr)
       ivl_expr_t idx_arg = (parm_count > 4) ? ivl_expr_parm(expr, 2) : 0;
       ivl_expr_t acc_arg = (parm_count > 4) ? ivl_expr_parm(expr, 3) : 0;
       ivl_expr_t val = (parm_count > 4) ? ivl_expr_parm(expr, 4) : 0;
+      ivl_expr_t recv_parm = (parm_count > 5) ? ivl_expr_parm(expr, 5) : 0;
 
 	/* A whole-array receiver is IVL_EX_SIGNAL for queue/darray
-	 * object variables, IVL_EX_ARRAY for fixed-size arrays. */
-      if (!a_arg || (ivl_expr_type(a_arg) != IVL_EX_SIGNAL
-		     && ivl_expr_type(a_arg) != IVL_EX_ARRAY)
-	  || !ivl_expr_signal(a_arg)
+	 * object variables, IVL_EX_ARRAY for fixed-size arrays; other
+	 * object-valued receivers go through the hidden recv_parm
+	 * net. */
+      ivl_signal_t a_sig = draw_array_method_recv_(a_arg, recv_parm);
+      if (!a_sig
 	  || !iter_arg || ivl_expr_type(iter_arg) != IVL_EX_SIGNAL
 	  || !ivl_expr_signal(iter_arg)
 	  || !idx_arg || ivl_expr_type(idx_arg) != IVL_EX_SIGNAL
@@ -772,7 +800,6 @@ int draw_array_reduce_vec4(ivl_expr_t expr)
 	    return 0;
       }
 
-      ivl_signal_t a_sig = ivl_expr_signal(a_arg);
       ivl_signal_t iter_sig = ivl_expr_signal(iter_arg);
       ivl_signal_t idx_sig = ivl_expr_signal(idx_arg);
       ivl_signal_t acc_sig = ivl_expr_signal(acc_arg);
@@ -978,10 +1005,11 @@ static int eval_object_sfunc(ivl_expr_t expr)
 	    ivl_expr_t best_arg = ivl_expr_parm(expr, 4);
 	    ivl_expr_t bitem_arg = ivl_expr_parm(expr, 5);
 	    ivl_expr_t val = ivl_expr_parm(expr, 6);
+	    ivl_expr_t recv_parm = (parm_count > 7)
+		  ? ivl_expr_parm(expr, 7) : 0;
 
-	    if (!a_arg || (ivl_expr_type(a_arg) != IVL_EX_SIGNAL
-			   && ivl_expr_type(a_arg) != IVL_EX_ARRAY)
-		|| !ivl_expr_signal(a_arg)
+	    ivl_signal_t a_sig = draw_array_method_recv_(a_arg, recv_parm);
+	    if (!a_sig
 		|| !iter_arg || ivl_expr_type(iter_arg) != IVL_EX_SIGNAL
 		|| !ivl_expr_signal(iter_arg)
 		|| !result_arg || ivl_expr_type(result_arg) != IVL_EX_SIGNAL
@@ -996,7 +1024,6 @@ static int eval_object_sfunc(ivl_expr_t expr)
 		  fprintf(vvp_out, "    %%null; ; minmax: bad arg shape\n");
 		  return 0;
 	    }
-	    ivl_signal_t a_sig = ivl_expr_signal(a_arg);
 	    ivl_signal_t iter_sig = ivl_expr_signal(iter_arg);
 	    ivl_signal_t result_sig = ivl_expr_signal(result_arg);
 	    ivl_signal_t idx_sig = ivl_expr_signal(idx_arg);
@@ -1129,10 +1156,11 @@ static int eval_object_sfunc(ivl_expr_t expr)
 	    ivl_expr_t result_arg = ivl_expr_parm(expr, 2);
 	    ivl_expr_t idx_arg = ivl_expr_parm(expr, 3);
 	    ivl_expr_t pred = ivl_expr_parm(expr, 4);
+	    ivl_expr_t recv_parm = (parm_count > 5)
+		  ? ivl_expr_parm(expr, 5) : 0;
 
-	    if (!q_arg || (ivl_expr_type(q_arg) != IVL_EX_SIGNAL
-			   && ivl_expr_type(q_arg) != IVL_EX_ARRAY)
-		|| !ivl_expr_signal(q_arg)
+	    ivl_signal_t q_sig = draw_array_method_recv_(q_arg, recv_parm);
+	    if (!q_sig
 		|| !iter_arg || ivl_expr_type(iter_arg) != IVL_EX_SIGNAL
 		|| !ivl_expr_signal(iter_arg)
 		|| !result_arg || ivl_expr_type(result_arg) != IVL_EX_SIGNAL
@@ -1143,7 +1171,6 @@ static int eval_object_sfunc(ivl_expr_t expr)
 		  fprintf(vvp_out, "    %%null; ; find_with: bad arg shape\n");
 		  return 0;
 	    }
-	    ivl_signal_t q_sig = ivl_expr_signal(q_arg);
 	    ivl_signal_t iter_sig = ivl_expr_signal(iter_arg);
 	    ivl_signal_t result_sig = ivl_expr_signal(result_arg);
 	    ivl_signal_t idx_sig = ivl_expr_signal(idx_arg);

--- a/tgt-vvp/eval_vec4.c
+++ b/tgt-vvp/eval_vec4.c
@@ -1496,6 +1496,14 @@ static void draw_sfunc_vec4(ivl_expr_t expr)
 	    draw_array_reduce_vec4(expr);
 	    return;
       }
+      if (strcmp(ivl_expr_name(expr),"$ivl_process$status")==0) {
+	      /* IEEE 1800-2017 9.7: query the live process state. */
+	    ivl_expr_t parg = ivl_expr_parm(expr, 0);
+	    assert(parg);
+	    draw_eval_object(parg);
+	    fprintf(vvp_out, "    %%process/status;\n");
+	    return;
+      }
       if (strcmp(ivl_expr_name(expr),"$ivl_event_method$triggered")==0) {
 	      /* IEEE 1800-2017 15.5.3: read the named event's
 	         triggered-this-time-step state. */

--- a/tgt-vvp/eval_vec4.c
+++ b/tgt-vvp/eval_vec4.c
@@ -1490,6 +1490,12 @@ static void draw_sfunc_vec4(ivl_expr_t expr)
 	    draw_stream_pack_pieces(expr, ivl_expr_width(expr));
 	    return;
       }
+      if (strncmp(ivl_expr_name(expr),"$ivl_darray_method$reduce|",26)==0) {
+	      /* IEEE 1800-2017 7.12.3 array reduction methods: inline
+	         loop leaving the accumulated value on the vec4 stack. */
+	    draw_array_reduce_vec4(expr);
+	    return;
+      }
       if (strcmp(ivl_expr_name(expr),"$ivl_event_method$triggered")==0) {
 	      /* IEEE 1800-2017 15.5.3: read the named event's
 	         triggered-this-time-step state. */

--- a/tgt-vvp/vvp_priv.h
+++ b/tgt-vvp/vvp_priv.h
@@ -630,6 +630,15 @@ extern void stream_elem_type_text(ivl_type_t element_type,
                                   char*buf, size_t bufsz);
 
 /*
+ * Array reduction methods (IEEE 1800-2017 7.12.3): lower the internal
+ * system function "$ivl_darray_method$reduce|<kind>" to an inline
+ * loop over the array receiver, leaving the accumulated value on the
+ * vec4 stack.  Defined in eval_object.c (it shares the array-receiver
+ * helpers with the locator loops), called from draw_sfunc_vec4.
+ */
+extern int draw_array_reduce_vec4(ivl_expr_t expr);
+
+/*
  * These are various statement code generators.
  */
 extern int show_statement(ivl_statement_t net, ivl_scope_t sscope);

--- a/tgt-vvp/vvp_process.c
+++ b/tgt-vvp/vvp_process.c
@@ -2555,17 +2555,33 @@ static int show_system_task_call(ivl_statement_t net)
 	  || strcmp(stmt_name,"$ivl_queue_method$shuffle") == 0) {
 	    ivl_expr_t parm0 = (ivl_stmt_parm_count(net) > 0)
 		  ? ivl_stmt_parm(net, 0) : 0;
-	    if (!parm0 || ivl_expr_type(parm0) != IVL_EX_SIGNAL
-		|| !ivl_expr_signal(parm0)) {
-		  /* Phase 63b/B5: class-property queues (IVL_EX_PROPERTY)
-		     and other non-signal queue receivers can't use the
-		     %qsort/%qunique opcodes which take a signal argument.
-		     A real implementation would need a queue-by-handle
-		     variant of the opcodes; until that lands, silently
-		     skip rather than warning on every UVM compile. */
+	    ivl_expr_t recv_parm = (ivl_stmt_parm_count(net) > 1)
+		  ? ivl_stmt_parm(net, 1) : 0;
+	    ivl_signal_t sig = 0;
+	    if (parm0 && ivl_expr_type(parm0) == IVL_EX_SIGNAL
+		&& ivl_expr_signal(parm0)) {
+		  sig = ivl_expr_signal(parm0);
+	    } else if (parm0 && recv_parm
+		       && ivl_expr_type(recv_parm) == IVL_EX_SIGNAL
+		       && ivl_expr_signal(recv_parm)) {
+		    /* Non-signal receiver (class property, nested chain):
+		       evaluate the receiver object once and run the
+		       opcode against the hidden net holding its handle
+		       (queue/darray variables hold containers by handle,
+		       so the in-place reorder reaches the property). */
+		  sig = ivl_expr_signal(recv_parm);
+		  draw_eval_object(parm0);
+		  fprintf(vvp_out, "    %%store/obj v%p_0;\n", sig);
+	    } else {
+		  static int warned_recv = 0;
+		  if (!warned_recv) {
+			fprintf(stderr, "Warning: %s on an unsupported"
+				" receiver shape; skipping (further similar"
+				" warnings suppressed)\n", stmt_name);
+			warned_recv = 1;
+		  }
 		  return 0;
 	    }
-	    ivl_signal_t sig = ivl_expr_signal(parm0);
 	    const char*opcode =
 		  (strcmp(stmt_name,"$ivl_queue_method$sort")==0)    ? "%qsort"    :
 		  (strcmp(stmt_name,"$ivl_queue_method$rsort")==0)   ? "%qsort/r"  :
@@ -2599,12 +2615,25 @@ static int show_system_task_call(ivl_statement_t net)
 	    ivl_expr_t keys_arg = ivl_stmt_parm(net, 2);
 	    ivl_expr_t idx_arg = ivl_stmt_parm(net, 3);
 	    ivl_expr_t pred = ivl_stmt_parm(net, 4);
-	    if (!q_arg || ivl_expr_type(q_arg) != IVL_EX_SIGNAL
+	    ivl_expr_t recv_parm = (ivl_stmt_parm_count(net) > 5)
+		  ? ivl_stmt_parm(net, 5) : 0;
+	    if (!q_arg
 		|| !iter_arg || ivl_expr_type(iter_arg) != IVL_EX_SIGNAL
 		|| !keys_arg || ivl_expr_type(keys_arg) != IVL_EX_SIGNAL
 		|| !idx_arg || ivl_expr_type(idx_arg) != IVL_EX_SIGNAL
 		|| !pred) return 0;
-	    ivl_signal_t q_sig = ivl_expr_signal(q_arg);
+	    ivl_signal_t q_sig = 0;
+	    if (ivl_expr_type(q_arg) == IVL_EX_SIGNAL
+		&& ivl_expr_signal(q_arg)) {
+		  q_sig = ivl_expr_signal(q_arg);
+	    } else if (recv_parm
+		       && ivl_expr_type(recv_parm) == IVL_EX_SIGNAL
+		       && ivl_expr_signal(recv_parm)) {
+		    /* Non-signal receiver: see the plain family above. */
+		  q_sig = ivl_expr_signal(recv_parm);
+		  draw_eval_object(q_arg);
+		  fprintf(vvp_out, "    %%store/obj v%p_0;\n", q_sig);
+	    }
 	    ivl_signal_t iter_sig = ivl_expr_signal(iter_arg);
 	    ivl_signal_t keys_sig = ivl_expr_signal(keys_arg);
 	    ivl_signal_t idx_sig = ivl_expr_signal(idx_arg);
@@ -2670,9 +2699,15 @@ static int show_system_task_call(ivl_statement_t net)
 		  return 0;
 	    }
 
-	    /* Step 1: keys = empty queue */
+	    /* Step 1: keys = empty queue, typed by the with expression
+	       (IEEE 1800-2017 7.12.2): string and real keys keep their
+	       full value; everything else is a signed 32-bit key. */
+	    ivl_variable_type_t key_vt = ivl_expr_value(pred);
+	    const char*keys_enc =
+		  (key_vt == IVL_VT_STRING) ? "S" :
+		  (key_vt == IVL_VT_REAL)   ? "r" : "sb32";
 	    fprintf(vvp_out, "    %%ix/load 5, 0, 0;\n");
-	    fprintf(vvp_out, "    %%new/queue \"sb32\";\n");
+	    fprintf(vvp_out, "    %%new/queue \"%s\";\n", keys_enc);
 	    fprintf(vvp_out, "    %%store/obj v%p_0;\n", keys_sig);
 
 	    /* Step 2: idx_sig = 0 */
@@ -2695,8 +2730,17 @@ static int show_system_task_call(ivl_statement_t net)
 	    fprintf(vvp_out, "    %%%s;\n", store_iter);
 
 	    /* eval predicate (key) and store to keys queue */
-	    {
-		  /* Save line number for predicate trace. */
+	    if (key_vt == IVL_VT_STRING) {
+		  draw_eval_string(pred);
+		  fprintf(vvp_out, "    %%ix/load 5, 0, 0;\n");
+		  fprintf(vvp_out, "    %%store/qb/str v%p_0, 5;\n",
+			  keys_sig);
+	    } else if (key_vt == IVL_VT_REAL) {
+		  draw_eval_real(pred);
+		  fprintf(vvp_out, "    %%ix/load 5, 0, 0;\n");
+		  fprintf(vvp_out, "    %%store/qb/r v%p_0, 5;\n",
+			  keys_sig);
+	    } else {
 		  unsigned pred_wid = ivl_expr_width(pred);
 		  draw_eval_vec4(pred);
 		  /* Pad/truncate to 32-bit signed for keys queue. */

--- a/tgt-vvp/vvp_scope.c
+++ b/tgt-vvp/vvp_scope.c
@@ -2544,7 +2544,12 @@ int draw_scope(ivl_scope_t net, ivl_scope_t parent)
       suffix[0] = 0;
 
       switch (ivl_scope_type(net)) {
-      case IVL_SCT_MODULE:   type = "module";   break;
+      case IVL_SCT_MODULE:
+	    /* Program blocks elaborate as module scopes with the
+	       program flag; the runtime schedules their processes in
+	       the Reactive region set (IEEE 1800-2017 4.4.2.5, 24.3). */
+	    type = ivl_scope_program(net) ? "program" : "module";
+	    break;
       case IVL_SCT_FUNCTION: type = "function"; break;
       case IVL_SCT_TASK:     type = "task";     break;
       case IVL_SCT_BEGIN:    type = "begin";    break;

--- a/vvp/codes.h
+++ b/vvp/codes.h
@@ -332,6 +332,7 @@ extern bool of_PROP_V_I(vthread_t thr, vvp_code_t code);
 extern bool of_PROCESS_AWAIT(vthread_t thr, vvp_code_t code);
 extern bool of_PROCESS_KILL(vthread_t thr, vvp_code_t code);
 extern bool of_PROCESS_SELF(vthread_t thr, vvp_code_t code);
+extern bool of_PROCESS_STATUS(vthread_t thr, vvp_code_t code);
 /* Mailbox opcodes */
 extern bool of_MBX_NEW(vthread_t thr, vvp_code_t code);
 extern bool of_MBX_PUT(vthread_t thr, vvp_code_t code);

--- a/vvp/compile.cc
+++ b/vvp/compile.cc
@@ -364,6 +364,7 @@ static const struct opcode_table_s opcode_table[] = {
       { "%process/await",of_PROCESS_AWAIT,0,{OA_NONE, OA_NONE, OA_NONE} },
       { "%process/kill", of_PROCESS_KILL, 0,{OA_NONE, OA_NONE, OA_NONE} },
       { "%process/self", of_PROCESS_SELF, 0,{OA_NONE, OA_NONE, OA_NONE} },
+      { "%process/status",of_PROCESS_STATUS,0,{OA_NONE, OA_NONE, OA_NONE} },
       { "%prop/obj",of_PROP_OBJ,2,  {OA_NUMBER,   OA_BIT1,     OA_NONE} },
       { "%prop/r",  of_PROP_R,  1,  {OA_NUMBER,   OA_NONE,     OA_NONE} },
       { "%prop/str",of_PROP_STR,1,  {OA_NUMBER,   OA_NONE,     OA_NONE} },

--- a/vvp/schedule.cc
+++ b/vvp/schedule.cc
@@ -81,6 +81,9 @@ struct event_time_s {
 	    active = 0;
 	    inactive = 0;
 	    nbassign = 0;
+	    reactive = 0;
+	    re_inactive = 0;
+	    re_nbassign = 0;
 	    rwsync = 0;
 	    rosync = 0;
 	    del_thr = 0;
@@ -92,6 +95,9 @@ struct event_time_s {
       struct event_s*active;
       struct event_s*inactive;
       struct event_s*nbassign;
+      struct event_s*reactive;
+      struct event_s*re_inactive;
+      struct event_s*re_nbassign;
       struct event_s*rwsync;
       struct event_s*rosync;
       struct event_s*del_thr;
@@ -696,6 +702,7 @@ static void schedule_final_event(struct event_s*cur)
  * queue.
  */
 typedef enum event_queue_e { SEQ_START, SEQ_ACTIVE, SEQ_INACTIVE, SEQ_NBASSIGN,
+			     SEQ_REACTIVE, SEQ_RE_INACTIVE, SEQ_RE_NBASSIGN,
 			     SEQ_RWSYNC, SEQ_ROSYNC, DEL_THREAD } event_queue_t;
 
 static void schedule_event_(struct event_s*cur, vvp_time64_t delay,
@@ -778,6 +785,19 @@ static void schedule_event_(struct event_s*cur, vvp_time64_t delay,
 	    q = &ctim->nbassign;
 	    break;
 
+	  case SEQ_REACTIVE:
+	    q = &ctim->reactive;
+	    break;
+
+	  case SEQ_RE_INACTIVE:
+	    assert(delay == 0);
+	    q = &ctim->re_inactive;
+	    break;
+
+	  case SEQ_RE_NBASSIGN:
+	    q = &ctim->re_nbassign;
+	    break;
+
 	  case SEQ_RWSYNC:
 	    q = &ctim->rwsync;
 	    break;
@@ -835,7 +855,11 @@ void schedule_vthread(vthread_t thr, vvp_time64_t delay, bool push_flag)
 	    schedule_event_push_(cur);
 
       } else {
-	    schedule_event_(cur, delay, SEQ_ACTIVE);
+	      /* Program-block processes resume in the Reactive region
+		 of the target time slot (IEEE 1800-2017 4.4.2.5). */
+	    schedule_event_(cur, delay,
+			    vthread_is_reactive(thr) ? SEQ_REACTIVE
+						     : SEQ_ACTIVE);
       }
 }
 
@@ -853,7 +877,10 @@ void schedule_inactive(vthread_t thr)
 
       cur->thr = thr;
       vthread_mark_scheduled(thr);
-      schedule_event_(cur, 0, SEQ_INACTIVE);
+	/* #0 in a program-block process defers to the Re-Inactive
+	   region (IEEE 1800-2017 4.4.2.6). */
+      schedule_event_(cur, 0, vthread_is_reactive(thr) ? SEQ_RE_INACTIVE
+						       : SEQ_INACTIVE);
 }
 
 void schedule_init_vthread(vthread_t thr)
@@ -880,13 +907,16 @@ void schedule_final_vthread(vthread_t thr)
 void schedule_assign_vector(vvp_net_ptr_t ptr,
 			    unsigned base, unsigned vwid,
 			    const vvp_vector4_t&bit,
-			    vvp_time64_t delay)
+			    vvp_time64_t delay, bool reactive)
 {
       struct assign_vector4_event_s*cur = new struct assign_vector4_event_s(bit);
       cur->ptr = ptr;
       cur->base = base;
       cur->vwid = vwid;
-      schedule_event_(cur, delay, SEQ_NBASSIGN);
+	/* Nonblocking assignments from program-block processes
+	   schedule in the Re-NBA region (IEEE 1800-2017 4.4.2.7). */
+      schedule_event_(cur, delay, reactive ? SEQ_RE_NBASSIGN
+					   : SEQ_NBASSIGN);
 }
 
 void schedule_force_vector(vvp_net_t*net,
@@ -928,26 +958,28 @@ void schedule_assign_array_word(vvp_array_t mem,
 				unsigned word_addr,
 				unsigned off,
 				const vvp_vector4_t&val,
-				vvp_time64_t delay)
+				vvp_time64_t delay, bool reactive)
 {
       struct assign_array_word_s*cur = new struct assign_array_word_s;
       cur->mem = mem;
       cur->adr = word_addr;
       cur->off = off;
       cur->val = val;
-      schedule_event_(cur, delay, SEQ_NBASSIGN);
+      schedule_event_(cur, delay, reactive ? SEQ_RE_NBASSIGN
+					   : SEQ_NBASSIGN);
 }
 
 void schedule_assign_array_word(vvp_array_t mem,
 				unsigned word_addr,
 				double val,
-				vvp_time64_t delay)
+				vvp_time64_t delay, bool reactive)
 {
       struct assign_array_r_word_s*cur = new struct assign_array_r_word_s;
       cur->mem = mem;
       cur->adr = word_addr;
       cur->val = val;
-      schedule_event_(cur, delay, SEQ_NBASSIGN);
+      schedule_event_(cur, delay, reactive ? SEQ_RE_NBASSIGN
+					   : SEQ_NBASSIGN);
 }
 
 void schedule_set_vector(vvp_net_ptr_t ptr, const vvp_vector4_t&bit)
@@ -1122,7 +1154,9 @@ static void run_rosync(struct event_time_s*ctim)
 	    delete cur;
       }
 
-      if (ctim->active || ctim->inactive || ctim->nbassign || ctim->rwsync) {
+      if (ctim->active || ctim->inactive || ctim->nbassign
+	  || ctim->reactive || ctim->re_inactive || ctim->re_nbassign
+	  || ctim->rwsync) {
 	    cerr << "SCHEDULER ERROR: read-only sync events "
 		 << "created RW events!" << endl;
       }
@@ -1272,6 +1306,24 @@ void schedule_simulate(void)
 		  if (ctim->active == 0) {
 			ctim->active = ctim->nbassign;
 			ctim->nbassign = 0;
+
+			  /* Reactive region set (IEEE 1800-2017
+			     4.4.2.5-4.4.2.7): program-block processes,
+			     their #0 continuations, and their
+			     nonblocking updates run after the design
+			     regions have settled. */
+			if (ctim->active == 0) {
+			      ctim->active = ctim->reactive;
+			      ctim->reactive = 0;
+			}
+			if (ctim->active == 0) {
+			      ctim->active = ctim->re_inactive;
+			      ctim->re_inactive = 0;
+			}
+			if (ctim->active == 0) {
+			      ctim->active = ctim->re_nbassign;
+			      ctim->re_nbassign = 0;
+			}
 
 			if (ctim->active == 0) {
 			      ctim->active = ctim->rwsync;

--- a/vvp/schedule.h
+++ b/vvp/schedule.h
@@ -50,18 +50,21 @@ extern void schedule_final_vthread(vthread_t thr);
 extern void schedule_assign_vector(vvp_net_ptr_t ptr,
 				   unsigned base, unsigned vwid,
 				   const vvp_vector4_t&val,
-				   vvp_time64_t  delay);
+				   vvp_time64_t  delay,
+				   bool reactive =false);
 
 extern void schedule_assign_array_word(vvp_array_t mem,
 				       unsigned word_address,
 				       unsigned off,
 				       const vvp_vector4_t&val,
-				       vvp_time64_t delay);
+				       vvp_time64_t delay,
+				       bool reactive =false);
 
 extern void schedule_assign_array_word(vvp_array_t mem,
 				       unsigned word_address,
 				       double val,
-				       vvp_time64_t delay);
+				       vvp_time64_t delay,
+				       bool reactive =false);
 
 /*
  * Create an event to force the output of a net.

--- a/vvp/vpi_scope.cc
+++ b/vvp/vpi_scope.cc
@@ -391,6 +391,16 @@ class vpiScopeModule  : public __vpiScope {
       int get_type_code(void) const override { return vpiModule; }
 };
 
+/* Program-block instance scope (IEEE 1800-2017 clause 24): threads
+   whose scope chain includes one of these schedule in the Reactive
+   region set. */
+class vpiScopeProgram  : public __vpiScope {
+    public:
+      inline vpiScopeProgram(const char*nam, const char*tnam)
+      : __vpiScope(nam,tnam,false) { }
+      int get_type_code(void) const override { return vpiProgram; }
+};
+
 struct vpiScopePackage  : public __vpiScope {
       inline vpiScopePackage(const char*nam, const char*tnam)
       : __vpiScope(nam,tnam) { }
@@ -545,6 +555,8 @@ compile_scope_decl(char*label, char*type, char*name, char*tname,
 	    scope = new vpiScopePackage(name, tname);
       } else if (strcmp(type,"class") == 0) {
 	    scope = new vpiScopeClass(name, tname);
+      } else if (strcmp(type,"program") == 0) {
+	    scope = new vpiScopeProgram(name, tname);
       } else {
 	    scope = new vpiScopeModule(name, tname);
 	    assert(0);

--- a/vvp/vthread.cc
+++ b/vvp/vthread.cc
@@ -11496,12 +11496,44 @@ static void process_status_to_vec4_(unsigned status, vvp_vector4_t&val)
 bool of_PROCESS_SELF(vthread_t thr, vvp_code_t)
 {
       vthread_t owner = logical_process_thread_(thr);
+      if (getenv("IVL_PROC_TRACE"))
+	    fprintf(stderr, "[proc] self: thr=%p callf=%d forkv=%d -> owner=%p obj=%p\n",
+		    (void*)thr, thr->is_callf_child ? 1 : 0,
+		    thr->is_fork_v_child ? 1 : 0, (void*)owner,
+		    owner ? (void*)owner->process_obj_.peek<vvp_process>() : 0);
       if (!owner) {
 	    thr->push_object(vvp_object_t());
 	    return true;
       }
 
       thr->push_object(owner->process_obj_);
+      return true;
+}
+
+/*
+ * %process/status
+ *   Pop a process object and push its live state as a 32-bit vec4
+ *   per IEEE 1800-2017 9.7 (FINISHED=0, RUNNING=1, WAITING=2,
+ *   SUSPENDED=3, KILLED=4).  A nil handle pushes x.
+ */
+bool of_PROCESS_STATUS(vthread_t thr, vvp_code_t)
+{
+      vvp_object_t obj;
+      thr->pop_object(obj);
+
+      vvp_process*proc = obj.peek<vvp_process>();
+      if (getenv("IVL_PROC_TRACE"))
+	    fprintf(stderr, "[proc] status: proc=%p owner=%p st=%u\n",
+		    (void*)proc, proc ? (void*)proc->owner() : 0,
+		    proc ? proc->status() : 99);
+      if (!proc) {
+	    thr->push_vec4(vvp_vector4_t(32, BIT4_X));
+	    return true;
+      }
+
+      vvp_vector4_t val;
+      process_status_to_vec4_(proc->status(), val);
+      thr->push_vec4(val);
       return true;
 }
 

--- a/vvp/vthread.cc
+++ b/vvp/vthread.cc
@@ -489,6 +489,10 @@ struct vthread_s {
       unsigned pending_nonlocal_jmp :1;
       unsigned is_callf_child    :1;
       unsigned is_fork_v_child   :1;
+	/* Program-block process (IEEE 1800-2017 clause 24): scheduled
+	   in the Reactive region set.  Set at creation from the scope
+	   chain and inherited by spawned children. */
+      unsigned is_reactive_process :1;
       unsigned owns_automatic_context :1;
 	/* This points to the children of the thread. */
       set<struct vthread_s*>children;
@@ -2816,6 +2820,13 @@ vthread_t vthread_new(vvp_code_t pc, __vpiScope*scope)
       thr->pending_nonlocal_jmp = 0;
       thr->is_callf_child = 0;
       thr->is_fork_v_child = 0;
+      thr->is_reactive_process = 0;
+      for (__vpiScope*sc = scope ; sc ; sc = sc->scope) {
+	    if (sc->get_type_code() == vpiProgram) {
+		  thr->is_reactive_process = 1;
+		  break;
+	    }
+      }
       thr->owns_automatic_context = 0;
       thr->owned_context = 0;
       thr->transferred_context = 0;
@@ -2901,6 +2912,7 @@ static void vthread_reap(vthread_t thr)
 		  assert(child->parent == thr);
 		  if (thr->parent) {
 			child->parent = thr->parent;
+			child->is_reactive_process |= thr->is_reactive_process;
 			thr->parent->children.insert(child);
 		  } else {
 			child->parent = 0;
@@ -2921,6 +2933,7 @@ static void vthread_reap(vthread_t thr)
 		  assert(child->i_am_detached);
 		  if (thr->parent) {
 			child->parent = thr->parent;
+			child->is_reactive_process |= thr->is_reactive_process;
 			thr->parent->detached_children.insert(child);
 		  } else {
 			child->parent = 0;
@@ -3132,6 +3145,16 @@ void vthread_mark_scheduled(vthread_t thr)
 	    thr->is_scheduled = 1;
 	    thr = thr->wait_next;
       }
+}
+
+int vthread_is_reactive(vthread_t thr)
+{
+      return (thr && thr->is_reactive_process) ? 1 : 0;
+}
+
+static inline bool schedule_assign_is_reactive_(vthread_t thr)
+{
+      return thr && thr->is_reactive_process;
 }
 
 void vthread_mark_final(vthread_t thr)
@@ -3384,7 +3407,32 @@ void vthread_schedule_list(vthread_t thr)
 	    cur->waiting_for_event = 0;
       }
 
-      schedule_vthread(thr, 0);
+	/* A single event functor can wake both design processes and
+	   program-block processes.  Those belong in different regions
+	   (IEEE 1800-2017 4.4.2: Active vs. Reactive), so partition
+	   the wake chain by region, preserving relative order within
+	   each partition, and schedule the partitions separately. */
+      vthread_t design_head = 0, design_tail = 0;
+      vthread_t reactive_head = 0, reactive_tail = 0;
+      for (vthread_t cur = thr ;  cur ; ) {
+	    vthread_t next = cur->wait_next;
+	    cur->wait_next = 0;
+	    if (cur->is_reactive_process) {
+		  if (reactive_tail) reactive_tail->wait_next = cur;
+		  else reactive_head = cur;
+		  reactive_tail = cur;
+	    } else {
+		  if (design_tail) design_tail->wait_next = cur;
+		  else design_head = cur;
+		  design_tail = cur;
+	    }
+	    cur = next;
+      }
+
+      if (design_head)
+	    schedule_vthread(design_head, 0);
+      if (reactive_head)
+	    schedule_vthread(reactive_head, 0);
 }
 
 static __vpiScope* resolve_context_scope(__vpiScope*scope);
@@ -4215,7 +4263,8 @@ bool of_ASSIGN_AR(vthread_t thr, vvp_code_t cp)
       if (adr >= 0) {
 	    vvp_array_t array = resolve_runtime_array_(cp, "%assign/ar");
 	    if (array)
-		  schedule_assign_array_word(array, adr, value, delay);
+		  schedule_assign_array_word(array, adr, value, delay,
+					     thr->is_reactive_process);
       }
 
       return true;
@@ -4235,7 +4284,8 @@ bool of_ASSIGN_ARD(vthread_t thr, vvp_code_t cp)
 	    vvp_time64_t delay = thr->words[cp->bit_idx[0]].w_uint;
 	    vvp_array_t array = resolve_runtime_array_(cp, "%assign/ar/d");
 	    if (array)
-		  schedule_assign_array_word(array, adr, value, delay);
+		  schedule_assign_array_word(array, adr, value, delay,
+					     thr->is_reactive_process);
       }
 
       return true;
@@ -4258,7 +4308,8 @@ bool of_ASSIGN_ARE(vthread_t thr, vvp_code_t cp)
 	    if (!array)
 		  return true;
 	    if (thr->ecount == 0) {
-		  schedule_assign_array_word(array, adr, value, 0);
+		  schedule_assign_array_word(array, adr, value, 0,
+					     thr->is_reactive_process);
 	    } else {
 		  schedule_evctl(array, adr, value, thr->event,
 		                 thr->ecount);
@@ -4277,7 +4328,8 @@ bool of_ASSIGN_VEC4(vthread_t thr, vvp_code_t cp)
       unsigned delay = cp->bit_idx[0];
       const vvp_vector4_t&val = thr->peek_vec4();
 
-      schedule_assign_vector(ptr, 0, 0, val, delay);
+      schedule_assign_vector(ptr, 0, 0, val, delay,
+			     thr->is_reactive_process);
       thr->pop_vec4(1);
       return true;
 }
@@ -4353,7 +4405,8 @@ bool of_ASSIGN_VEC4_A_D(vthread_t thr, vvp_code_t cp)
       if (!resize_rval_vec(val, off, array->get_word_size()))
 	    return true;
 
-      schedule_assign_array_word(array, adr, off, val, del);
+      schedule_assign_array_word(array, adr, off, val, del,
+				 schedule_assign_is_reactive_(thr));
 
       return true;
 }
@@ -4384,7 +4437,8 @@ bool of_ASSIGN_VEC4_A_E(vthread_t thr, vvp_code_t cp)
 	    return true;
 
       if (thr->ecount == 0) {
-	    schedule_assign_array_word(array, adr, off, val, 0);
+	    schedule_assign_array_word(array, adr, off, val, 0,
+				       schedule_assign_is_reactive_(thr));
       } else {
 	    schedule_evctl(array, adr, val, off, thr->event, thr->ecount);
       }
@@ -4416,7 +4470,8 @@ bool of_ASSIGN_VEC4_OFF_D(vthread_t thr, vvp_code_t cp)
       if (!resize_rval_vec(val, off, sig->value_size()))
 	    return true;
 
-      schedule_assign_vector(ptr, off, sig->value_size(), val, del);
+      schedule_assign_vector(ptr, off, sig->value_size(), val, del,
+			     schedule_assign_is_reactive_(thr));
       return true;
 }
 
@@ -4443,7 +4498,8 @@ bool of_ASSIGN_VEC4_OFF_E(vthread_t thr, vvp_code_t cp)
 	    return true;
 
       if (thr->ecount == 0) {
-	    schedule_assign_vector(ptr, off, sig->value_size(), val, 0);
+	    schedule_assign_vector(ptr, off, sig->value_size(), val, 0,
+				   schedule_assign_is_reactive_(thr));
       } else {
 	    schedule_evctl(ptr, val, off, sig->value_size(), thr->event, thr->ecount);
       }
@@ -4465,7 +4521,8 @@ bool of_ASSIGN_VEC4D(vthread_t thr, vvp_code_t cp)
       vvp_signal_value*sig = dynamic_cast<vvp_signal_value*> (cp->net->fil);
       assert(sig);
 
-      schedule_assign_vector(ptr, 0, sig->value_size(), value, del);
+      schedule_assign_vector(ptr, 0, sig->value_size(), value, del,
+			     schedule_assign_is_reactive_(thr));
 
       return true;
 }
@@ -4482,7 +4539,8 @@ bool of_ASSIGN_VEC4E(vthread_t thr, vvp_code_t cp)
       assert(sig);
 
       if (thr->ecount == 0) {
-	    schedule_assign_vector(ptr, 0, sig->value_size(), value, 0);
+	    schedule_assign_vector(ptr, 0, sig->value_size(), value, 0,
+				   schedule_assign_is_reactive_(thr));
       } else {
 	    schedule_evctl(ptr, value, 0, sig->value_size(), thr->event, thr->ecount);
       }
@@ -5697,6 +5755,7 @@ static bool do_callf_void(vthread_t thr, vthread_t child)
 
         // Mark the function thread as a direct child of the current thread.
       child->parent = thr;
+      child->is_reactive_process |= thr->is_reactive_process;
       thr->children.insert(child);
         // This should be the only child
       assert(thr->children.size()==1);
@@ -8450,6 +8509,7 @@ bool of_FORK(vthread_t thr, vvp_code_t cp)
       trace_context_event_("fork", thr, child->parent_scope, child->wt_context);
 
       child->parent = thr;
+      child->is_reactive_process |= thr->is_reactive_process;
 	/* Task calls compiled as %fork...%join should share the parent's
 	   logical process for process::self(), matching SV semantics where
 	   a task call runs in the calling thread's process. Mark them
@@ -8502,6 +8562,7 @@ bool of_FORK_V(vthread_t thr, vvp_code_t cp)
       trace_context_event_("fork", thr, child->parent_scope, child->wt_context);
 
       child->parent = thr;
+      child->is_reactive_process |= thr->is_reactive_process;
       child->is_fork_v_child = 1;
       thr->children.insert(child);
 
@@ -15008,6 +15069,7 @@ static bool do_exec_ufunc(vthread_t thr, vvp_code_t cp, vthread_t child)
       child->delay_delete = 1;
 
       child->parent = thr;
+      child->is_reactive_process |= thr->is_reactive_process;
       thr->children.insert(child);
 	// This should be the only child
       assert(thr->children.size()==1);

--- a/vvp/vthread.cc
+++ b/vvp/vthread.cc
@@ -1892,9 +1892,12 @@ bool of_QUNIQUE_IDX(vthread_t thr, vvp_code_t cp)
 
 /* Phase 63b/Q-methods (gap close): sort q by keys queue.  q[i]
  * stays paired with keys[i] under the permutation.  After sort,
- * q is in ascending (sort) or descending (rsort) order of keys. */
-template<typename ELEM>
-static void qsort_with_keys_helper_(vvp_darray*q, vector<int32_t>&keys,
+ * q is in ascending (sort) or descending (rsort) order of keys.
+ * The key type follows the with expression (IEEE 1800-2017 7.12.2:
+ * the relational operators shall be defined for the type of the
+ * expression): signed 32-bit integral, string, or real. */
+template<typename ELEM, typename KEY>
+static void qsort_with_keys_helper_(vvp_darray*q, vector<KEY>&keys,
                                     bool reverse)
 {
       size_t sz = q->get_size();
@@ -1904,12 +1907,26 @@ static void qsort_with_keys_helper_(vvp_darray*q, vector<int32_t>&keys,
       for (size_t i = 0; i < sz; i++) perm[i] = i;
       std::sort(perm.begin(), perm.end(),
                 [&](size_t a, size_t b) {
-                      return reverse ? keys[a] > keys[b]
+                      return reverse ? keys[b] < keys[a]
                                      : keys[a] < keys[b];
                 });
       vector<ELEM> sorted(sz);
       for (size_t i = 0; i < sz; i++) sorted[i] = qvals[perm[i]];
       for (size_t i = 0; i < sz; i++) q->set_word((unsigned)i, sorted[i]);
+}
+
+template<typename KEY>
+static void qsort_by_keys_elem_dispatch_(vvp_darray*q, vector<KEY>&keys,
+                                         bool reverse)
+{
+      if (dynamic_cast<vvp_queue_real*>(q) || dynamic_cast<vvp_darray_real*>(q))
+            qsort_with_keys_helper_<double, KEY>(q, keys, reverse);
+      else if (dynamic_cast<vvp_queue_string*>(q) || dynamic_cast<vvp_darray_string*>(q))
+            qsort_with_keys_helper_<string, KEY>(q, keys, reverse);
+      else if (dynamic_cast<vvp_queue_object*>(q) || dynamic_cast<vvp_darray_object*>(q))
+            qsort_with_keys_helper_<vvp_object_t, KEY>(q, keys, reverse);
+      else
+            qsort_with_keys_helper_<vvp_vector4_t, KEY>(q, keys, reverse);
 }
 
 static void qsort_with_keys_dispatch_(vvp_darray*q, vvp_darray*keys_arr,
@@ -1919,7 +1936,25 @@ static void qsort_with_keys_dispatch_(vvp_darray*q, vvp_darray*keys_arr,
       size_t sz = q->get_size();
       if (sz != keys_arr->get_size()) return;
 
-      // Extract keys as int32_t.
+      if (dynamic_cast<vvp_queue_string*>(keys_arr)
+          || dynamic_cast<vvp_darray_string*>(keys_arr)) {
+            vector<string> keys(sz);
+            for (size_t i = 0; i < sz; i++)
+                  keys_arr->get_word((unsigned)i, keys[i]);
+            qsort_by_keys_elem_dispatch_<string>(q, keys, reverse);
+            return;
+      }
+
+      if (dynamic_cast<vvp_queue_real*>(keys_arr)
+          || dynamic_cast<vvp_darray_real*>(keys_arr)) {
+            vector<double> keys(sz, 0.0);
+            for (size_t i = 0; i < sz; i++)
+                  keys_arr->get_word((unsigned)i, keys[i]);
+            qsort_by_keys_elem_dispatch_<double>(q, keys, reverse);
+            return;
+      }
+
+      // Default: signed 32-bit integral keys.
       vector<int32_t> keys(sz, 0);
       for (size_t i = 0; i < sz; i++) {
             vvp_vector4_t kv;
@@ -1929,15 +1964,7 @@ static void qsort_with_keys_dispatch_(vvp_darray*q, vvp_darray*keys_arr,
             vector4_to_value(kv, overflow, u);
             keys[i] = (int32_t)u;
       }
-
-      if (dynamic_cast<vvp_queue_real*>(q) || dynamic_cast<vvp_darray_real*>(q))
-            qsort_with_keys_helper_<double>(q, keys, reverse);
-      else if (dynamic_cast<vvp_queue_string*>(q) || dynamic_cast<vvp_darray_string*>(q))
-            qsort_with_keys_helper_<string>(q, keys, reverse);
-      else if (dynamic_cast<vvp_queue_object*>(q) || dynamic_cast<vvp_darray_object*>(q))
-            qsort_with_keys_helper_<vvp_object_t>(q, keys, reverse);
-      else
-            qsort_with_keys_helper_<vvp_vector4_t>(q, keys, reverse);
+      qsort_by_keys_elem_dispatch_<int32_t>(q, keys, reverse);
 }
 
 bool of_QSORT_KEYS(vthread_t thr, vvp_code_t cp)
@@ -1965,13 +1992,13 @@ bool of_QRSORT_KEYS(vthread_t thr, vvp_code_t cp)
 }
 
 /* unique with key extractor: keep first element with each unique key. */
-template<typename ELEM>
-static void qunique_keys_helper_(vvp_darray*q, vector<int32_t>&keys)
+template<typename ELEM, typename KEY>
+static void qunique_keys_helper_(vvp_darray*q, vector<KEY>&keys)
 {
       size_t sz = q->get_size();
       vector<ELEM> qvals(sz);
       for (size_t i = 0; i < sz; i++) q->get_word((unsigned)i, qvals[i]);
-      vector<int32_t> seen_keys;
+      vector<KEY> seen_keys;
       vector<ELEM> kept;
       for (size_t i = 0; i < sz; i++) {
             bool found = false;
@@ -1991,6 +2018,19 @@ static void qunique_keys_helper_(vvp_darray*q, vector<int32_t>&keys)
       }
 }
 
+template<typename KEY>
+static void qunique_by_keys_elem_dispatch_(vvp_darray*q, vector<KEY>&keys)
+{
+      if (dynamic_cast<vvp_queue_real*>(q) || dynamic_cast<vvp_darray_real*>(q))
+            qunique_keys_helper_<double, KEY>(q, keys);
+      else if (dynamic_cast<vvp_queue_string*>(q) || dynamic_cast<vvp_darray_string*>(q))
+            qunique_keys_helper_<string, KEY>(q, keys);
+      else if (dynamic_cast<vvp_queue_object*>(q) || dynamic_cast<vvp_darray_object*>(q))
+            qunique_keys_helper_<vvp_object_t, KEY>(q, keys);
+      else
+            qunique_keys_helper_<vvp_vector4_t, KEY>(q, keys);
+}
+
 bool of_QUNIQUE_KEYS(vthread_t thr, vvp_code_t cp)
 {
       (void)thr;
@@ -2003,6 +2043,24 @@ bool of_QUNIQUE_KEYS(vthread_t thr, vvp_code_t cp)
       size_t sz = q->get_size();
       if (sz != k->get_size()) return true;
 
+      if (dynamic_cast<vvp_queue_string*>(k)
+          || dynamic_cast<vvp_darray_string*>(k)) {
+            vector<string> keys(sz);
+            for (size_t i = 0; i < sz; i++)
+                  k->get_word((unsigned)i, keys[i]);
+            qunique_by_keys_elem_dispatch_<string>(q, keys);
+            return true;
+      }
+
+      if (dynamic_cast<vvp_queue_real*>(k)
+          || dynamic_cast<vvp_darray_real*>(k)) {
+            vector<double> keys(sz, 0.0);
+            for (size_t i = 0; i < sz; i++)
+                  k->get_word((unsigned)i, keys[i]);
+            qunique_by_keys_elem_dispatch_<double>(q, keys);
+            return true;
+      }
+
       vector<int32_t> keys(sz, 0);
       for (size_t i = 0; i < sz; i++) {
             vvp_vector4_t kv;
@@ -2012,15 +2070,7 @@ bool of_QUNIQUE_KEYS(vthread_t thr, vvp_code_t cp)
             vector4_to_value(kv, overflow, u);
             keys[i] = (int32_t)u;
       }
-
-      if (dynamic_cast<vvp_queue_real*>(q) || dynamic_cast<vvp_darray_real*>(q))
-            qunique_keys_helper_<double>(q, keys);
-      else if (dynamic_cast<vvp_queue_string*>(q) || dynamic_cast<vvp_darray_string*>(q))
-            qunique_keys_helper_<string>(q, keys);
-      else if (dynamic_cast<vvp_queue_object*>(q) || dynamic_cast<vvp_darray_object*>(q))
-            qunique_keys_helper_<vvp_object_t>(q, keys);
-      else
-            qunique_keys_helper_<vvp_vector4_t>(q, keys);
+      qunique_by_keys_elem_dispatch_<int32_t>(q, keys);
       return true;
 }
 

--- a/vvp/vthread.h
+++ b/vvp/vthread.h
@@ -52,6 +52,14 @@ extern vthread_t vthread_new(vvp_code_t sa, __vpiScope*scope);
 extern void vthread_mark_scheduled(vthread_t thr);
 
 /*
+ * True when the thread belongs to a program block (its scope chain
+ * includes a vpiProgram scope) or was spawned by such a thread; the
+ * scheduler places these in the Reactive region set (IEEE 1800-2017
+ * 4.4.2.5, clause 24).
+ */
+extern int vthread_is_reactive(vthread_t thr);
+
+/*
  * This function marks the thread as being a final procedure.
  */
 extern void vthread_mark_final(vthread_t thr);


### PR DESCRIPTION
# Summary

Five stacked checkpoints.

## Checkpoint 1 — M6 item 2: Reactive region set for program blocks (4.4.2.5–.7, clause 24)

Program-block processes now schedule in the Reactive region set, so testbench code observes the design's **post-NBA state** race-free. New per-slot queues (`reactive`/`re_inactive`/`re_nbassign`) with the 4.4.2 promotion order; per-thread reactive flag from the new `.scope program` type (new `ivl_scope_program` API, exported in `ivl.def`), inherited by spawned children; event wake chains partitioned by region. Test: `tests/m6_reactive_region_test.sv`.

## Checkpoint 2 — G10: array reduction methods and min()/max() locators (7.12)

7.12.3 reductions (`sum/product/and/or/xor`) and 7.12.1 `min()/max()` over queues, dynamic arrays and 1-D fixed-size unpacked arrays, in all four source forms (call, call+with, paren-less, paren-less+with) including the keyword-named `.and()/.or()/.xor()` (new grammar rules, +6 documented s/r conflicts). `find*` locators extended to dynamic and fixed arrays. Result width/signedness follow the with expression per 7.12.3. Per-call iterator binding via new `NetScope::set_signal_alias` (7.12: "the scope for the iterator_argument is the with expression") — also fixes a pre-existing find_with bug where sibling calls sharing one hidden `item` net poisoned signedness/width and could clobber a user variable named `item`. Runtime is inline vvp loops from existing opcodes only. Tests: `tests/g10_array_methods_test.sv` (43 checks incl. all 7.12.3 LRM literal examples) + `tests/negative/g10_reduction_non_integral.sv`.

## Checkpoint 3 — G10 tail: class-property receivers (the dominant UVM shape)

`this.q.sum()`, nested chains (`cfg.st.q.max()`), external and paren-less forms, call-result chains. Non-signal object receivers are evaluated once and their handle stored into a hidden container-typed net the loop indexes (`draw_array_method_recv_`); the PEIdent class-property tail path that previously **warned and silently dropped** the expression now routes to the same machinery.

## Checkpoint 4 — G68/G69: two latent defects exposed by checkpoint 3

Checkpoint 3 made the UVM sequencer zombie predicate execute for the first time, deterministically deadlocking seq_trace_test / vif_smoke / vif_smoke_v2 (SEQLCKZMB@0 → PH_TIMEOUT@9200). Root-caused via pointer-normalized image diffs and an env-gated runtime trace:

- **G68 (9.7)**: `process::status()` read a dead stored property (always 0 = FINISHED) — and the compile-progress stub classifier also folded it to 0. Now a live query via new vvp opcode `%process/status`; `process::` state enum constants also bind in module scope. Test: `tests/g68_process_status_test.sv`.
- **G69 (Table 11-2)**: `inside` sat at ternary precedence, so `a && b inside {c,d}` parsed as `(a && b) inside {c,d}` — making `0 inside {KILLED, FINISHED=0}` match every non-lock arbitration entry. `K_inside` moved to the relational `%left` group; conflict counts unchanged. Test: `tests/g69_inside_precedence_test.sv`.

## Checkpoint 5 — 7.12.2 ordering methods: property receivers, typed sort keys, iterator aliasing

Three silent defects in the sort/rsort/reverse/shuffle/unique statement paths: **(1)** instance-property receivers were a silent no-op (explicit skip in tgt-vvp) — now the hidden-recv-net pattern from checkpoint 3, so `r.iq.sort()` really sorts; **(2)** with-clause sort keys were always truncated to int32 — string keys sharing a 4-byte prefix compared equal, silently mis-sorting the exact UVM shape `sort() with (item.get_full_name())` (uvm_cmdline_report, uvm_phase_hopper); keys queues are now typed by the with expression (string/real/signed-32) end to end, with the runtime key helpers generalized over key type — no new opcodes; **(3)** the sort_with elaboration still used the shared iterator-net scheme — now fresh per-call nets via `NetScope::set_signal_alias`. Test: `tests/g10_ordering_methods_test.sv` (28 checks).

## Regressions (final, quiet machine, head 543454a)

| Suite | Result |
|---|---|
| UVM (`.github/uvm_test.sh`) | **122 passed, 0 failed** (118 baseline + 4 new tests) |
| ivtest `vvp_reg.pl` | 2961/3101 passed, 132 pre-existing fails — **failure names identical to baseline** |
| ivtest `vpi_reg.pl --with-pli1` | 85/85 |
| ivtest `vvp_reg.py` | Ran 284, Failed 12 (same pre-existing set) |
| `tests/negative` | 6/6 rejected with diagnostics |
| Focused m6/g12/m3/g10/g68/g69 suites + all reduced probes | all pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017kkDsUYVP7DtfaJLMQNgSC