### PR TITLE
M8 entry: clocking blocks in module/program scope (G01/G02) + procedural ##N cycle delays

### DIFF
--- a/Module.h
+++ b/Module.h
@@ -150,6 +150,13 @@ class Module : public PScopeExtra, public PNamedItem {
       std::map<perm_string,PModport*> modports;
       std::map<perm_string,PClocking*> clocking_blocks;
 
+	/* IEEE 1800-2017 14.12: at most one default clocking block per
+	   module, interface, or program. Nil when no default is declared.
+	   Anonymous default clocking blocks are registered in
+	   clocking_blocks under an internal name that no source
+	   identifier can collide with. */
+      perm_string default_clocking;
+
 	/* List for specify paths and timing checks */
       std::list<PSpecPath*> specify_paths;
       std::list<PTimingCheck*> timing_checks;

--- a/Statement.cc
+++ b/Statement.cc
@@ -304,6 +304,15 @@ PDelayStatement::~PDelayStatement()
 {
 }
 
+PCycleDelay::PCycleDelay(PExpr*count, Statement*st)
+: count_(count), statement_(st)
+{
+}
+
+PCycleDelay::~PCycleDelay()
+{
+}
+
 PDisable::PDisable(const pform_name_t&sc)
 : scope_(sc)
 {

--- a/Statement.h
+++ b/Statement.h
@@ -476,6 +476,29 @@ class PDelayStatement  : public Statement {
       Statement*statement_;
 };
 
+/*
+ * IEEE 1800-2017 14.11: procedural cycle delay `## count [statement]`.
+ * Waits `count` events of the default clocking block visible in the
+ * enclosing module/interface/program scope, then runs the optional
+ * sub-statement. Elaboration lowers this to
+ *   repeat (count) @(<default clocking>) ; <statement>
+ */
+class PCycleDelay : public Statement {
+
+    public:
+      PCycleDelay(PExpr*count, Statement*st);
+      ~PCycleDelay() override;
+
+      virtual void dump(std::ostream&out, unsigned ind) const override;
+      virtual NetProc* elaborate(Design*des, NetScope*scope) const override;
+      virtual void elaborate_scope(Design*des, NetScope*scope) const override;
+      virtual void elaborate_sig(Design*des, NetScope*scope) const override;
+
+    private:
+      PExpr*count_;
+      Statement*statement_;
+};
+
 
 /*
  * This represents the parsing of a disable <scope> statement.

--- a/docs/claude/uvm_ieee1800_gap_audit_2026_05.md
+++ b/docs/claude/uvm_ieee1800_gap_audit_2026_05.md
@@ -22,6 +22,20 @@ Iverilog under test: `Icarus Verilog version 13.0 (devel) (s20251012-102-g9b44d5
 - Layer: parser/pform.
 - Complexity: small if just lifting the assertion to an error; larger to actually plumb through code-gen.
 - Blocks: any module-level clocking + program blocks.
+- **STATUS 2026-07-14: FIXED** (M8 entry;
+  `session_logs/2026-07-14_g01_clocking_blocks.md`). Clocking blocks
+  register and work in module/interface/program scope: same-scope
+  `@(cb)` + `cb.sig` read/drive, hierarchical `@(inst.cb)` +
+  `inst.cb.sig`. Also: `default clocking` declaration/reference forms
+  registered (were parsed-and-dropped), full 14.4 skew SYNTAX
+  (`#1step`, edge skews, default skew items — skews accepted and
+  discarded under the alias model), and procedural `##N` cycle delays
+  (14.11) lowering to `repeat (N) @(default clocking)`. REMAINING
+  (next M8 increment): actual sample/drive skew semantics — `cb.sig`
+  is still a direct alias of the underlying signal; `cb.sig <= ##N v`
+  intra-assignment cycle delays; `clocking_decl_assign`; `global
+  clocking` (14.14). Tests: `tests/g01_module_clocking_test.sv`,
+  `tests/g01_cycle_delay_test.sv`, `tests/negative/g01_*.sv`.
 
 ### G02 program blocks parse but reject clocking inside
 - Symptom: program block parses but clocking inside fails the same `is_interface` assertion as G01.
@@ -30,6 +44,9 @@ Iverilog under test: `Icarus Verilog version 13.0 (devel) (s20251012-102-g9b44d5
 - Layer: parser/pform.
 - Complexity: same fix as G01 widens the predicate.
 - Blocks: program blocks (24.2 testbench style).
+- **STATUS 2026-07-14: FIXED** with G01 (same root cause; program-scope
+  clocking verified end to end incl. output drives —
+  `tests/g01_module_clocking_test.sv` program section).
 
 ### G03 `let` declarations always rejected as `sorry:`
 - Symptom: `let MAX(a,b) = (a>b)?a:b;` produces `sorry: let declarations (MAX) are not currently supported.`

--- a/docs/conformance/CURRENT_WORK.md
+++ b/docs/conformance/CURRENT_WORK.md
@@ -3,6 +3,49 @@
 Keep this accurate enough that another session can resume without repeating
 the investigation. Update at every meaningful checkpoint.
 
+## State as of 2026-07-14i (session: M8 entry — G01/G02 clocking blocks + ##N)
+
+- **Branch**: `claude/ieee1800-uvm-implementation-tt3pll` (fresh from
+  merged main at fb79080 after PR #72; new draft PR for this work).
+- **This checkpoint** opens M8 at the gap-audit entry point:
+  - **G01 FIXED**: `clocking ... endclocking` in a module no longer
+    crashes (was: error + pform.cc is_interface assertion + core dump);
+    it is registered and functional (14.3). **G02 FIXED**: same for
+    program blocks. Same-scope `@(cb)` and `cb.sig` (read + drive) now
+    resolve in modules/programs — new shared
+    `rewrite_enclosing_scope_clocking_member_path` in netmisc.cc; the
+    two previously-duplicated interface rewrite helpers were unified
+    into netmisc.cc and generalized past `is_interface` (debt
+    reduction; elab_expr.cc/elab_lval.cc statics deleted).
+  - **default clocking registered** (14.12): named + anonymous
+    declaration forms REGISTER the block (parse-and-drop fallback
+    removed); new `default clocking id;` reference form; at most one
+    default per scope enforced; existence validated at endmodule.
+    `Module::default_clocking` records it.
+  - **Clause 14.4 skew syntax complete**: `#1step` lexes (new K_1step),
+    edge skews and `default input/output skew` items parse per A.6.11;
+    `ref` no longer wrongly accepted as a clocking direction. Skews are
+    accepted and DISCARDED — the clocking model is still the alias
+    model (cb.sig = underlying signal, no sampling/drive scheduling).
+  - **Procedural ##N cycle delay (14.11)**: `##` lexes (K_CYCLE_DELAY),
+    new PCycleDelay statement lowers at elaboration to
+    `repeat (N) @(<default clocking>)` via the existing Phase 55 @(cb)
+    resolver; clause-referenced error when no default clocking is in
+    scope. Number/identifier/(expr) count forms.
+  - Latent crash fixed: duplicate clocking-block name + items no longer
+    dies on the pform_add_clocking_signal assertion.
+- **Regressions**: UVM 129/129 (+2 new tests); ivtest vvp_reg.pl
+  2961/3101 failure-name-identical to a fresh same-machine pristine
+  baseline (worktree at fb79080); vvp_reg.py 284/12 and vpi_reg.pl
+  76/76 baseline-identical; negative suite 9/9 (+3 new); region trace
+  PASS; bison conflicts DOWN 459→458 s/r, 1060→1053 r/r.
+  Details: `session_logs/2026-07-14_g01_clocking_blocks.md`.
+- **Next (M8 increment 2)**: real clocking semantics — input sampling
+  (#1step history / #0 Observed) and synchronous drives (Re-NBA),
+  replacing the alias rewrites for all scopes at once on the M6 region
+  entry points; then `cb.sig <= ##N v` drives. See the session log's
+  "Next engineering step". G05/G06 (SVA) remain the M9 entry.
+
 ## State as of 2026-07-14h (session: M6 COMPLETION — trampoline default + scheduled-path deletion)
 
 - **Branch**: `claude/ieee1800-systemverilog-uvm-tqk5qy` (fresh from

--- a/docs/conformance/session_logs/2026-07-14_g01_clocking_blocks.md
+++ b/docs/conformance/session_logs/2026-07-14_g01_clocking_blocks.md
@@ -119,8 +119,10 @@ scope-complete and consistent, not deeper.
 
 ## Regressions (final build, quiet machine)
 
-- UVM `.github/uvm_test.sh`: **129/129** (127 baseline + 2 new tests) —
-  see commit message for the exact tail.
+- UVM `.github/uvm_test.sh`: **129 passed, 0 failed, 0 skipped**
+  (127 baseline + 2 new tests) — CONFIRMED on the final build after the
+  full battery (this run included the ##N implementation and both new
+  tests).
 - ivtest `vvp_reg.pl`: **2961/3101 passed, 132 failed** with failure names
   **identical to the same-machine pristine-main baseline** (fresh baseline
   built from fb79080 in a worktree, diffed by name).

--- a/docs/conformance/session_logs/2026-07-14_g01_clocking_blocks.md
+++ b/docs/conformance/session_logs/2026-07-14_g01_clocking_blocks.md
@@ -1,0 +1,153 @@
+# Session 2026-07-14i — G01/G02: clocking blocks outside interfaces + ##N cycle delays (M8 entry)
+
+## Target
+
+Gap-audit entry point for milestone M8 (clocking blocks): **G01** —
+`clocking ... endclocking` in a module produced
+`error: clocking declarations are only allowed in interfaces.` followed by
+`assert: pform.cc:3874: failed assertion scope && scope->is_interface` and a
+core dump. **G02** — the same crash for clocking inside program blocks.
+IEEE 1800-2017 14.3 explicitly permits clocking blocks in modules,
+interfaces, programs, and checkers.
+
+Scope grew to the adjacent same-clause defects found while reducing:
+
+1. `default clocking` declarations (named and anonymous) were **parsed and
+   silently dropped** (a compile-progress fallback in parse.y), and the
+   `default clocking existing_id;` reference form (A.1.4) did not parse.
+2. Clause 14.4 skew syntax barely parsed: `#1step` did not lex, edge skews
+   (`input negedge x;`) and `default input <skew> output <skew>;` items were
+   syntax errors. `ref` was wrongly accepted as a clocking direction.
+3. Procedural cycle delays (`##N;`, 14.11) did not lex at all — `##` was two
+   `'#'` tokens and always a syntax error.
+4. A latent crash: a duplicate clocking-block *name* left
+   `pform_cur_clocking` null and the first clocking item then died on the
+   `pform_add_clocking_signal` assertion.
+
+## Root cause
+
+Clocking blocks were implemented (Phase 13/55) only for the interface +
+virtual-interface UVM path: `pform_start_clocking_block` asserted
+`scope->is_interface`, and every elaboration-side resolver
+(`resolve_interface_pform_clocking_event_`, the two path-rewrite helpers
+duplicated across elab_expr.cc/elab_lval.cc) gated on `is_interface()`. The
+grammar's non-interface branch still called `pform_start_clocking_block`
+after issuing the error → assertion → abort.
+
+## Implementation
+
+The existing clocking model **aliases** `cb.sig` to the underlying signal
+(no sample/drive skew semantics yet — that is the next M8 increment; the
+audit records the approximation). This session makes the model
+scope-complete and consistent, not deeper.
+
+- **pform.cc / pform.h**: `pform_start_clocking_block` accepts any
+  module/interface/program scope (14.3); gains `is_default` (registers the
+  scope's default clocking, errors on a second default per 14.12) and a null
+  name for the anonymous default form (registered under the internal name
+  `$default_clocking`, unreachable from source). New
+  `pform_set_default_clocking_ref` for `default clocking id;`; existence is
+  validated in `pform_endmodule` so declaration order doesn't matter.
+  `pform_add_clocking_signal` now tolerates a failed block open (fixes the
+  duplicate-name crash). `Module` gains `perm_string default_clocking`.
+
+- **parse.y**: `clocking_declaration` no longer errors outside interfaces;
+  the two `default clocking` declaration forms now register their blocks
+  (fallback removed) and the reference form is new. `clocking_item` was
+  rewritten to the A.6.11 shape: `input|output [clocking_skew]`,
+  `input [skew] output [skew]`, `inout` (no skew, and no `ref`, per LRM),
+  and the three `default` skew items. New `clocking_skew` nonterminal:
+  `edge_identifier [delay_control] | delay_control`, with `#1step`,
+  `#(expr)`, `#value` and `posedge/negedge/edge` forms. Skews are accepted
+  and discarded (alias model). **Bison conflicts went down**: 459→458 s/r,
+  1060→1053 r/r (the old `port_direction '#' expression` rule was the
+  conflicting one); all three "useless rule" warnings are pre-existing.
+
+- **lexor.lex**: `1step` (5.8) and `##` (14.11) tokens, both
+  SystemVerilog-gated with REJECT fallback — neither sequence was lexable
+  before, so no legacy behavior changes.
+
+- **netmisc.cc / netmisc.h**: the two clocking path-rewrite helpers that
+  were *duplicated* as statics in elab_expr.cc and elab_lval.cc are now
+  shared functions (debt reduction):
+  `rewrite_class_clocking_member_path` (virtual-interface receivers,
+  unchanged logic) and `rewrite_clocking_member_path_via_scope`
+  (generalized: any instance scope — interface, module, or program). New
+  `rewrite_enclosing_scope_clocking_member_path` resolves **same-scope**
+  `cb.sig` references (leading path component names a clocking block of an
+  enclosing MODULE-type scope) — this is what module/program-scope clocking
+  and clocking inside interface task bodies need. Wired into both l-value
+  and expression elaboration plus the two compile-progress rescue sites,
+  guarded on `!sr.net` so real symbol resolutions always win.
+
+- **elaborate.cc**: `resolve_interface_pform_clocking_event_` →
+  `resolve_scope_pform_clocking_event_` (drops both `is_interface` gates)
+  so `@(inst.cb)` works for module/program instances. The Phase 55
+  same-scope `@(cb)` walker already worked for any MODULE-type scope.
+
+- **##N cycle delay (14.11)**: new `PCycleDelay` statement
+  (Statement.h/.cc, elab_scope.cc, elab_sig.cc, pform_dump.cc). Grammar:
+  `## delay_value_simple [stmt]` and `## ( expression ) [stmt]` (A.6.11
+  forms: number, identifier, parenthesized expression). Elaboration finds
+  the nearest enclosing scope with a `default_clocking` (walks NetScope
+  chain → pform_modules) and lowers to `repeat (count) @(<cb name>) ;` —
+  the synthesized `@(name)` resolves through the SAME Phase 55 machinery as
+  source-level `@(cb)`, so the underlying event expression is picked up
+  from the block declaration and resolved in the referencing scope. No
+  default clocking in scope → clause-referenced error.
+
+## What deliberately did NOT change
+
+- No skew *semantics*: `cb.sig` remains a direct alias (input sampling at
+  1step/Observed, synchronous output drives in Re-NBA, and `cb.sig <= ##N v`
+  intra-assignment cycle delays are the next M8 increment — the M6
+  Preponed/Observed entry points are the landing spot).
+- No UVM-specific branches anywhere; all lookups are name/scope-driven.
+- Interface clocking behavior is unchanged (regressions byte-identical).
+
+## Tests added
+
+- `tests/g01_module_clocking_test.sv` — module-scope clocking (@(cb) wait,
+  input read, output drive), every A.6.11 skew item form, named default
+  clocking used by name, reference form, hierarchical `@(sub.cb)` +
+  `sub.cb.sig`, program-block clocking with drive (G02), multiple blocks
+  coexisting.
+- `tests/g01_cycle_delay_test.sv` — ##0/##1/##2, statement form,
+  `##(expr)`, `##identifier`, cycle delay inside a task body.
+- `tests/negative/g01_cycle_delay_no_default.sv`,
+  `g01_multiple_default_clocking.sv`, `g01_undeclared_default_clocking.sv`.
+
+## Regressions (final build, quiet machine)
+
+- UVM `.github/uvm_test.sh`: **129/129** (127 baseline + 2 new tests) —
+  see commit message for the exact tail.
+- ivtest `vvp_reg.pl`: **2961/3101 passed, 132 failed** with failure names
+  **identical to the same-machine pristine-main baseline** (fresh baseline
+  built from fb79080 in a worktree, diffed by name).
+- ivtest `vvp_reg.py`: 284 ran / 12 failed (baseline-identical);
+  `vpi_reg.pl`: 76/76 (baseline-identical).
+- Negative suite: **9/9** (3 new).
+- `tests/m6_region_trace/run_region_trace.sh`: PASS.
+- Bison: 458 s/r + 1053 r/r (both LOWER than baseline 459/1060); flex clean.
+
+## Gap audit deltas
+
+- **G01 FIXED** (crash removed; module clocking functional under the alias
+  model). **G02 FIXED** (program clocking functional).
+- New capability: default clocking registration + procedural ##N.
+- Remaining clause-14 tail (recorded for the next M8 increment): skew
+  sampling/driving semantics; `cb.sig <= ##N v` synchronous drives with
+  cycle delay; `clocking_decl_assign` (`input a = expr;`); `global
+  clocking` (14.14); default clocking in generate scopes resolves to the
+  enclosing module's block.
+
+## Next engineering step
+
+M8 increment 2 — real clocking semantics: input sampling (#1step via a
+1-deep value/timestamp history on the sampled signal, matching the
+Preponed-region value; #0 via `schedule_at_observed`) and synchronous
+output drives (scheduled into Re-NBA via `schedule_at_observed`/re-nba
+queues added in M6), replacing the alias rewrites for all scopes at once.
+Entry: `rewrite_*_clocking_member_path*` call sites become typed
+sample/drive lowerings; characterization tests first
+(`g01_module_clocking_test` pins the alias behavior today).

--- a/elab_expr.cc
+++ b/elab_expr.cc
@@ -752,109 +752,8 @@ static int ensure_class_property_idx_(Design*des, const netclass_t*class_type,
       return const_cast<netclass_t*>(class_type)->ensure_property_decl(des, name);
 }
 
-/* When the interface instance is a plain Verilog scope (sr.net is null
-   but sr.scope is an interface scope), rewrite `iface.cb.sig` to
-   `iface.sig` by looking up the clocking block in pform_modules.
-   Drops clocking-block scoping from the path so the underlying
-   interface signal is accessed directly. */
-static bool rewrite_interface_clocking_member_path_via_scope_(const PEIdent*ident,
-							      const symbol_search_results&sr,
-							      pform_name_t&rewritten)
-{
-      if (sr.net || !sr.scope) return false;
-      if (!sr.scope->is_interface()) return false;
-      if (ident->path().size() < 3) return false;
-      perm_string iface_module = sr.scope->module_name();
-      if (iface_module.nil()) return false;
-      auto cur = pform_modules.find(iface_module);
-      if (cur == pform_modules.end() || !cur->second->is_interface)
-	    return false;
-      const Module*iface_mod = cur->second;
-
-      pform_name_t newpath = ident->path().name;
-      auto it = newpath.begin();
-      ++it; /* skip iface name */
-      while (it != newpath.end()) {
-	    auto nx = it; ++nx;
-	    if (nx == newpath.end()) break;
-	    auto cb_it = iface_mod->clocking_blocks.find(it->name);
-	    if (cb_it != iface_mod->clocking_blocks.end()) {
-		  const auto&signals = cb_it->second->signals;
-		  if (std::find(signals.begin(), signals.end(), nx->name)
-			    != signals.end()) {
-			newpath.erase(it);
-			rewritten = newpath;
-			return true;
-		  }
-	    }
-	    ++it;
-      }
-      return false;
-}
-
-static bool rewrite_interface_clocking_member_path_(const PEIdent*ident,
-						    const symbol_search_results&sr,
-						    pform_name_t&rewritten)
-{
-      const netclass_t*class_type = dynamic_cast<const netclass_t*>(sr.type);
-      if (!class_type || sr.path_tail.size() < 2)
-	    return false;
-
-      size_t offset = 0;
-      for (pform_name_t::const_iterator it = sr.path_tail.begin()
-		 ; it != sr.path_tail.end() ; ++it, ++offset) {
-	    pform_name_t::const_iterator next = it;
-	    ++next;
-
-	    if (class_type->is_interface()) {
-		  const name_component_t&clocking_comp = *it;
-		  if (!clocking_comp.index.empty())
-			return false;
-
-		  const netclass_t::clocking_block_t*clocking =
-			class_type->find_clocking_block(clocking_comp.name);
-		  if (clocking && next != sr.path_tail.end()) {
-			if (std::find(clocking->signals.begin(), clocking->signals.end(),
-				      next->name) == clocking->signals.end())
-			      return false;
-
-			rewritten = ident->path().name;
-			size_t resolved_count = ident->path().name.size() - sr.path_tail.size();
-			pform_name_t::iterator erase_it = rewritten.begin();
-			advance(erase_it, resolved_count + offset);
-			if (erase_it == rewritten.end() || erase_it->name != clocking_comp.name)
-			      return false;
-
-			rewritten.erase(erase_it);
-			return true;
-		  }
-	    }
-
-	    int pidx = ensure_class_property_idx_(0, class_type, it->name);
-	    if (pidx < 0)
-		  return false;
-
-	    ivl_type_t ptype = class_type->get_prop_type(pidx);
-	    if (!it->index.empty()) {
-		  if (const netdarray_t*darr = dynamic_cast<const netdarray_t*>(ptype))
-			ptype = darr->element_type();
-		  else if (const netuarray_t*uarr = dynamic_cast<const netuarray_t*>(ptype))
-			ptype = uarr->element_type();
-		  else if (const netarray_t*arr = dynamic_cast<const netarray_t*>(ptype))
-			ptype = arr->element_type();
-		  else if (const netqueue_t*que = dynamic_cast<const netqueue_t*>(ptype))
-			ptype = que->element_type();
-		  else
-			return false;
-	    }
-
-	    class_type = dynamic_cast<const netclass_t*>(ptype);
-	    if (!class_type)
-		  return false;
-      }
-
-      return false;
-}
+/* Clocking-block member path rewrites are shared with l-value
+   elaboration — see rewrite_*_clocking_member_path* in netmisc.cc. */
 
 static long builtin_process_state_value_(perm_string name)
 {
@@ -5895,8 +5794,9 @@ NetExpr* PEIdent::elaborate_expr_class_field_(Design*des, NetScope*scope,
       const name_component_t comp = sr.path_tail.front();
 
       pform_name_t rewritten_path;
-      if (rewrite_interface_clocking_member_path_(this, sr, rewritten_path)
-	  || rewrite_interface_clocking_member_path_via_scope_(this, sr, rewritten_path)) {
+      if (rewrite_class_clocking_member_path(this, sr, rewritten_path)
+	  || rewrite_clocking_member_path_via_scope(this, sr, rewritten_path)
+	  || (!sr.net && rewrite_enclosing_scope_clocking_member_path(this, scope, rewritten_path))) {
 	    if (path_.package) {
 		  PEIdent mapped_ident(path_.package, rewritten_path, lexical_pos_);
 		  return mapped_ident.elaborate_expr(des, scope, expr_wid, flags);
@@ -10519,7 +10419,8 @@ NetExpr* PEIdent::elaborate_expr_(Design*des, NetScope*scope,
 		      // semantics not yet implemented; do a flat rewrite).
 		    if (gn_system_verilog()) {
 			  pform_name_t rewritten;
-			  if (rewrite_interface_clocking_member_path_via_scope_(this, sr, rewritten)) {
+			  if (rewrite_clocking_member_path_via_scope(this, sr, rewritten)
+			      || rewrite_enclosing_scope_clocking_member_path(this, scope, rewritten)) {
 				PEIdent mapped(rewritten, lexical_pos_);
 				return mapped.elaborate_expr(des, scope, expr_wid, flags);
 			  }
@@ -10652,7 +10553,8 @@ NetExpr* PEIdent::elaborate_expr_(Design*des, NetScope*scope,
 	/* SV clocking-block path: bif.cb.sig -> bif.sig */
       if (gn_system_verilog()) {
 	    pform_name_t rewritten;
-	    if (rewrite_interface_clocking_member_path_via_scope_(this, sr, rewritten)) {
+	    if (rewrite_clocking_member_path_via_scope(this, sr, rewritten)
+		|| rewrite_enclosing_scope_clocking_member_path(this, scope, rewritten)) {
 		  PEIdent mapped(rewritten, lexical_pos_);
 		  return mapped.elaborate_expr(des, scope, expr_wid, flags);
 	    }

--- a/elab_lval.cc
+++ b/elab_lval.cc
@@ -46,110 +46,8 @@ using namespace std;
 
 static bool warned_darray_multi_index_fallback = false;
 
-/* When the interface instance is a plain Verilog scope (sr.net is null
-   but sr.scope is an interface scope), rewrite `iface.cb.sig` to
-   `iface.sig` by looking up the clocking block in pform_modules. */
-static bool rewrite_interface_clocking_member_path_via_scope_(const PEIdent*ident,
-							      const symbol_search_results&sr,
-							      pform_name_t&rewritten)
-{
-      if (sr.net || !sr.scope) return false;
-      if (!sr.scope->is_interface()) return false;
-      if (ident->path().size() < 3) return false;
-      perm_string iface_module = sr.scope->module_name();
-      if (iface_module.nil()) return false;
-      auto cur = pform_modules.find(iface_module);
-      if (cur == pform_modules.end() || !cur->second->is_interface)
-	    return false;
-      const Module*iface_mod = cur->second;
-
-      /* Walk the path: [iface, cb, sig, ...]. Find a component that
-         names a clocking block and the next component must be a signal
-         in that block. */
-      pform_name_t newpath = ident->path().name;
-      auto it = newpath.begin();
-      ++it; /* skip the iface name */
-      while (it != newpath.end()) {
-	    auto nx = it; ++nx;
-	    if (nx == newpath.end()) break;
-	    auto cb_it = iface_mod->clocking_blocks.find(it->name);
-	    if (cb_it != iface_mod->clocking_blocks.end()) {
-		  const auto&signals = cb_it->second->signals;
-		  if (std::find(signals.begin(), signals.end(), nx->name)
-			    != signals.end()) {
-			newpath.erase(it);
-			rewritten = newpath;
-			return true;
-		  }
-	    }
-	    ++it;
-      }
-      return false;
-}
-
-static bool rewrite_interface_clocking_member_path_(const PEIdent*ident,
-						    const symbol_search_results&sr,
-						    pform_name_t&rewritten)
-{
-      const netclass_t*class_type = dynamic_cast<const netclass_t*>(sr.type);
-      if (!class_type || sr.path_tail.size() < 2)
-	    return false;
-
-      size_t offset = 0;
-      for (pform_name_t::const_iterator it = sr.path_tail.begin()
-		 ; it != sr.path_tail.end() ; ++it, ++offset) {
-	    pform_name_t::const_iterator next = it;
-	    ++next;
-
-	    if (class_type->is_interface()) {
-		  const name_component_t&clocking_comp = *it;
-		  if (!clocking_comp.index.empty())
-			return false;
-
-		  const netclass_t::clocking_block_t*clocking =
-			class_type->find_clocking_block(clocking_comp.name);
-		  if (clocking && next != sr.path_tail.end()) {
-			if (std::find(clocking->signals.begin(), clocking->signals.end(),
-				      next->name) == clocking->signals.end())
-			      return false;
-
-			rewritten = ident->path().name;
-			size_t resolved_count = ident->path().name.size() - sr.path_tail.size();
-			pform_name_t::iterator erase_it = rewritten.begin();
-			advance(erase_it, resolved_count + offset);
-			if (erase_it == rewritten.end() || erase_it->name != clocking_comp.name)
-			      return false;
-
-			rewritten.erase(erase_it);
-			return true;
-		  }
-	    }
-
-	    int pidx = const_cast<netclass_t*>(class_type)->ensure_property_decl(0, it->name);
-	    if (pidx < 0)
-		  return false;
-
-	    ivl_type_t ptype = class_type->get_prop_type(pidx);
-	    if (!it->index.empty()) {
-		  if (const netdarray_t*darr = dynamic_cast<const netdarray_t*>(ptype))
-			ptype = darr->element_type();
-		  else if (const netuarray_t*uarr = dynamic_cast<const netuarray_t*>(ptype))
-			ptype = uarr->element_type();
-		  else if (const netarray_t*arr = dynamic_cast<const netarray_t*>(ptype))
-			ptype = arr->element_type();
-		  else if (const netqueue_t*que = dynamic_cast<const netqueue_t*>(ptype))
-			ptype = que->element_type();
-		  else
-			return false;
-	    }
-
-	    class_type = dynamic_cast<const netclass_t*>(ptype);
-	    if (!class_type)
-		  return false;
-      }
-
-      return false;
-}
+/* Clocking-block member path rewrites are shared with expression
+   elaboration — see rewrite_*_clocking_member_path* in netmisc.cc. */
 
 /*
  * These methods generate a NetAssign_ object for the l-value of the
@@ -293,8 +191,9 @@ NetAssign_* PEIdent::elaborate_lval(Design*des,
       const pform_name_t &member_path = sr.path_tail;
 
       pform_name_t rewritten_path;
-      if ((reg && rewrite_interface_clocking_member_path_(this, sr, rewritten_path))
-	  || rewrite_interface_clocking_member_path_via_scope_(this, sr, rewritten_path)) {
+      if ((reg && rewrite_class_clocking_member_path(this, sr, rewritten_path))
+	  || rewrite_clocking_member_path_via_scope(this, sr, rewritten_path)
+	  || (!reg && rewrite_enclosing_scope_clocking_member_path(this, scope, rewritten_path))) {
 	    if (path_.package) {
 		  PEIdent mapped_ident(path_.package, rewritten_path, lexical_pos_);
 		  return mapped_ident.elaborate_lval(des, scope, is_cassign,

--- a/elab_scope.cc
+++ b/elab_scope.cc
@@ -3173,6 +3173,12 @@ void PDelayStatement::elaborate_scope(Design*des, NetScope*scope) const
 	    statement_ -> elaborate_scope(des, scope);
 }
 
+void PCycleDelay::elaborate_scope(Design*des, NetScope*scope) const
+{
+      if (statement_)
+	    statement_ -> elaborate_scope(des, scope);
+}
+
 /*
  * Statements that contain a further statement but do not
  * intrinsically add a scope need to elaborate_scope the contained

--- a/elab_sig.cc
+++ b/elab_sig.cc
@@ -1443,6 +1443,12 @@ void PDelayStatement::elaborate_sig(Design*des, NetScope*scope) const
 	    statement_->elaborate_sig(des, scope);
 }
 
+void PCycleDelay::elaborate_sig(Design*des, NetScope*scope) const
+{
+      if (statement_)
+	    statement_->elaborate_sig(des, scope);
+}
+
 void PDoWhile::elaborate_sig(Design*des, NetScope*scope) const
 {
       if (statement_)

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -319,25 +319,25 @@ static NetEvent* resolve_named_event_member_from_search_(const symbol_search_res
       return nullptr;
 }
 
-/* Resolve `<iface_instance_scope>` (no NetNet, but path consumed) to the
+/* Resolve `<instance_scope>` (no NetNet, but path consumed) to the
    clocking block named by the LAST component of the original path. This
    handles the @(bif.cb) case where symbol_search resolves `bif` as a
    sub-scope of the current module and absorbs `cb` as part of the scope
-   path. */
+   path. The instance may be an interface, module, or program
+   (IEEE 1800-2017 14.3). */
 static const PEventStatement*
-resolve_interface_pform_clocking_event_(const PEIdent*id,
-					const symbol_search_results&sr,
-					perm_string&cb_name_out,
-					size_t&base_path_components)
+resolve_scope_pform_clocking_event_(const PEIdent*id,
+				    const symbol_search_results&sr,
+				    perm_string&cb_name_out,
+				    size_t&base_path_components)
 {
       if (sr.net || !sr.scope) return nullptr;
-      if (!sr.scope->is_interface()) return nullptr;
       if (id->path().size() < 2) return nullptr;
 
-      perm_string iface_module = sr.scope->module_name();
-      if (iface_module.nil()) return nullptr;
-      auto cur = pform_modules.find(iface_module);
-      if (cur == pform_modules.end() || !cur->second->is_interface)
+      perm_string scope_module = sr.scope->module_name();
+      if (scope_module.nil()) return nullptr;
+      auto cur = pform_modules.find(scope_module);
+      if (cur == pform_modules.end())
 	    return nullptr;
       perm_string cb_name = id->path().name.back().name;
       auto cb_it = cur->second->clocking_blocks.find(cb_name);
@@ -7289,6 +7289,72 @@ NetDeassign* PDeassign::elaborate(Design*des, NetScope*scope) const
  * expression to the constructor of NetPDelay so that the code
  * generator knows to evaluate the expression at run time.
  */
+/* IEEE 1800-2017 14.11: `## count [statement]` waits `count` events of
+   the default clocking block (14.12) visible in the nearest enclosing
+   module/interface/program scope. Lower it to
+
+       repeat (count) @(<default clocking name>) ; <statement>
+
+   The synthesized @(name) event control resolves through the same
+   clocking-block machinery as source-level `@(cb)` references, so the
+   underlying event expression (e.g. posedge clk) is picked up from the
+   block's declaration. */
+NetProc* PCycleDelay::elaborate(Design*des, NetScope*scope) const
+{
+      ivl_assert(*this, scope);
+
+      perm_string cb_name;
+      for (const NetScope*walker = scope ; walker ; walker = walker->parent()) {
+	    if (walker->type() != NetScope::MODULE)
+		  continue;
+	    perm_string mn = walker->module_name();
+	    if (mn.nil()) continue;
+	    auto pmod_it = pform_modules.find(mn);
+	    if (pmod_it == pform_modules.end()) continue;
+	    if (!pmod_it->second->default_clocking.nil()) {
+		  cb_name = pmod_it->second->default_clocking;
+		  break;
+	    }
+      }
+
+      if (cb_name.nil()) {
+	    cerr << get_fileline() << ": error: ## cycle delay requires a "
+		 << "default clocking block in scope (IEEE 1800-2017 14.11)."
+		 << endl;
+	    des->errors += 1;
+	    return 0;
+      }
+
+	/* Heap-allocate the synthesized pform fragment: PRepeat's
+	   destructor deletes its children, and pform objects normally
+	   live for the whole compilation anyway. UINT_MAX as the
+	   lexical position marks the reference as following all
+	   declarations, so no declared-after-use diagnostics fire. */
+      PEIdent*cb_id = new PEIdent(cb_name, UINT_MAX);
+      cb_id->set_line(*this);
+      PEEvent*cb_ev = new PEEvent(PEEvent::ANYEDGE, cb_id);
+      PEventStatement*wait_stmt = new PEventStatement(cb_ev);
+      wait_stmt->set_line(*this);
+      PRepeat*rep_stmt = new PRepeat(count_, wait_stmt);
+      rep_stmt->set_line(*this);
+
+      NetProc*rep = rep_stmt->elaborate(des, scope);
+      if (rep == 0)
+	    return 0;
+      if (statement_ == 0)
+	    return rep;
+
+      NetProc*sub = statement_->elaborate(des, scope);
+      if (sub == 0)
+	    return 0;
+
+      NetBlock*blk = new NetBlock(NetBlock::SEQU, 0);
+      blk->set_line(*this);
+      blk->append(rep);
+      blk->append(sub);
+      return blk;
+}
+
 NetProc* PDelayStatement::elaborate(Design*des, NetScope*scope) const
 {
       ivl_assert(*this, scope);
@@ -7571,7 +7637,7 @@ NetProc* PEventStatement::elaborate_st(Design*des, NetScope*scope,
 		  perm_string scope_cb_name;
 		  const PEventStatement*pform_event = clocking
 			? clocking->event
-			: resolve_interface_pform_clocking_event_(id, sr, scope_cb_name,
+			: resolve_scope_pform_clocking_event_(id, sr, scope_cb_name,
 							      base_path_components);
 		  /* Phase 55: pform-side clocking-block lookup for the simple
 		   * `@cb` form within the same interface body or task. */

--- a/lexor.lex
+++ b/lexor.lex
@@ -537,6 +537,24 @@ TU [munpf]
       }
 }
 
+  /* IEEE 1800-2017 14.11: `##` introduces a cycle delay. Adjacent
+     `##` had no legal meaning before this rule (two '#' tokens never
+     parse), so reserving it for SystemVerilog changes no legacy
+     behavior. */
+"##" {
+      if (gn_system_verilog()) {
+	    return K_CYCLE_DELAY;
+      } else REJECT; }
+
+  /* IEEE 1800-2017 5.8: `1step` is a special delay value (clocking
+     skews, cycle delays). It cannot collide with identifiers (which
+     may not start with a digit) or plain numbers (longest match wins),
+     and `1step` was already a lexical error before this rule. */
+1step {
+      if (gn_system_verilog()) {
+	    return K_1step;
+      } else REJECT; }
+
   /* This rule handles scaled time values for SystemVerilog.
      Strip underscore separators (IEEE 1800-2012 §5.7.1) so atof() works. */
 [0-9][0-9_]*(\.[0-9][0-9_]*)?{TU}?s {

--- a/netmisc.cc
+++ b/netmisc.cc
@@ -22,13 +22,19 @@
 # include  <cstdlib>
 # include  <climits>
 # include  <map>
+# include  <algorithm>
 # include  "netlist.h"
 # include  "netparray.h"
 # include  "netvector.h"
 # include  "netmisc.h"
+# include  "netclass.h"
+# include  "netdarray.h"
+# include  "netqueue.h"
 # include  "PExpr.h"
 # include  "PTask.h"
 # include  "pform_types.h"
+# include  "Module.h"
+# include  "parse_api.h"
 # include  "compiler.h"
 # include  "ivl_assert.h"
 
@@ -2187,4 +2193,155 @@ bool calculate_param_range(const LineInfo&line, ivl_type_t par_type,
       par_lsv = use_range.get_lsb();
 
       return true;
+}
+
+/* IEEE 1800-2017 clause 14 — clocking-block member path rewrites.
+   See netmisc.h for the model description. These were previously
+   duplicated as statics in elab_expr.cc and elab_lval.cc; they are
+   shared here so expression and l-value elaboration cannot drift. */
+
+bool rewrite_class_clocking_member_path(const PEIdent*ident,
+					const symbol_search_results&sr,
+					pform_name_t&rewritten)
+{
+      const netclass_t*class_type = dynamic_cast<const netclass_t*>(sr.type);
+      if (!class_type || sr.path_tail.size() < 2)
+	    return false;
+
+      size_t offset = 0;
+      for (pform_name_t::const_iterator it = sr.path_tail.begin()
+		 ; it != sr.path_tail.end() ; ++it, ++offset) {
+	    pform_name_t::const_iterator next = it;
+	    ++next;
+
+	    if (class_type->is_interface()) {
+		  const name_component_t&clocking_comp = *it;
+		  if (!clocking_comp.index.empty())
+			return false;
+
+		  const netclass_t::clocking_block_t*clocking =
+			class_type->find_clocking_block(clocking_comp.name);
+		  if (clocking && next != sr.path_tail.end()) {
+			if (std::find(clocking->signals.begin(), clocking->signals.end(),
+				      next->name) == clocking->signals.end())
+			      return false;
+
+			rewritten = ident->path().name;
+			size_t resolved_count = ident->path().name.size() - sr.path_tail.size();
+			pform_name_t::iterator erase_it = rewritten.begin();
+			advance(erase_it, resolved_count + offset);
+			if (erase_it == rewritten.end() || erase_it->name != clocking_comp.name)
+			      return false;
+
+			rewritten.erase(erase_it);
+			return true;
+		  }
+	    }
+
+	    int pidx = class_type->property_idx_from_name(it->name);
+	    if (pidx < 0)
+		  pidx = const_cast<netclass_t*>(class_type)->ensure_property_decl(0, it->name);
+	    if (pidx < 0)
+		  return false;
+
+	    ivl_type_t ptype = class_type->get_prop_type(pidx);
+	    if (!it->index.empty()) {
+		  if (const netdarray_t*darr = dynamic_cast<const netdarray_t*>(ptype))
+			ptype = darr->element_type();
+		  else if (const netuarray_t*uarr = dynamic_cast<const netuarray_t*>(ptype))
+			ptype = uarr->element_type();
+		  else if (const netarray_t*arr = dynamic_cast<const netarray_t*>(ptype))
+			ptype = arr->element_type();
+		  else if (const netqueue_t*que = dynamic_cast<const netqueue_t*>(ptype))
+			ptype = que->element_type();
+		  else
+			return false;
+	    }
+
+	    class_type = dynamic_cast<const netclass_t*>(ptype);
+	    if (!class_type)
+		  return false;
+      }
+
+      return false;
+}
+
+/* When the receiver resolved to a plain instance scope (sr.net is null
+   but sr.scope is an interface, module, or program instance), rewrite
+   `inst.cb.sig` to `inst.sig` by looking up the clocking block in the
+   instance's pform Module. */
+bool rewrite_clocking_member_path_via_scope(const PEIdent*ident,
+					    const symbol_search_results&sr,
+					    pform_name_t&rewritten)
+{
+      if (sr.net || !sr.scope) return false;
+      if (ident->path().size() < 3) return false;
+      perm_string scope_module = sr.scope->module_name();
+      if (scope_module.nil()) return false;
+      auto cur = pform_modules.find(scope_module);
+      if (cur == pform_modules.end())
+	    return false;
+      const Module*mod = cur->second;
+      if (mod->clocking_blocks.empty()) return false;
+
+	/* Walk the path: [inst, cb, sig, ...]. Find a component that
+	   names a clocking block where the next component is a signal
+	   in that block. */
+      pform_name_t newpath = ident->path().name;
+      auto it = newpath.begin();
+      ++it; /* skip the instance name */
+      while (it != newpath.end()) {
+	    auto nx = it; ++nx;
+	    if (nx == newpath.end()) break;
+	    auto cb_it = mod->clocking_blocks.find(it->name);
+	    if (cb_it != mod->clocking_blocks.end()) {
+		  const auto&signals = cb_it->second->signals;
+		  if (std::find(signals.begin(), signals.end(), nx->name)
+			    != signals.end()) {
+			newpath.erase(it);
+			rewritten = newpath;
+			return true;
+		  }
+	    }
+	    ++it;
+      }
+      return false;
+}
+
+/* Same-scope `cb.sig` reference (IEEE 1800-2017 14.3: the clocking
+   block is a named scope member of its enclosing module, interface,
+   or program). The leading path component names a clocking block of
+   an enclosing scope and the next component is one of its signals:
+   erase the clocking component so the underlying signal resolves in
+   the ordinary way. */
+bool rewrite_enclosing_scope_clocking_member_path(const PEIdent*ident,
+						  const NetScope*scope,
+						  pform_name_t&rewritten)
+{
+      if (ident->path().size() < 2) return false;
+      const name_component_t&cb_comp = ident->path().name.front();
+      if (!cb_comp.index.empty()) return false;
+
+      for (const NetScope*walker = scope ; walker ; walker = walker->parent()) {
+	    if (walker->type() != NetScope::MODULE)
+		  continue;
+	    perm_string mn = walker->module_name();
+	    if (mn.nil()) continue;
+	    auto pmod_it = pform_modules.find(mn);
+	    if (pmod_it == pform_modules.end()) continue;
+	    auto cb_it = pmod_it->second->clocking_blocks.find(cb_comp.name);
+	    if (cb_it == pmod_it->second->clocking_blocks.end())
+		  continue;
+
+	    pform_name_t::const_iterator nx = ident->path().name.begin();
+	    ++nx;
+	    const auto&signals = cb_it->second->signals;
+	    if (std::find(signals.begin(), signals.end(), nx->name)
+		      == signals.end())
+		  return false;
+	    rewritten = ident->path().name;
+	    rewritten.erase(rewritten.begin());
+	    return true;
+      }
+      return false;
 }

--- a/netmisc.h
+++ b/netmisc.h
@@ -129,6 +129,37 @@ extern bool symbol_search(const LineInfo *li, Design *des, NetScope *scope,
 			  struct symbol_search_results*res);
 
 /*
+ * IEEE 1800-2017 clause 14 — clocking-block member path rewrites.
+ * The current clocking-block model aliases cb.sig to the underlying
+ * signal (sample/drive skew semantics are not implemented yet): these
+ * helpers detect a clocking-block component in an identifier path and
+ * erase it, so `inst.cb.sig` resolves as `inst.sig` and a same-scope
+ * `cb.sig` resolves as `sig`. All return true and fill `rewritten`
+ * only when a clocking block and one of its signals were positively
+ * identified.
+ *
+ * - rewrite_class_clocking_member_path: virtual-interface receivers
+ *   (the interface is modeled as a netclass_t carrying clocking
+ *   blocks).
+ * - rewrite_clocking_member_path_via_scope: the receiver resolved to
+ *   an instance scope (interface, module, or program instance) and the
+ *   clocking block is found in its pform Module.
+ * - rewrite_enclosing_scope_clocking_member_path: same-scope
+ *   references — the leading path component names a clocking block of
+ *   an enclosing module/interface/program scope.
+ */
+class PEIdent;
+extern bool rewrite_class_clocking_member_path(const PEIdent*ident,
+					       const symbol_search_results&sr,
+					       pform_name_t&rewritten);
+extern bool rewrite_clocking_member_path_via_scope(const PEIdent*ident,
+						   const symbol_search_results&sr,
+						   pform_name_t&rewritten);
+extern bool rewrite_enclosing_scope_clocking_member_path(const PEIdent*ident,
+							 const NetScope*scope,
+							 pform_name_t&rewritten);
+
+/*
  * This function transforms an expression by either zero or sign extending
  * the high bits until the expression has the desired width. This may mean
  * not transforming the expression at all, if it is already wide enough.

--- a/parse.y
+++ b/parse.y
@@ -1138,7 +1138,9 @@ Module::port_t *module_declare_port(const YYLTYPE&loc, char *id,
  /* The new tokens from 1364-2005. */
 %token K_wone K_uwire
 
- /* The new tokens from 1800-2005. */
+ /* The new tokens from 1800-2005. K_1step is the 5.8 `1step` delay
+    value; K_CYCLE_DELAY is `##` (cycle delays, clause 14). */
+%token K_1step K_CYCLE_DELAY
 %token K_alias K_always_comb K_always_ff K_always_latch K_assert
 %token K_assume K_before K_bind K_bins K_binsof K_bit K_break K_byte
 %token K_chandle K_class K_clocking K_const K_constraint K_context
@@ -4334,22 +4336,26 @@ modport_tf_port
   | K_function data_type_or_implicit_or_void IDENTIFIER tf_port_list_parens_opt
   ;
 
-clocking_declaration
+clocking_declaration /* IEEE 1800-2017 14.3: legal in module, interface,
+                        program, and checker scope. */
   : K_clocking IDENTIFIER event_control ';'
-      { if (!pform_in_interface())
-	      yyerror(@1, "error: clocking declarations are only allowed "
-			  "in interfaces.");
-	pform_start_clocking_block(@2, $2, $3);
-      }
+      { pform_start_clocking_block(@2, $2, $3); }
     clocking_items_opt K_endclocking
       { pform_end_clocking_block(@7); }
-  /* SV `default clocking [name] event_control; ... endclocking` — silently
-     accepted at module/interface scope. We don't yet model clocking-block
-     sample/drive semantics; the declaration is parsed and dropped. */
-  | K_default K_clocking IDENTIFIER event_control ';' clocking_items_opt K_endclocking
-      { delete[] $3; }
-  | K_default K_clocking event_control ';' clocking_items_opt K_endclocking
-      { /* anonymous default clocking */ }
+  /* 14.12: named default clocking declaration. */
+  | K_default K_clocking IDENTIFIER event_control ';'
+      { pform_start_clocking_block(@3, $3, $4, true); }
+    clocking_items_opt K_endclocking
+      { pform_end_clocking_block(@8); }
+  /* 14.12: anonymous default clocking declaration. */
+  | K_default K_clocking event_control ';'
+      { pform_start_clocking_block(@2, 0, $3, true); }
+    clocking_items_opt K_endclocking
+      { pform_end_clocking_block(@7); }
+  /* A.1.4 module_or_generate_item_declaration: `default clocking id;`
+     selects a clocking block declared elsewhere in this scope. */
+  | K_default K_clocking IDENTIFIER ';'
+      { pform_set_default_clocking_ref(@3, $3); }
   /* SV `default disable iff (expr);` — silently accepted. */
   | K_default K_disable K_iff '(' expression ')' ';'
       { delete $5; }
@@ -4373,23 +4379,68 @@ clocking_declaration
         yyerrok;
       }
 
+  /* IEEE 1800-2017 A.6.11. Skews (14.4) are accepted and discarded:
+     the current clocking model aliases cb.sig to the underlying
+     signal, which does not model sample/drive skew times. */
 clocking_item
-  : port_direction list_of_identifiers ';'
+  : K_input clocking_skew_opt list_of_identifiers ';'
+      {
+	    for (std::list<pform_ident_t>::iterator cur = $3->begin()
+		       ; cur != $3->end() ; ++cur)
+		  pform_add_clocking_signal(@3, cur->first);
+	    delete $3;
+      }
+  | K_output clocking_skew_opt list_of_identifiers ';'
+      {
+	    for (std::list<pform_ident_t>::iterator cur = $3->begin()
+		       ; cur != $3->end() ; ++cur)
+		  pform_add_clocking_signal(@3, cur->first);
+	    delete $3;
+      }
+  /* clocking_direction: `input [skew] output [skew] ids;` — the same
+     signals are sampled on read and driven on write. */
+  | K_input clocking_skew_opt K_output clocking_skew_opt list_of_identifiers ';'
+      {
+	    for (std::list<pform_ident_t>::iterator cur = $5->begin()
+		       ; cur != $5->end() ; ++cur)
+		  pform_add_clocking_signal(@5, cur->first);
+	    delete $5;
+      }
+  | K_inout list_of_identifiers ';'
       {
 	    for (std::list<pform_ident_t>::iterator cur = $2->begin()
 		       ; cur != $2->end() ; ++cur)
 		  pform_add_clocking_signal(@2, cur->first);
 	    delete $2;
       }
-  /* clocking skew: input/output #delay id_list; — parse and ignore skew */
-  | port_direction '#' expression list_of_identifiers ';'
-      {
-	    delete $3;
-	    for (std::list<pform_ident_t>::iterator cur = $4->begin()
-		       ; cur != $4->end() ; ++cur)
-		  pform_add_clocking_signal(@4, cur->first);
-	    delete $4;
-      }
+  /* default_skew items: set the block's default skews (discarded). */
+  | K_default K_input clocking_skew ';'
+  | K_default K_output clocking_skew ';'
+  | K_default K_input clocking_skew K_output clocking_skew ';'
+  ;
+
+  /* IEEE 1800-2017 A.6.11:
+     clocking_skew ::= edge_identifier [delay_control] | delay_control
+     The parsed skew has no semantic carrier yet (see clocking_item). */
+clocking_skew
+  : '#' delay_value_simple { delete $2; }
+  | '#' '(' delay_value ')' { delete $3; }
+  | '#' K_1step
+  | K_posedge clocking_skew_delay_opt
+  | K_negedge clocking_skew_delay_opt
+  | K_edge clocking_skew_delay_opt
+  ;
+
+clocking_skew_delay_opt
+  : '#' delay_value_simple { delete $2; }
+  | '#' '(' delay_value ')' { delete $3; }
+  | '#' K_1step
+  |
+  ;
+
+clocking_skew_opt
+  : clocking_skew
+  |
   ;
 
 clocking_items
@@ -12065,6 +12116,21 @@ statement_item /* This is roughly statement_item in the LRM */
 	assert($1->size() == 1);
 	delete $1;
 	PDelayStatement*tmp = new PDelayStatement(del, $2);
+	FILE_NAME(tmp, @1);
+	$$ = tmp;
+      }
+
+  /* IEEE 1800-2017 14.11 procedural cycle delay: `## cycle_delay_value
+     [statement]` waits that many default-clocking events. A.6.11:
+     cycle_delay ::= ## integral_number | ## identifier | ## ( expression ) */
+
+  | K_CYCLE_DELAY delay_value_simple statement_or_null
+      { PCycleDelay*tmp = new PCycleDelay($2, $3);
+	FILE_NAME(tmp, @1);
+	$$ = tmp;
+      }
+  | K_CYCLE_DELAY '(' expression ')' statement_or_null
+      { PCycleDelay*tmp = new PCycleDelay($3, $5);
 	FILE_NAME(tmp, @1);
 	$$ = tmp;
       }

--- a/pform.cc
+++ b/pform.cc
@@ -1798,6 +1798,21 @@ void pform_endmodule(const char*name, bool inside_celldefine,
       pform_cur_module.pop_front();
       perm_string mod_name = cur_module->mod_name();
 
+	/* IEEE 1800-2017 14.12: a `default clocking <id>;` item must name
+	   a clocking block declared in this scope. (Declaration forms
+	   register the block themselves, so only the reference form can
+	   leave a dangling name.) */
+      if (!cur_module->default_clocking.nil()
+	  && (cur_module->clocking_blocks.find(cur_module->default_clocking)
+	      == cur_module->clocking_blocks.end())) {
+	    ostringstream msg;
+	    msg << "error: default clocking block `"
+		<< cur_module->default_clocking
+		<< "' is not declared in `" << mod_name << "'.";
+	    VLerror(msg.str().c_str());
+	    cur_module->default_clocking = perm_string();
+      }
+
 	// Oops, there may be some sort of nesting problem. If
 	// SystemVerilog is activated, it is possible for modules to
 	// be nested. But if the nested module is broken, the parser
@@ -3868,14 +3883,33 @@ void pform_add_modport_port(const struct vlltype&loc,
 
 void pform_start_clocking_block(const struct vlltype&loc,
 				const char*name,
-				PEventStatement*event)
+				PEventStatement*event,
+				bool is_default)
 {
       Module*scope = pform_cur_module.front();
-      ivl_assert(loc, scope && scope->is_interface);
+	/* IEEE 1800-2017 14.3: clocking blocks may be declared in a
+	   module, interface, program, or checker. */
+      ivl_assert(loc, scope);
       /* On parse error, a previous clocking block may not have been ended. Reset it. */
       if (pform_cur_clocking) pform_cur_clocking = 0;
 
-      perm_string use_name = lex_strings.make(name);
+      if (is_default && !scope->default_clocking.nil()) {
+	    cerr << loc << ": error: multiple default clocking declarations "
+		 << "in `" << scope->mod_name() << "' (IEEE 1800-2017 14.12 "
+		 << "allows at most one per module, interface, or program)."
+		 << endl;
+	    error_count += 1;
+	    delete[] name;
+	    delete event;
+	    return;
+      }
+
+	/* An anonymous `default clocking @(event); ... endclocking`
+	   (14.12) is registered under an internal name that no source
+	   identifier can collide with. */
+      perm_string use_name = name
+	    ? lex_strings.make(name)
+	    : perm_string::literal("$default_clocking");
       if (scope->clocking_blocks.find(use_name) != scope->clocking_blocks.end()) {
 	    cerr << loc << ": error: duplicate declaration of clocking block `"
 		 << use_name << "'." << endl;
@@ -3888,13 +3922,40 @@ void pform_start_clocking_block(const struct vlltype&loc,
       pform_cur_clocking = new Module::PClocking(use_name, event);
       FILE_NAME(pform_cur_clocking, loc);
       scope->clocking_blocks[use_name] = pform_cur_clocking;
+      if (is_default)
+	    scope->default_clocking = use_name;
 
+      delete[] name;
+}
+
+void pform_set_default_clocking_ref(const struct vlltype&loc,
+				    const char*name)
+{
+      Module*scope = pform_cur_module.front();
+      ivl_assert(loc, scope);
+
+      if (!scope->default_clocking.nil()) {
+	    cerr << loc << ": error: multiple default clocking declarations "
+		 << "in `" << scope->mod_name() << "' (IEEE 1800-2017 14.12 "
+		 << "allows at most one per module, interface, or program)."
+		 << endl;
+	    error_count += 1;
+	    delete[] name;
+	    return;
+      }
+
+	/* Existence is validated in pform_endmodule so the referenced
+	   block may be declared before or after this item. */
+      scope->default_clocking = lex_strings.make(name);
       delete[] name;
 }
 
 void pform_add_clocking_signal(const struct vlltype&loc, perm_string name)
 {
-      ivl_assert(loc, pform_cur_clocking);
+	/* The enclosing block open may have failed (duplicate name) or
+	   been skipped on a parse error; drop the signal quietly — an
+	   error has already been reported. */
+      if (pform_cur_clocking == 0) return;
 
       if (!pform_cur_clocking->add_signal(name)) {
 	    cerr << loc << ": error: duplicate signal `" << name

--- a/pform.h
+++ b/pform.h
@@ -243,11 +243,22 @@ extern void pform_end_modport_item(const struct vlltype&loc);
 extern void pform_add_modport_port(const struct vlltype&loc,
 				   NetNet::PortType port_type,
 				   perm_string name, PExpr*expr);
+/* Open a clocking block declaration in the current module, interface,
+   or program scope (IEEE 1800-2017 14.3). A null name declares an
+   anonymous default clocking block (14.12), registered under an
+   internal name. is_default records the block as the scope's default
+   clocking. */
 extern void pform_start_clocking_block(const struct vlltype&loc,
 				       const char*name,
-				       PEventStatement*event);
+				       PEventStatement*event,
+				       bool is_default = false);
 extern void pform_add_clocking_signal(const struct vlltype&loc, perm_string name);
 extern void pform_end_clocking_block(const struct vlltype&loc);
+/* `default clocking <id>;` — select an existing clocking block as the
+   scope default (IEEE 1800-2017 14.12). Existence is checked at
+   endmodule so declaration order doesn't matter. */
+extern void pform_set_default_clocking_ref(const struct vlltype&loc,
+					   const char*name);
 
 /*
  * This creates an identifier aware of names that may have been

--- a/pform_dump.cc
+++ b/pform_dump.cc
@@ -1070,6 +1070,18 @@ void PDelayStatement::dump(ostream&out, unsigned ind) const
       }
 }
 
+void PCycleDelay::dump(ostream&out, unsigned ind) const
+{
+      out << setw(ind) << "" << "##" << *count_ << " /* " <<
+	    get_fileline() << " */";
+      if (statement_) {
+	    out << endl;
+	    statement_->dump(out, ind+2);
+      } else {
+	    out << " /* noop */;" << endl;
+      }
+}
+
 void PDisable::dump(ostream&out, unsigned ind) const
 {
       out << setw(ind) << "" << "disable ";

--- a/tests/g01_cycle_delay_test.sv
+++ b/tests/g01_cycle_delay_test.sv
@@ -1,0 +1,73 @@
+// IEEE 1800-2017 14.11 regression: procedural cycle delay `## count`.
+// `##N [stmt]` waits N events of the default clocking block (14.12) of
+// the enclosing scope, then runs the optional statement. Previously
+// `##` did not lex at all (two '#' tokens, syntax error). It now lowers
+// to `repeat (N) @(<default clocking>)` at elaboration.
+//
+// Checks (clk period 10, posedge at 5, 15, 25, ...):
+//   1. `##1;` waits exactly one clocking event
+//   2. `##2;` waits exactly two
+//   3. `##N stmt` runs stmt after the wait
+//   4. `##(expr)` parenthesized expression count
+//   5. `##id` identifier count evaluated at runtime
+//   6. `##0;` completes without waiting for any clocking event
+//   7. cycle delays work inside tasks of the same scope
+
+`timescale 1ns/1ns
+
+module g01_cycle_delay_test;
+  logic clk = 0;
+  int hits = 0;
+  int errors = 0;
+
+  always #5 clk = ~clk;
+
+  default clocking dcb @(posedge clk);
+  endclocking
+
+  task automatic check_time(string what, time want);
+    if ($time != want) begin
+      $display("FAIL: %s at t=%0t (want %0t)", what, $time, want);
+      errors++;
+    end
+  endtask
+
+  task automatic wait_two_cycles;
+    ##2;  // 7: cycle delay inside a task body
+  endtask
+
+  initial begin
+    ##0;                                  // 6: no wait
+    check_time("##0", 0);
+
+    ##1;                                  // 1: first posedge at t=5
+    check_time("##1", 5);
+
+    ##2;                                  // 2: two more edges -> t=25
+    check_time("##2", 25);
+
+    ##3 hits++;                           // 3: statement form -> t=55
+    check_time("##3 stmt", 55);
+    if (hits !== 1) begin
+      $display("FAIL: ##3 statement did not run");
+      errors++;
+    end
+
+    ##(1+1);                              // 4: expression form -> t=75
+    check_time("##(1+1)", 75);
+
+    begin : blk
+      int k;
+      k = 2;
+      ##k;                                // 5: identifier form -> t=95
+      check_time("##k", 95);
+    end
+
+    wait_two_cycles();                    // 7: -> t=115
+    check_time("task ##2", 115);
+
+    if (errors == 0) $display("PASS: procedural cycle delays");
+    else $display("FAIL: %0d errors", errors);
+    $finish(0);
+  end
+endmodule

--- a/tests/g01_module_clocking_test.sv
+++ b/tests/g01_module_clocking_test.sv
@@ -1,0 +1,134 @@
+// G01/G02 regression: clocking blocks outside interfaces.
+// IEEE 1800-2017 14.3: a clocking block may be declared in a module,
+// interface, program, or checker. Previously `clocking` in a module or
+// program emitted "only allowed in interfaces" and then died on the
+// pform.cc is_interface assertion (hard crash). 14.12: default clocking
+// declarations (named, anonymous, and the reference form) were parsed
+// and silently dropped; they are now registered like any other clocking
+// block. 14.4: skew syntax (#1step, #0, #(n), edge [#d], default
+// input/output skews) parses; skew *semantics* remain the alias model
+// (cb.sig accesses the underlying signal directly).
+//
+// Checks:
+//   1. module-scope clocking: @(cb) waits for the clocking event
+//   2. module-scope clocking: cb.in reads the underlying signal
+//   3. module-scope clocking: cb.out <= drives the underlying signal
+//   4. named default clocking is registered and usable by name
+//   5. `default clocking cb;` reference form accepted
+//   6. hierarchical @(sub.cb) and sub.cb.sig from the parent module
+//   7. program-block clocking: input read + output drive (G02)
+//   8. skew syntax parses on every A.6.11 clocking_item form
+//   9. multiple clocking blocks in one module coexist
+
+`timescale 1ns/1ns
+
+// -- 6: submodule with its own clocking block ------------------------
+module g01_sub(input logic clk);
+  logic [7:0] q;
+  clocking sub_cb @(posedge clk);
+    input q;
+  endclocking
+endmodule
+
+// -- 7: program block with a clocking block (G02) --------------------
+program g01_prog(input logic clk, input logic [7:0] pin, output logic [7:0] pout);
+  clocking pcb @(posedge clk);
+    input pin;
+    output pout;
+  endclocking
+  initial begin
+    @(pcb);
+    if (pcb.pin !== 8'h5a) $display("FAIL: program pcb.pin = %h", pcb.pin);
+    pcb.pout <= 8'h77;
+    @(pcb);
+    if (pout !== 8'h77) $display("FAIL: program pcb.pout = %h", pout);
+    else $display("PROGRAM CLOCKING OK");
+  end
+endprogram
+
+module g01_module_clocking_test;
+  logic clk = 0;
+  logic [7:0] data = 8'h00;
+  logic [7:0] result = 8'h00;
+  logic [7:0] pin = 8'h5a;
+  logic [7:0] pout;
+  logic [3:0] dv = 4'h0;
+  logic s1 = 0, s2 = 0, s3 = 0, s4 = 0, s5 = 0;
+  int errors = 0;
+
+  always #5 clk = ~clk;
+
+  g01_sub  u_sub (.clk(clk));
+  g01_prog u_prog(.clk(clk), .pin(pin), .pout(pout));
+
+  // -- 1..3: plain module-scope clocking block -----------------------
+  clocking cb @(posedge clk);
+    input data;
+    output result;
+  endclocking
+
+  // -- 8: every clocking_item skew form (A.6.11 / 14.4) --------------
+  clocking skew_cb @(posedge clk);
+    input #1step s1;
+    output #0 s2;
+    input #2 s3;
+    input posedge #1step s4;
+    default input #1step output #0;
+    input #1step output #0 s5;
+  endclocking
+
+  // -- 4: named default clocking (also checks 9: coexistence) --------
+  default clocking dcb @(posedge clk);
+    input dv;
+  endclocking
+
+  task automatic check(string name, logic [7:0] got, logic [7:0] want);
+    if (got !== want) begin
+      $display("FAIL: %s = %h (want %h)", name, got, want);
+      errors++;
+    end
+  endtask
+
+  initial begin
+    data = 8'h42;
+    dv = 4'h9;
+    s1 = 1;
+
+    // 1+2: @(cb) waits for posedge clk; cb.data reads `data`
+    @(cb);
+    check("cb.data", cb.data, 8'h42);
+
+    // 3: synchronous drive through the clocking block
+    cb.result <= 8'h99;
+    @(cb);
+    check("result", result, 8'h99);
+
+    // 4: default clocking block used by name
+    @(dcb);
+    check("dcb.dv", {4'h0, dcb.dv}, 8'h09);
+
+    // 8: skewed signals still alias the underlying nets
+    @(skew_cb);
+    check("skew_cb.s1", {7'h0, skew_cb.s1}, 8'h01);
+    skew_cb.s2 <= 1;
+    @(skew_cb);
+    check("s2", {7'h0, s2}, 8'h01);
+
+    // 6: hierarchical clocking access into a submodule
+    u_sub.q = 8'hc3;
+    @(u_sub.sub_cb);
+    check("u_sub.sub_cb.q", u_sub.sub_cb.q, 8'hc3);
+
+    if (errors == 0) $display("PASS: module/program clocking blocks");
+    else $display("FAIL: %0d errors", errors);
+    $finish(0);
+  end
+endmodule
+
+// -- 5: reference form in a sibling module ---------------------------
+module g01_default_ref_check;
+  logic clk2 = 0;
+  clocking rcb @(posedge clk2);
+  endclocking
+  default clocking rcb;
+endmodule

--- a/tests/negative/g01_cycle_delay_no_default.sv
+++ b/tests/negative/g01_cycle_delay_no_default.sv
@@ -1,0 +1,8 @@
+// IEEE 1800-2017 14.11: a procedural cycle delay requires a default
+// clocking block in scope. Must produce an error, not hang or ignore.
+module top;
+  logic clk = 0;
+  initial begin
+    ##1;
+  end
+endmodule

--- a/tests/negative/g01_multiple_default_clocking.sv
+++ b/tests/negative/g01_multiple_default_clocking.sv
@@ -1,0 +1,8 @@
+// IEEE 1800-2017 14.12: at most one default clocking per module.
+module top;
+  logic clk = 0;
+  clocking cb1 @(posedge clk); endclocking
+  clocking cb2 @(posedge clk); endclocking
+  default clocking cb1;
+  default clocking cb2;
+endmodule

--- a/tests/negative/g01_undeclared_default_clocking.sv
+++ b/tests/negative/g01_undeclared_default_clocking.sv
@@ -1,0 +1,6 @@
+// IEEE 1800-2017 14.12: `default clocking id;` must name a clocking
+// block declared in the same scope.
+module top;
+  logic clk = 0;
+  default clocking nosuch;
+endmodule


### PR DESCRIPTION
## Summary

Opens milestone **M8 (clocking blocks)** at the gap-audit entry point.

- **G01 FIXED** — `clocking ... endclocking` in a **module** crashed the compiler (`error: clocking declarations are only allowed in interfaces.` + `assert: pform.cc:3874: failed assertion scope && scope->is_interface` + core dump). IEEE 1800-2017 **14.3** permits clocking blocks in modules, interfaces, programs, and checkers. Module-scope clocking now registers and works end to end: `@(cb)` waits, `cb.sig` reads, `cb.sig <= v` drives, hierarchical `@(inst.cb)` / `inst.cb.sig`.
- **G02 FIXED** — same crash for clocking inside **program** blocks; program-scope clocking verified including output drives.
- **14.12 default clocking** — the named/anonymous declaration forms were parsed and **silently dropped** (compile-progress fallback); they now register their block, `Module::default_clocking` records the scope default (at most one, enforced), and the `default clocking id;` reference form (A.1.4) is new (existence validated at endmodule, declaration-order free).
- **14.4 skew syntax** — `#1step` now lexes (new SV-gated `1step` token), edge skews (`posedge/negedge/edge [#d]`), `#(expr)`, combined `input ... output ...` directions, and `default input/output skew` items parse per A.6.11. Skews are accepted and discarded: the clocking model remains the documented **alias model** (`cb.sig` accesses the underlying signal directly); sample/drive skew *semantics* are the next M8 increment. `ref` is no longer wrongly accepted as a clocking direction.
- **14.11 procedural cycle delays** — **new**: `##` lexes (SV-gated), and `##N;` / `##N stmt` / `##(expr)` / `##id` lower at elaboration to `repeat (N) @(<default clocking>)` through the same resolver as source-level `@(cb)`. Clause-referenced error when no default clocking is in scope.
- **Debt reduction** — the two clocking path-rewrite helpers duplicated as statics in `elab_expr.cc`/`elab_lval.cc` are unified in `netmisc.cc` and generalized past `is_interface`; new shared same-scope resolver (`rewrite_enclosing_scope_clocking_member_path`). Latent crash fixed: duplicate clocking-block name + items no longer trips the `pform_add_clocking_signal` assertion.
- Bison conflicts went **down**: 459→458 shift/reduce, 1060→1053 reduce/reduce.

## Tests

- `tests/g01_module_clocking_test.sv` — module/program clocking (G01/G02), every A.6.11 clocking_item form, default-clocking forms, hierarchical access, multiple blocks coexisting.
- `tests/g01_cycle_delay_test.sv` — `##0/##1/##2`, statement/expression/identifier count forms, cycle delay inside a task body.
- `tests/negative/g01_cycle_delay_no_default.sv`, `g01_multiple_default_clocking.sv`, `g01_undeclared_default_clocking.sv`.

## Regression evidence

Fresh same-machine pristine baseline built from `fb79080` (merged main) in a worktree:

| Suite | Result | vs baseline |
|---|---|---|
| UVM `.github/uvm_test.sh` | 128/128 on the clocking increment; final 129-test rerun (incl. the new cycle-delay test) recorded in the promotion commit | +2 new tests |
| ivtest `vvp_reg.pl` | 2961/3101, 132 failed | failure **names identical** (diff empty) |
| ivtest `vvp_reg.py` | 284 ran / 12 failed | identical |
| ivtest `vpi_reg.pl` | 76/76 (`--with-pli1`: 76/85) | identical incl. the 9 environmental pli1 fails on pristine main |
| negative suite | 9/9 (3 new) | — |
| `m6_region_trace`, `make check` | PASS | — |

## Docs

- Session log: `docs/conformance/session_logs/2026-07-14_g01_clocking_blocks.md`
- `docs/conformance/CURRENT_WORK.md` — new 2026-07-14i state + M8 increment-2 continuation plan (real sampling/drive semantics on the M6 Preponed/Observed/Re-NBA entry points)
- Gap audit: G01/G02 marked FIXED with the remaining clause-14 tail recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKqGtKR9YdKC3T4Uzcqwj6

---
_Generated by [Claude Code](https://claude.ai/code/session_01AKqGtKR9YdKC3T4Uzcqwj6)_