### PR TITLE
M6 completion: trampoline is the default callf model; remove the broken scheduled path

### DIFF
--- a/docs/conformance/CURRENT_WORK.md
+++ b/docs/conformance/CURRENT_WORK.md
@@ -3,6 +3,37 @@
 Keep this accurate enough that another session can resume without repeating
 the investigation. Update at every meaningful checkpoint.
 
+## State as of 2026-07-14h (session: M6 COMPLETION — trampoline default + scheduled-path deletion)
+
+- **Branch**: `claude/ieee1800-systemverilog-uvm-tqk5qy` (fresh from
+  merged main after PR #71; new PR to open for this work).
+- **This checkpoint completes M6**:
+  - **Increment 3**: flipped the callf default to the trampoline
+    (`IVL_TRAMPOLINE_CALLF=0` = legacy synchronous fallback).  Full
+    default-config battery clean (UVM 127/127, ivtest baseline-identical,
+    vpi 85/85, py 284/12).  The default subroutine-call model now
+    preserves function-call atomicity (IEEE 13.4.3) and bounds C++ stack
+    depth by the `vthread_run` loop, not SV call depth.
+  - **Increment 4**: deleted the BROKEN scheduled-call path
+    (`IVL_SCHED_CALLF`, `sched_callf_enabled_`, `schedule_defer_calls_ok`,
+    `sched_main_loop_running`) — proven incorrect by the atomicity
+    finding, so dead/wrong code.  RETAINED (one-release fallback) the
+    synchronous drain loops + staging + limit maps behind
+    `IVL_TRAMPOLINE_CALLF=0`.
+  - Details: `session_logs/2026-07-14_m6_completion.md`; rearchitecture
+    doc increments 3-4 recorded.
+- **M6 STATUS: functionally complete.**  All five remediation items
+  delivered (region tagging/invariants; reactive regions; slot-persistent
+  event.triggered/G08; Preponed/Observed; atomicity-correct trampoline
+  call model as default).  Sole remaining item is code hygiene — deleting
+  the retained synchronous fallback + staging heuristics after a release
+  soak (no behavior/capability change).
+- **Next milestone**: M8 (clocking blocks) or M9 (core SVA engine) — both
+  now have their scheduler foundation (region tags/invariants,
+  Preponed/Observed entry points, atomicity-correct calls).  G01 (clocking
+  outside interface, hard crash) and G05/G06 (SVA sequence operators) are
+  the gap-audit entry points.
+
 ## State as of 2026-07-14g (session: M6 item 5 rearchitecture increment 2 — trampolined callf)
 
 - **Branch**: `claude/ieee1800-systemverilog-uvm-tqk5qy` (PR #71 open,

--- a/docs/conformance/m6_callf_rearchitecture.md
+++ b/docs/conformance/m6_callf_rearchitecture.md
@@ -111,12 +111,20 @@ general watchdog.  This is the full realization of step 5.
    limitation: `do_join`'s automatic-context reconciliation is O(depth),
    so recursion beyond a few thousand frames is slow (O(depth²)) — still
    deeper than the synchronous model's 4096 cap; a perf follow-up.
-3. **NEXT** — Flip the default to the trampoline (its own checkpoint,
-   the highest-risk change); then delete the three synchronous drain
-   loops + the automatic-context staging in `do_callf_void`.
-4. Delete the now-unused limit maps and the depth backstops (the
-   trampoline needs only the single `TRAMPOLINE_MAX_DEPTH` runaway
-   guard, or the scheduler's zero-time watchdog).
+3. **DONE 2026-07-14** — Flipped the default to the trampoline
+   (`IVL_TRAMPOLINE_CALLF=0` selects the legacy synchronous fallback).
+   Full default-config battery clean: UVM 127/127, ivtest failure names
+   byte-identical to baseline, vpi 85/85, py 284/12.
+4. **PARTIAL 2026-07-14** — Deleted the BROKEN scheduled-call path
+   (`IVL_SCHED_CALLF` and `schedule_defer_calls_ok`/`sched_main_loop_running`):
+   the atomicity finding proved it wrong, so it was dead, incorrect
+   code — an unconditional removal.  **Retained** (for one release, per
+   the manifesto's fallback rule) the synchronous `do_callf_void` drain
+   loops + automatic-context staging + limit maps as the
+   `IVL_TRAMPOLINE_CALLF=0` fallback: ~450 lines of battle-tested
+   edge-case handling (reaped-child recovery, dynamic-dispatch mirroring)
+   that deserve a soak before removal.  Their deletion is the final
+   follow-up once the trampoline default has soaked a release.
 
 Each step preserves the atomicity invariant
 (`tests/m6_call_atomicity_test.sv`) and the call semantics

--- a/docs/conformance/session_logs/2026-07-14_m6_completion.md
+++ b/docs/conformance/session_logs/2026-07-14_m6_completion.md
@@ -1,0 +1,70 @@
+# Session log — 2026-07-14: M6 completion — trampoline default + scheduled-path deletion
+
+Engineering target: complete M6 by flipping the callf default to the
+trampoline (increment 3) and deleting the broken scheduled-call path
+(increment 4).
+
+## Increment 3 — trampoline is the default
+
+`trampoline_callf_enabled_()` now defaults ON; `IVL_TRAMPOLINE_CALLF=0`
+selects the legacy synchronous fallback.  The trampoline (increment 2)
+had already reached full parity behind the flag; as the default it is
+clean across the whole battery:
+- UVM **127/127**
+- ivtest `vvp_reg.pl` failure names **byte-identical to baseline**
+- `vpi_reg.pl` 85/85, `vvp_reg.py` 284/12
+- negative 6/6; all focused M6 SV suites incl. `m6_call_atomicity`
+- `IVL_TRAMPOLINE_CALLF=0` fallback still passes the focused suites.
+
+So the default subroutine-call model now preserves function-call
+atomicity (IEEE 1800-2017 13.4.3) AND bounds C++ stack depth by the
+`vthread_run` loop rather than the SV call depth.
+
+## Increment 4 — delete the broken scheduled-call path
+
+The scheduled-call path (`IVL_SCHED_CALLF`) was proven incorrect by the
+step-3 atomicity finding (it suspends the caller, so concurrent calls
+interleave — `pr2001162`/`pr2053944`).  It was dead, wrong code, so it is
+removed unconditionally:
+- `sched_callf_enabled_()` and its `do_callf_void` branch (vthread.cc);
+- `schedule_defer_calls_ok()` + `sched_main_loop_running` (schedule.cc/.h)
+  — these existed only to gate the scheduled path.
+
+## What is retained, and why (manifesto: one-release fallback)
+
+The synchronous `do_callf_void` drain loops, the automatic-context
+staging (`staged_alloc_rd_context` / `skip_free_context`), and the
+name-agnostic limit maps are kept as the `IVL_TRAMPOLINE_CALLF=0`
+fallback.  These are ~450 lines of battle-tested edge-case handling
+(reaped-child recovery, dynamic-dispatch output mirroring); with the
+trampoline only just made the default, they warrant a soak before
+deletion.  SV functions cannot fork (13.4.4), so the descendant-drain
+loops cover no legal function case the trampoline misses — but the other
+edge-case handling justifies the caution.
+
+## M6 status
+
+All five remediation items delivered their capabilities:
+1. region tagging + invariants — DONE
+2. reactive region scheduling — DONE
+3. slot-persistent `event.triggered` (G08) — DONE
+4. Preponed + Observed regions — DONE
+5. atomicity-correct call model (trampoline) is the DEFAULT; the broken
+   scheduled experiment is removed.
+
+M6's remediation is **functionally complete**: a correct, race-aware
+scheduler with region ownership, the SVA/clocking region foundation, and
+an atomicity-preserving call model as the default.  The single remaining
+item is pure code hygiene — deleting the retained synchronous fallback +
+its staging heuristics after a release soak — which changes no behavior
+or capability.
+
+## Next
+
+Per the plan, move to the next milestone.  M6's foundation (region
+tags/invariants, Preponed/Observed entry points, atomicity-correct
+calls) directly unblocks M8 (clocking blocks) and M9 (core SVA engine).
+
+## Regression evidence
+
+Recorded in the checkpoint commit message.

--- a/vvp/schedule.cc
+++ b/vvp/schedule.cc
@@ -1284,18 +1284,6 @@ static bool sim_at_rosync = false;
 bool schedule_at_rosync(void)
 { return sim_at_rosync; }
 
-/*
- * True only while the main stratified event loop is draining events.
- * The scheduled-call protocol (M6 item 5) suspends the caller and lets
- * the scheduler drive the callee, so it is only valid here: the
- * pre-simulation init phase, the post-simulation final phase, and the
- * read-only Postponed (rosync) region have no active-queue loop to
- * drive a deferred call and are inherently sequential, so calls there
- * must execute synchronously.
- */
-static bool sched_main_loop_running = false;
-bool schedule_defer_calls_ok(void)
-{ return sched_main_loop_running && !sim_at_rosync; }
 
 /*
  * The scheduler uses this function to drain the rosync events of the
@@ -1457,7 +1445,6 @@ void schedule_simulate(void)
       vvp_time64_t last_trace_time = 0;
       vvp_time64_t last_sim_time = schedule_time;
 
-      sched_main_loop_running = true;
       if (schedule_runnable) while (sched_list) {
 
 	    if (schedule_stopped_flag) {
@@ -1626,7 +1613,6 @@ void schedule_simulate(void)
 	    delete (cur);
       }
       sched_current_region = SEQ_START;
-      sched_main_loop_running = false;
 
       if (schedule_runnable && !sched_list)
             vthread_dump_live_threads("scheduler-quiesce");

--- a/vvp/schedule.h
+++ b/vvp/schedule.h
@@ -196,14 +196,6 @@ extern vvp_time64_t schedule_simtime(void);
 extern bool schedule_at_rosync(void);
 
 /*
- * True only while the main stratified event loop is draining events.
- * The scheduled-call protocol (M6 item 5) is valid only here; the
- * init/final/rosync phases are inherently sequential and must run
- * subroutine calls synchronously.
- */
-extern bool schedule_defer_calls_ok(void);
-
-/*
  * This function is the equivalent of the $finish system task. It
  * tells the simulator that simulation is done, the current thread
  * should be stopped, all remaining events abandoned and the

--- a/vvp/vthread.cc
+++ b/vvp/vthread.cc
@@ -5067,20 +5067,26 @@ static bool sched_callf_enabled_()
 }
 
 /*
- * M6 item 5 rearchitecture, increment 2: trampolined synchronous call.
- * Under IVL_TRAMPOLINE_CALLF, a %callf does not recurse into
- * vthread_run(child); instead the caller's vthread_run loop switches to
- * the callee frame and back, so the call runs synchronously (atomicity
- * preserved) WITHOUT consuming C++ stack per SV call depth.  Default
- * OFF: the synchronous do_callf_void path is unchanged.  See
- * docs/conformance/m6_callf_rearchitecture.md.
+ * M6 item 5 rearchitecture: trampolined synchronous call.  A %callf does
+ * not recurse into vthread_run(child); instead the caller's vthread_run
+ * loop switches to the callee frame and back, so the call runs
+ * synchronously (function-call atomicity preserved, IEEE 1800-2017
+ * 13.4.3) WITHOUT consuming C++ stack per SV call depth.
+ *
+ * Increment 3 (2026-07-14): this is now the DEFAULT.  It reached full
+ * parity behind the flag (UVM 127/127 + ivtest failure names
+ * byte-identical to baseline, atomicity suite passing).  Set
+ * IVL_TRAMPOLINE_CALLF=0 to fall back to the synchronous do_callf_void
+ * path for one release.  See docs/conformance/m6_callf_rearchitecture.md.
  */
 static bool trampoline_callf_enabled_()
 {
       static int enabled = -1;
       if (enabled < 0) {
             const char*env = getenv("IVL_TRAMPOLINE_CALLF");
-            enabled = (env && *env && strcmp(env, "0") != 0) ? 1 : 0;
+              // Default ON; only an explicit "0" selects the legacy
+              // synchronous fallback.
+            enabled = (env && strcmp(env, "0") == 0) ? 0 : 1;
       }
       return enabled != 0;
 }

--- a/vvp/vthread.cc
+++ b/vvp/vthread.cc
@@ -5047,24 +5047,6 @@ static bool callf_trace_enabled_()
       return enabled != 0;
 }
 
-/*
- * M6 remediation item 5, migration step 2: gate the scheduled-call
- * protocol.  When IVL_SCHED_CALLF is set, a %callf schedules the callee
- * as a normal Active-region thread and suspends the caller instead of
- * running the callee synchronously inside the caller's opcode dispatch.
- * Default OFF: the synchronous do_callf_void path is unchanged, so
- * production behavior and every regression are byte-identical.  See
- * docs/conformance/m6_scheduled_call_protocol.md.
- */
-static bool sched_callf_enabled_()
-{
-      static int enabled = -1;
-      if (enabled < 0) {
-            const char*env = getenv("IVL_SCHED_CALLF");
-            enabled = (env && *env && strcmp(env, "0") != 0) ? 1 : 0;
-      }
-      return enabled != 0;
-}
 
 /*
  * M6 item 5 rearchitecture: trampolined synchronous call.  A %callf does
@@ -5908,33 +5890,6 @@ static bool do_callf_void(vthread_t thr, vthread_t child)
             trampoline_call_stack.push_back(thr);
             trampoline_switch_to = child;
             return true;
-      }
-
-        /* Scheduled-call protocol (M6 item 5, step 2, IVL_SCHED_CALLF):
-         * hand the callee to the scheduler as an Active-region thread
-         * (pushed to the front so it runs next, matching the
-         * synchronous model's zero-time semantics) and SUSPEND the
-         * caller.  The caller's return placeholder is already on its
-         * stack and %ret targets child->parent (the caller), so the
-         * value lands while the caller is frozen.  On %end, of_END sees
-         * the caller's i_am_joining flag and resumes it via the
-         * existing join machinery (resume_joining_parent_ -> do_join),
-         * which mirrors output/ref args and reaps the callee.  Returning
-         * false pauses the caller; its PC already points past the
-         * %callf, so it resumes at the next opcode with the filled
-         * return value.  schedule_vthread owns is_scheduled, so it is
-         * not pre-set here. */
-      if (sched_callf_enabled_() && schedule_defer_calls_ok()) {
-            child->i_am_in_function = 1;
-            child->delay_delete = 1;
-            thr->i_am_joining = 1;
-              /* The scheduled callee unwinds through the scheduler, not
-               * this C++ frame, so drop the synchronous-recursion
-               * bookkeeping taken on entry. */
-            callf_scope_stack.pop_back();
-            callf_depth--;
-            schedule_vthread(child, 0, true);
-            return false;
       }
 
       child->is_scheduled = 1;


### PR DESCRIPTION
# Summary

Completes the M6 scheduler-remediation program by making the trampolined synchronous call the default subroutine-call model and removing the broken scheduled-call experiment.

## Increment 3 — trampoline is the default

`trampoline_callf_enabled_()` now defaults ON (`IVL_TRAMPOLINE_CALLF=0` selects the legacy synchronous fallback). The trampoline (merged in PR #71 behind the flag) had already reached full parity; as the default the whole battery is clean. The default call model now preserves function-call atomicity (IEEE 1800-2017 13.4.3 — a function executes as part of the calling process, so concurrent calls must not interleave) **and** bounds C++ stack depth by the `vthread_run` loop rather than the SV call depth.

## Increment 4 — delete the broken scheduled-call path

The scheduled-call path (`IVL_SCHED_CALLF`) was proven incorrect by the atomicity finding (it suspends the caller, so concurrent calls interleave — `pr2001162`/`pr2053944`). It's dead, wrong code, removed unconditionally: `sched_callf_enabled_()` + its `do_callf_void` branch, and the now-dead `schedule_defer_calls_ok()` / `sched_main_loop_running` that only gated it.

**Retained** (manifesto one-release fallback): the synchronous `do_callf_void` drain loops + automatic-context staging + name-agnostic limit maps as the `IVL_TRAMPOLINE_CALLF=0` fallback — ~450 lines of battle-tested edge-case handling that warrant a soak before deletion. Their removal is the final follow-up.

## M6 status: functionally complete

All five remediation items delivered their capabilities: (1) region tagging + invariants, (2) reactive region scheduling, (3) slot-persistent `event.triggered` (G08), (4) Preponed + Observed regions, (5) atomicity-correct trampoline call model as the default with the broken experiment removed. The scheduler now has region ownership, the SVA/clocking region foundation, and an atomicity-preserving call model — unblocking M8 (clocking) and M9 (SVA). The sole remaining M6 item is code hygiene (deleting the retained fallback after a soak), which changes no behavior.

Design + increment history: `docs/conformance/m6_callf_rearchitecture.md`, `docs/conformance/session_logs/2026-07-14_m6_completion.md`.

## Regressions (default config = trampoline, quiet machine)

| Suite | Result |
|---|---|
| UVM (`.github/uvm_test.sh`) | **127 passed, 0 failed** |
| ivtest `vvp_reg.pl` | 2961/3101 passed, 132 pre-existing — **failure names identical to baseline** |
| ivtest `vpi_reg.pl --with-pli1` | 85/85 |
| ivtest `vvp_reg.py` | Ran 284, Failed 12 (baseline-identical) |
| `tests/negative` | 6/6 rejected with diagnostics |
| region-trace + focused M6×6 suites (incl. `m6_call_atomicity`) | all pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017kkDsUYVP7DtfaJLMQNgSC

---
_Generated by [Claude Code](https://claude.ai/code/session_017kkDsUYVP7DtfaJLMQNgSC)_