### PR TITLE
Refactor automatic-variable storage to the single-task-frame model

### DIFF
--- a/docs/conformance/auto_var_storage_refactor_notes.md
+++ b/docs/conformance/auto_var_storage_refactor_notes.md
@@ -1,0 +1,101 @@
+# Automatic-variable storage refactor — working notes
+
+Status: in progress (incremental migration).
+Governing doc: `iverilog_ieee1800_uvm_manifesto.md`; root-cause writeup:
+`test_suite_audit_2026-07-17.md` (search "automatic_events2").
+
+## Models
+
+**Upstream (9b44d55) single-task-frame model.** One activation frame
+(`vvp_context_t`) per automatic *task/function call*, allocated by `%alloc
+S_<task>` at the call site. Nested block/fork scopes inside the task get **no**
+frame of their own: at vvp compile time, `vpip_peek_context_scope()` climbs
+from any nested automatic scope to the outermost automatic ancestor, so every
+nested-block local receives a context index *in the task frame*. Runtime is
+trivially simple: an automatic-variable access is
+`vvp_get_context_item(thread->rd_context, idx)` — the head of the thread's
+context stack. `%fork` children in an automatic scope share the parent's
+`wt_context` pointer; `do_join` only pops/pushes a context when joining a
+task/function *call* thread. Limitation: `%join/detach` (join_any/join_none)
+asserts if a detached child shares the parent's context — upstream simply does
+not support detached forks inside automatic scopes.
+
+**Fork per-block-frame model (being retired).** `PBlock::elaborate` wraps every
+automatic *named* block/fork scope in `NetAlloc`/`NetFree`;
+`vpip_peek_context_scope()` was changed to stop at `vpiNamedBegin`/
+`vpiNamedFork`, so each block owns a frame. Because a parent-scope variable
+reference can no longer assume "head of stack", a large heuristic layer was
+added: scope-matched chain search (`vthread_get_rd_context_item_scoped`),
+`automatic_context_owner`/`automatic_context_refcount` maps, context
+sanitizing/recovery, and retain-on-detach in `%join/detach` (that last one is
+what makes UVM's `fork…join_none`-in-automatic-tasks work — the reason the
+model exists at all). The known cost: in a blocking `fork…join` inside an
+automatic task, when one branch ends before a sibling reads a parent-scope
+local, the shared parent context is dropped from the chain the sibling reads
+through (ivtest `automatic_events2`; minimal repro below prints `r=x`,
+upstream prints `r=a1`).
+
+    task automatic w(input [7:0] id, output [7:0] r);
+      begin: body
+        reg [7:0] acc; acc = id;
+        fork begin #10; end begin #30 r = acc; end join
+      end
+    endtask
+
+## Where each side decides frame ownership (must stay in agreement)
+
+1. **elaborate.cc `PBlock::elaborate`** — emits `NetAlloc`/`NetFree`
+   (→ `%alloc`/`%free`) around a block's statements.
+2. **vvp/vpi_scope.cc `scope_has_own_automatic_context_` /
+   `vpip_peek_context_scope`** — compile-time: decides which scope's context
+   receives each `.var`/`.array`/event item.
+3. **vvp/vthread.cc `scope_has_own_automatic_context_` /
+   `resolve_context_scope`** — runtime: same climb, but treats a named
+   begin/fork as owning only if `nitem > 0` (i.e. only if compile time
+   actually placed items there). This self-adapts: stop placing items in a
+   scope and the runtime automatically climbs past it.
+
+## Frame taxonomy
+
+| Category | Own frame? | Why |
+|---|---|---|
+| automatic task/function (call site) | YES — keep | recursion; per-call locals |
+| named `begin` w/ automatic parent scope | NO — **collapsed (step 1)** | statement completes before parent resumes; locals ride enclosing frame (upstream semantics) |
+| named `begin` w/ *static* parent (block-local `automatic` vars in a static process) | YES — keep | no enclosing frame exists to ride |
+| `fork…join` (blocking) scopes | keep for now — collapse later (step 2) | safe in principle (all branches complete first) but vvp compile time cannot yet distinguish join type; needs a `.scope` annotation co-evolution |
+| `fork…join_any`/`join_none` scopes | YES — keep | detached branches outlive the statement; frame lifetime managed by retain-on-detach refcounting |
+
+## Step 1 (this change): collapse named begin blocks with automatic parents
+
+- `elaborate.cc PBlock::elaborate`: emit the alloc/free prefix only when the
+  scope is automatic AND NOT (BL_SEQ with an automatic parent scope). Collapsed
+  blocks take the upstream path: `var_inits` elaborate inline into the block
+  statement itself (which also restores the plain upstream path for
+  constant-function evaluation — the staged `set_var_init` copy is only needed
+  for frame-owning scopes whose initializers live in the scope-0 prefix).
+- `vvp/vpi_scope.cc scope_has_own_automatic_context_`: `vpiNamedBegin` owns a
+  context only when its parent scope is not automatic. (`vpiNamedFork`
+  unchanged.)
+- `vvp/vthread.cc`: **no change needed** — its `nitem > 0` guard self-adapts
+  (collapsed begins receive no items).
+- tgt-vvp: no change — `%alloc`/`%free` emission is driven purely by
+  `NetAlloc`/`NetFree` statements.
+
+Expected effects: `automatic_events2` (and the minimal repro) fixed because a
+begin-block under an automatic task no longer manufactures a second frame, so
+fork branches and their parent all read/write the one task frame, exactly as
+upstream. `disable` of a named begin is unaffected (thread control, not frame
+control). `fork…join_none` inside a collapsed begin still works: the detach
+retain logic operates on whatever shared context the threads carry — now the
+task frame instead of the block frame.
+
+## Later steps
+
+2. Collapse blocking `fork…join` scopes: requires the vvp `.scope` directive
+   (or a flag on it) to distinguish detached-capable fork scopes so item
+   placement can climb; co-evolve tgt-vvp `draw_scope` + vvp `compile_scope`.
+3. With per-block frames gone from the common paths, begin retiring the
+   heuristic layer in vvp/vthread.cc (owner/refcount maps, scoped chain
+   search, sanitize/recovery) in favor of the upstream invariants, keeping
+   only the retain-on-detach mechanism that supports detached forks in
+   automatic scopes (the fork's genuine extension over upstream).

--- a/docs/conformance/auto_var_storage_refactor_notes.md
+++ b/docs/conformance/auto_var_storage_refactor_notes.md
@@ -62,8 +62,23 @@ upstream prints `r=a1`).
 | automatic task/function (call site) | YES — keep | recursion; per-call locals |
 | named `begin` w/ automatic parent scope | NO — **collapsed (step 1)** | statement completes before parent resumes; locals ride enclosing frame (upstream semantics) |
 | named `begin` w/ *static* parent (block-local `automatic` vars in a static process) | YES — keep | no enclosing frame exists to ride |
-| `fork…join` (blocking) scopes | keep for now — collapse later (step 2) | safe in principle (all branches complete first) but vvp compile time cannot yet distinguish join type; needs a `.scope` annotation co-evolution |
+| `fork…join` (blocking) scopes w/ automatic parent | NO — **collapsed (step 2)** | all branches complete before the parent resumes; locals ride enclosing frame |
 | `fork…join_any`/`join_none` scopes | YES — keep | detached branches outlive the statement; frame lifetime managed by retain-on-detach refcounting |
+
+## Step 2: collapse blocking fork/join scopes with automatic parents
+
+The join type is known only to the front end (`PBlock::bl_type_`), so the
+collapse decision is made once in `elab_scope.cc` (a new
+`NetScope::auto_frame` flag: false for BL_SEQ/BL_PAR scopes with automatic
+parents) and communicated end to end: `PBlock::elaborate` consults the flag
+instead of recomputing; t-dll exposes it as `ivl_scope_auto_frame()`;
+tgt-vvp emits collapsed scopes as `.scope autobegin.shared` /
+`autofork.shared`; vvp's `compile_scope` parses the marker into
+`__vpiScope::shares_parent_frame`, which `scope_has_own_automatic_context_`
+consults for item placement. The runtime's `resolve_context_scope`
+continues to self-adapt via its `nitem > 0` guard. This moved ivtest
+`automatic_events`, `automatic_events2`, `automatic_events3` (formerly NI)
+and `recursive_task` to gold.
 
 ## Step 1 (this change): collapse named begin blocks with automatic parents
 

--- a/elab_scope.cc
+++ b/elab_scope.cc
@@ -3118,6 +3118,19 @@ void PBlock::elaborate_scope(Design*des, NetScope*scope) const
 	      // fork blocks as "autofork" and allocate block-entry storage.
             my_scope->is_auto(scope->is_auto()
 			      || scope_has_automatic_signal_locals_(wires));
+	      // Automatic block scopes that run to completion before the
+	      // parent resumes — named begin blocks and blocking fork/join
+	      // — are collapsed into the enclosing activation frame when
+	      // the parent scope is automatic: their locals get context
+	      // indices in the frame-owning ancestor scope and no
+	      // %alloc/%free is emitted for them (upstream
+	      // single-task-frame model). A frame of its own remains for
+	      // join_any/join_none forks (detached branches outlive the
+	      // statement) and for automatic blocks with a static parent
+	      // (no enclosing frame exists).
+	    if (my_scope->is_auto() && scope->is_auto()
+		&& (bl_type_ == BL_SEQ || bl_type_ == BL_PAR))
+		  my_scope->auto_frame(false);
 	    my_scope->add_imports(&explicit_imports);
 	    my_scope->add_typedefs(&typedefs);
 

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -4640,17 +4640,19 @@ NetProc* PBlock::elaborate(Design*des, NetScope*scope) const
       NetBlock*prefix = 0;
 
 	// Decide whether this automatic scope needs its own activation
-	// frame. A named begin block whose parent scope is also automatic
-	// does not: its statement runs to completion before the parent
-	// resumes, so its locals ride the enclosing task/function frame
-	// (matching the upstream single-task-frame model; the vvp side
-	// assigns such locals context indices in the frame-owning ancestor
-	// scope). A frame is still required when there is no enclosing
-	// automatic frame to ride (block-local automatic variables in a
-	// static process) and for fork scopes, whose join_any/join_none
-	// forms detach branches that outlive the statement.
+	// frame. Begin blocks and blocking fork/join scopes whose parent
+	// scope is also automatic do not: their statement runs to
+	// completion before the parent resumes, so their locals ride the
+	// enclosing task/function frame (matching the upstream
+	// single-task-frame model; the scope was marked in elab_scope and
+	// the vvp side assigns such locals context indices in the
+	// frame-owning ancestor scope). A frame is still required when
+	// there is no enclosing automatic frame to ride (block-local
+	// automatic variables in a static process) and for
+	// join_any/join_none forks, which detach branches that outlive
+	// the statement.
       bool needs_own_frame = nscope && nscope->is_auto()
-	    && !(type == NetBlock::SEQU && scope->is_auto());
+	    && nscope->auto_frame();
 
       if (nscope) {
 	      // Handle any variable initialization statements in this scope.

--- a/elaborate.cc
+++ b/elaborate.cc
@@ -4639,14 +4639,29 @@ NetProc* PBlock::elaborate(Design*des, NetScope*scope) const
       NetBlock*cur = new NetBlock(type, nscope);
       NetBlock*prefix = 0;
 
+	// Decide whether this automatic scope needs its own activation
+	// frame. A named begin block whose parent scope is also automatic
+	// does not: its statement runs to completion before the parent
+	// resumes, so its locals ride the enclosing task/function frame
+	// (matching the upstream single-task-frame model; the vvp side
+	// assigns such locals context indices in the frame-owning ancestor
+	// scope). A frame is still required when there is no enclosing
+	// automatic frame to ride (block-local automatic variables in a
+	// static process) and for fork scopes, whose join_any/join_none
+	// forms detach branches that outlive the statement.
+      bool needs_own_frame = nscope && nscope->is_auto()
+	    && !(type == NetBlock::SEQU && scope->is_auto());
+
       if (nscope) {
 	      // Handle any variable initialization statements in this scope.
-	      // For automatic scopes, stage a fresh activation frame before
-	      // any block-entry initializers run, then free it after the
-	      // block finishes. This covers automatic named begin/fork blocks
-	      // in the same way automatic task calls use %alloc/%free around
-	      // input setup and execution.
-	    if (nscope->is_auto()) {
+	      // For automatic scopes with their own frame, stage the fresh
+	      // activation frame before any block-entry initializers run,
+	      // then free it after the block finishes. This covers automatic
+	      // named fork blocks in the same way automatic task calls use
+	      // %alloc/%free around input setup and execution. Collapsed
+	      // automatic scopes (and static scopes) handle initializers
+	      // without a frame prefix.
+	    if (needs_own_frame) {
 		  prefix = new NetBlock(NetBlock::SEQU, 0);
 		  NetAlloc*ap = new NetAlloc(nscope);
 		  ap->set_line(*this);
@@ -4676,6 +4691,16 @@ NetProc* PBlock::elaborate(Design*des, NetScope*scope) const
 			      if (tmp) ceval->append(tmp);
 			}
 			nscope->set_var_init(ceval);
+		  }
+	    } else if (nscope->is_auto()) {
+		    // Collapsed automatic scope: no frame prefix. The
+		    // initializers are ordinary statements executed each
+		    // time the block is entered, targeting storage in the
+		    // enclosing frame. This is also the form the constant
+		    // function evaluator walks directly.
+		  for (unsigned idx = 0; idx < var_inits.size(); idx += 1) {
+			NetProc*tmp = var_inits[idx]->elaborate(des, nscope);
+			if (tmp) cur->append(tmp);
 		  }
 	    } else {
 		  elaborate_var_inits_(des, nscope);

--- a/ivl.def
+++ b/ivl.def
@@ -220,6 +220,7 @@ ivl_scope_file
 ivl_scope_func_type
 ivl_scope_func_signed
 ivl_scope_func_width
+ivl_scope_auto_frame
 ivl_scope_is_auto
 ivl_scope_is_cell
 ivl_scope_program

--- a/ivl_target.h
+++ b/ivl_target.h
@@ -1903,6 +1903,10 @@ extern unsigned     ivl_scope_events(ivl_scope_t net);
 extern ivl_event_t  ivl_scope_event(ivl_scope_t net, unsigned idx);
 extern const char* ivl_scope_file(ivl_scope_t net);
 extern unsigned ivl_scope_is_auto(ivl_scope_t net);
+  /* Does this automatic scope own an activation frame, or is it
+     collapsed into the enclosing frame? (Meaningful only when
+     ivl_scope_is_auto is true.) */
+extern unsigned ivl_scope_auto_frame(ivl_scope_t net);
   /* Return true if the scope is (or is inside) a program block
      (IEEE 1800-2017 clause 24); program processes schedule in the
      Reactive region set. */

--- a/ivtest/regress-vlg.list
+++ b/ivtest/regress-vlg.list
@@ -196,9 +196,9 @@ automatic_error10	CE			ivltests
 # automatic_events: pre-existing upstream bug — local/auto nets elided but
 # still referenced by .event definitions; "unresolved vvp_net reference" at
 # runtime. Not a regression from our changes. Tracked for future fix.
-automatic_events	NI			ivltests gold=automatic_events.gold
-automatic_events2	NI			ivltests gold=automatic_events.gold
-automatic_events3	NI			ivltests gold=automatic_events3.gold
+automatic_events	normal			ivltests gold=automatic_events.gold
+automatic_events2	normal			ivltests gold=automatic_events.gold
+automatic_events3	normal			ivltests gold=automatic_events3.gold
 automatic_task		normal			ivltests gold=automatic_task.gold
 automatic_task2		normal			ivltests gold=automatic_task2.gold
 automatic_task3		normal			ivltests gold=automatic_task3.gold

--- a/net_scope.cc
+++ b/net_scope.cc
@@ -120,6 +120,7 @@ NetScope::NetScope(NetScope*up, const hname_t&n, NetScope::TYPE t, NetScope*in_u
       events_ = 0;
       lcounter_ = 0;
       is_auto_ = false;
+      auto_frame_ = true;
       is_cell_ = false;
       calls_stask_ = false;
       in_final_ = false;

--- a/netlist.h
+++ b/netlist.h
@@ -1166,6 +1166,17 @@ class NetScope : public Definitions, public Attrib {
       void is_auto(bool is_auto__) { is_auto_ = is_auto__; };
       bool is_auto() const { return is_auto_; };
 
+	/* Does this automatic scope own an activation frame? True for
+	   automatic task/function scopes (frame per call) and for
+	   automatic block scopes that cannot ride an enclosing frame:
+	   blocks with a static parent scope, and fork scopes whose
+	   join_any/join_none branches may outlive the fork statement.
+	   False for begin/fork scopes collapsed into the enclosing
+	   frame (the upstream single-task-frame model). Only
+	   meaningful when is_auto() is true. */
+      void auto_frame(bool auto_frame__) { auto_frame_ = auto_frame__; };
+      bool auto_frame() const { return auto_frame_; };
+
 	/* Is the module a cell (is in a `celldefine) */
       void is_cell(bool is_cell__) { is_cell_ = is_cell__; };
       bool is_cell() const { return is_cell_; };
@@ -1413,7 +1424,7 @@ class NetScope : public Definitions, public Attrib {
       std::map<hname_t,NetScope*> children_;
 
       unsigned lcounter_;
-      bool need_const_func_, is_const_func_, is_auto_, is_cell_, calls_stask_;
+      bool need_const_func_, is_const_func_, is_auto_, auto_frame_, is_cell_, calls_stask_;
       bool is_virtual_method_ = false;
 
       /* Final procedures sets this to notify statements that

--- a/t-dll-api.cc
+++ b/t-dll-api.cc
@@ -2249,6 +2249,12 @@ extern "C" unsigned ivl_scope_is_auto(ivl_scope_t net)
       return net->is_auto;
 }
 
+extern "C" unsigned ivl_scope_auto_frame(ivl_scope_t net)
+{
+      assert(net);
+      return net->auto_frame;
+}
+
 extern "C" unsigned ivl_scope_program(ivl_scope_t net)
 {
       assert(net);

--- a/t-dll.cc
+++ b/t-dll.cc
@@ -654,6 +654,7 @@ void dll_target::add_root(const NetScope *s)
       root_->nattr = s->attr_cnt();
       root_->attr  = fill_in_attributes(s);
       root_->is_auto = 0;
+      root_->auto_frame = 1;
       root_->is_program = s->program_block();
       root_->is_interface = s->is_interface();
       root_->modport_names = s->modport_names();
@@ -2579,6 +2580,7 @@ void dll_target::scope(const NetScope*net)
 	    scop->nattr = net->attr_cnt();
 	    scop->attr = fill_in_attributes(net);
 	    scop->is_auto = net->is_auto();
+	    scop->auto_frame = net->auto_frame();
 	    scop->is_program = net->program_block();
 	    scop->is_interface = net->is_interface();
 	    scop->modport_names = net->modport_names();

--- a/t-dll.h
+++ b/t-dll.h
@@ -714,6 +714,7 @@ struct ivl_scope_s {
 	/* Scopes that are tasks/functions have a definition. */
       ivl_statement_t def;
       unsigned is_auto;
+      unsigned auto_frame;
       unsigned is_program;
       unsigned is_interface;
       std::vector<perm_string> modport_names;

--- a/tests/auto_task_frame_sharing_test.sv
+++ b/tests/auto_task_frame_sharing_test.sv
@@ -1,0 +1,66 @@
+// Regression: automatic-variable storage must follow the single-task-frame
+// model. A named begin block inside an automatic task does not get its own
+// activation frame; its locals live in the frame allocated for the task
+// call. Under the retired per-block-frame model, a blocking fork...join
+// inside such a block corrupted parent-scope reads: when one branch ended
+// before a sibling branch read a parent-scope automatic local, the shared
+// parent context was dropped from the context chain the live sibling read
+// through, and the read returned the element default (x).
+//
+// The failing shape (from ivtest automatic_events2 root-cause analysis):
+// branch A ends at #10, branch B reads the named-block local `acc` at #30.
+module top;
+
+  task automatic w(input byte id, output byte r);
+    begin: body
+      reg [7:0] acc;
+      acc = id;
+      fork
+        begin #10 ; end          // branch A ends early
+        begin #30 r = acc; end   // branch B reads parent-scope local later
+      join
+    end
+  endtask
+
+  // Same shape one level deeper: the reading branch is inside a nested
+  // named block, and the written local sits two automatic block scopes
+  // above it, all riding the one task frame.
+  task automatic w2(input byte id, output byte r);
+    begin: outer
+      reg [7:0] acc;
+      begin: inner
+        reg [7:0] acc2;
+        acc = id;
+        acc2 = ~id;
+        fork
+          begin #5 ; end
+          begin #20 r = acc ^ acc2; end
+        join
+      end
+    end
+  endtask
+
+  // Overlapping calls: each invocation's frame must stay independent while
+  // both are suspended inside their forks.
+  byte r1, r2, r3, r4;
+
+  initial begin
+    automatic bit ok = 1;
+
+    w(8'ha1, r1);
+    if (r1 !== 8'ha1) begin ok = 0; $display("FAIL w r1=%0h exp a1", r1); end
+
+    fork
+      w(8'h5a, r2);
+      w(8'hc3, r3);
+    join
+    if (r2 !== 8'h5a) begin ok = 0; $display("FAIL overlap r2=%0h exp 5a", r2); end
+    if (r3 !== 8'hc3) begin ok = 0; $display("FAIL overlap r3=%0h exp c3", r3); end
+
+    w2(8'h0f, r4);
+    if (r4 !== 8'hff) begin ok = 0; $display("FAIL nested r4=%0h exp ff", r4); end
+
+    if (ok) $display("PASS: automatic task frame sharing (fork sibling reads)");
+    $finish;
+  end
+endmodule

--- a/tests/auto_task_frame_sharing_test.sv
+++ b/tests/auto_task_frame_sharing_test.sv
@@ -40,9 +40,43 @@ module top;
     end
   endtask
 
+  // Named blocking fork with its own declarations (the ivtest
+  // automatic_events2 shape): the fork scope is collapsed too, so its
+  // locals and the parent block's locals all ride the task frame, and a
+  // branch ending early must not disturb what the sibling branches read.
+  task automatic w3(input byte id, output byte r);
+    begin: body3
+      reg [7:0] acc;
+      acc = id;
+      fork: threads
+        reg [7:0] tmp;
+        begin #5 tmp = acc; end        // branch A ends early
+        begin #15 r = tmp ^ 8'hff; end // branch B reads fork-scope local later
+      join
+    end
+  endtask
+
+  // Recursive call whose recursion site sits inside the named block, with
+  // a sibling fork branch reading the block local before and after the
+  // nested call completes (the ivtest recursive_task shape).
+  task automatic fact(input int n, output int f);
+    begin: fb
+      int t;
+      fork
+        begin
+          if (n > 1) fact(n - 1, t);
+          else t = 1;
+          #1 f = n * t;
+        end
+        begin @f ; end   // sibling observes completion via the frame var
+      join
+    end
+  endtask
+
   // Overlapping calls: each invocation's frame must stay independent while
   // both are suspended inside their forks.
-  byte r1, r2, r3, r4;
+  byte r1, r2, r3, r4, r5;
+  int f4;
 
   initial begin
     automatic bit ok = 1;
@@ -59,6 +93,12 @@ module top;
 
     w2(8'h0f, r4);
     if (r4 !== 8'hff) begin ok = 0; $display("FAIL nested r4=%0h exp ff", r4); end
+
+    w3(8'h3c, r5);
+    if (r5 !== 8'hc3) begin ok = 0; $display("FAIL named-fork r5=%0h exp c3", r5); end
+
+    fact(4, f4);
+    if (f4 !== 24) begin ok = 0; $display("FAIL recursive fork f4=%0d exp 24", f4); end
 
     if (ok) $display("PASS: automatic task frame sharing (fork sibling reads)");
     $finish;

--- a/tgt-vvp/vvp_scope.c
+++ b/tgt-vvp/vvp_scope.c
@@ -2569,8 +2569,20 @@ int draw_scope(ivl_scope_t net, ivl_scope_t parent)
 	    break;
       case IVL_SCT_FUNCTION: type = "function"; break;
       case IVL_SCT_TASK:     type = "task";     break;
-      case IVL_SCT_BEGIN:    type = "begin";    break;
-      case IVL_SCT_FORK:     type = "fork";     break;
+	/* An automatic begin/fork scope that is collapsed into the
+	   enclosing activation frame is marked ".shared": the runtime
+	   places its automatic locals in the frame-owning ancestor
+	   scope and expects no %alloc/%free for it. */
+      case IVL_SCT_BEGIN:
+	    type = "begin";
+	    if (ivl_scope_is_auto(net) && !ivl_scope_auto_frame(net))
+		  snprintf(suffix, sizeof suffix, ".shared");
+	    break;
+      case IVL_SCT_FORK:
+	    type = "fork";
+	    if (ivl_scope_is_auto(net) && !ivl_scope_auto_frame(net))
+		  snprintf(suffix, sizeof suffix, ".shared");
+	    break;
       case IVL_SCT_GENERATE: type = "generate"; break;
       case IVL_SCT_PACKAGE:  type = "package";  break;
       case IVL_SCT_CLASS:    type = "class";    break;

--- a/vvp/vpi_priv.h
+++ b/vvp/vpi_priv.h
@@ -270,6 +270,12 @@ class __vpiScope : public __vpiHandle {
       inline const char*scope_def_name() const { return tname_; }
 	// TRUE if this is an automatic func/task/block
       inline bool is_automatic() const { return is_automatic_; }
+	// TRUE if this automatic begin/fork scope is collapsed into the
+	// enclosing activation frame (".shared" scope types): its
+	// automatic locals get context indices in the frame-owning
+	// ancestor scope and no %alloc/%free is emitted for it.
+      inline bool shares_parent_frame() const { return shares_parent_frame_; }
+      inline void set_shares_parent_frame() { shares_parent_frame_ = true; }
 
     public:
       __vpiScope *scope;
@@ -307,6 +313,9 @@ class __vpiScope : public __vpiHandle {
       const char*tname_;
 	/* the scope may be "automatic" */
       bool is_automatic_;
+	/* automatic begin/fork scopes collapsed into the enclosing
+	   frame (see shares_parent_frame()) */
+      bool shares_parent_frame_ = false;
 };
 
 class vpiScopeFunction  : public __vpiScope {

--- a/vvp/vpi_scope.cc
+++ b/vvp/vpi_scope.cc
@@ -917,9 +917,17 @@ static bool scope_has_own_automatic_context_(__vpiScope*scope)
       switch (scope->get_type_code()) {
           case vpiTask:
           case vpiFunction:
-          case vpiNamedBegin:
           case vpiNamedFork:
             return true;
+          case vpiNamedBegin:
+              /* A named begin block inside an automatic scope is collapsed
+                 into the enclosing frame: its statement runs to completion
+                 before the parent resumes, so its locals ride the enclosing
+                 task/function (or fork) frame and no %alloc is emitted for
+                 it. Only a begin block with a static parent (block-local
+                 automatic variables in a static process) owns a frame,
+                 because there is no enclosing frame to ride. */
+            return !(scope->scope && scope->scope->is_automatic());
           default:
             return false;
       }

--- a/vvp/vpi_scope.cc
+++ b/vvp/vpi_scope.cc
@@ -815,10 +815,19 @@ compile_scope_decl(char*label, char*type, char*name, char*tname,
 	    scope = new vpiScopeFork(name, tname);
       } else if (strcmp(type,"autofork") == 0) {
 	    scope = new vpiScopeForkAuto(name, tname);
+      } else if (strcmp(type,"autofork.shared") == 0) {
+	      /* Automatic fork scope collapsed into the enclosing
+	         activation frame: locals ride the frame-owning ancestor
+	         scope; no %alloc/%free is emitted for it. */
+	    scope = new vpiScopeForkAuto(name, tname);
+	    scope->set_shares_parent_frame();
       } else if (strcmp(type,"begin") == 0) {
 	    scope = new vpiScopeBegin(name, tname);
       } else if (strcmp(type,"autobegin") == 0) {
 	    scope = new vpiScopeBeginAuto(name, tname);
+      } else if (strcmp(type,"autobegin.shared") == 0) {
+	    scope = new vpiScopeBeginAuto(name, tname);
+	    scope->set_shares_parent_frame();
       } else if (strcmp(type,"generate") == 0) {
 	    scope = new vpiScopeGenerate(name, tname);
       } else if (strcmp(type,"package") == 0) {
@@ -917,17 +926,19 @@ static bool scope_has_own_automatic_context_(__vpiScope*scope)
       switch (scope->get_type_code()) {
           case vpiTask:
           case vpiFunction:
-          case vpiNamedFork:
             return true;
           case vpiNamedBegin:
-              /* A named begin block inside an automatic scope is collapsed
-                 into the enclosing frame: its statement runs to completion
-                 before the parent resumes, so its locals ride the enclosing
-                 task/function (or fork) frame and no %alloc is emitted for
-                 it. Only a begin block with a static parent (block-local
-                 automatic variables in a static process) owns a frame,
-                 because there is no enclosing frame to ride. */
-            return !(scope->scope && scope->scope->is_automatic());
+          case vpiNamedFork:
+              /* The compiler marks automatic begin/fork scopes that are
+                 collapsed into the enclosing frame with ".shared" scope
+                 types: their statement runs to completion before the
+                 parent resumes, so their locals ride the enclosing
+                 task/function (or frame-owning fork) frame and no %alloc
+                 is emitted for them. Unmarked automatic block scopes own
+                 a frame: join_any/join_none forks (detached branches
+                 outlive the statement) and blocks with a static parent
+                 (no enclosing frame exists to ride). */
+            return !scope->shares_parent_frame();
           default:
             return false;
       }

--- a/vvp/vthread.cc
+++ b/vvp/vthread.cc
@@ -9731,12 +9731,6 @@ static void do_join(vthread_t thr, vthread_t child)
                      ? child->parent_scope->get_type_code() : 0;
       __vpiScope*thr_ctx_scope = resolve_context_scope(thr ? thr->parent_scope : 0);
       __vpiScope*child_ctx_scope = resolve_context_scope(child ? child->parent_scope : 0);
-      bool shared_auto_scope = child_ctx_scope && thr_ctx_scope
-                            && (child_ctx_scope == thr_ctx_scope
-                                || scope_is_within_or_equal_(thr ? thr->parent_scope : 0,
-                                                             child_ctx_scope)
-                                || scope_is_within_or_equal_(child ? child->parent_scope : 0,
-                                                             thr_ctx_scope));
 
       if (child->transferred_context) {
             vvp_context_t child_context = child->transferred_context;
@@ -9759,17 +9753,18 @@ static void do_join(vthread_t thr, vthread_t child)
                   child_context = first_live_context_for_scope(thr->wt_context,
                                                                child_ctx_scope);
 
-            if (child_context && shared_auto_scope) {
-                    /* Same-scope recursive automatic calls must keep the child
-                       frame on the write stack for the matching %free, but the
-                       caller's immediate post-call loads still need to read the
-                       child frame. Point rd_context at the shared child head
-                       until %free removes it from both chains. */
-                  thr->rd_context = child_context;
-                  trace_context_event_("join-rd-share", thr,
-                                       child ? child->parent_scope : 0,
-                                       child_context);
-	            } else if (child_context) {
+              /* Same-scope recursive calls take the generic pop-push
+                 below as well: with nested begin blocks collapsed into
+                 the task frame, caller and callee frames share one owner
+                 scope, so the callee frame must come OFF the write stack
+                 at join — otherwise the post-join output copy-back, which
+                 stores through the write chain by owner scope, hits the
+                 callee frame instead of the caller's. The subsequent
+                 %free finds the callee frame at the head of the read
+                 chain. (The retired "join-rd-share" variant, which kept
+                 the callee frame on both stacks, was only viable when a
+                 per-block frame disambiguated the store target.) */
+	            if (child_context) {
 	                    /* Pop the child context from the write stack, then move that
 	                       same context to the top of the read stack without leaving a
 	                       duplicate stacked link behind. */


### PR DESCRIPTION
## What

Incremental migration of the automatic-variable storage model from the fork's per-block activation-frame design back to the reference (upstream Icarus) single-task-frame model: nested block/fork scopes inside an automatic task/function no longer get their own `%alloc`/`%free` frame — their locals ride the one frame allocated at the call. Frames remain only where lifetimes genuinely require them: recursion call frames, `join_any`/`join_none` fork scopes (detached branches outlive the statement), and automatic blocks with a static parent scope.

Working notes / frame taxonomy: `docs/conformance/auto_var_storage_refactor_notes.md`.

## Why

The per-block-frame model mis-handles a blocking `fork…join` in an automatic task: when one branch ends before a sibling branch reads a parent-scope automatic local, the shared parent context is dropped from the chain the live sibling reads through, and the read returns the element default. Single invocation reproduces (root cause of ivtest `automatic_events2`; writeup in `docs/conformance/test_suite_audit_2026-07-17.md`):

```systemverilog
task automatic w(input byte id, output byte r);
  begin: body
    reg [7:0] acc; acc = id;
    fork
      begin #10 ; end          // branch A ends early
      begin #30 r = acc; end   // branch B reads parent-scope local
    join
  end
endtask
// per-block model: r=0/x ; upstream + this PR: r=a1
```

## Step 1 — collapse automatic named-begin frames (d6e7fed)

- `elaborate.cc`: `PBlock::elaborate` no longer emits `NetAlloc`/`NetFree` for a named begin block whose parent scope is automatic; block-entry variable initializers elaborate inline (upstream form, which the constant-function evaluator also walks directly).
- `vvp/vpi_scope.cc`: compile-time context-index placement climbs past such blocks to the frame-owning ancestor scope. The runtime's `resolve_context_scope` self-adapts (its `nitem > 0` guard).
- `vvp/vthread.cc`: retire the `join-rd-share` special case in `do_join` — with caller and callee frames sharing one owner scope in same-scope recursion, it mis-routed the post-join output copy-back into the callee frame; the generic upstream pop-push protocol handles all cases.
- New regression test `tests/auto_task_frame_sharing_test.sv` (fails on the per-block model).

## Step 2 — collapse blocking `fork…join` frames (edd0b67)

The join type is known only to the front end, so the frame decision is made once in `elab_scope.cc` (new `NetScope::auto_frame` flag) and communicated end to end: `PBlock::elaborate` consults the flag; t-dll exposes `ivl_scope_auto_frame()`; tgt-vvp emits collapsed scopes as `.scope autobegin.shared` / `autofork.shared`; vvp's `compile_scope` parses the marker into `__vpiScope::shares_parent_frame`, which context-item placement consults. `join_any`/`join_none` fork scopes keep plain `autofork` and their `%alloc`/`%free`.

**ivtest wins:** `automatic_events`, `automatic_events2`, `automatic_events3` move from NI to passing normal tests; `automatic_task2`, `automatic_task3`, `recursive_task` move from Failed to passing.

## Planned next steps (same PR or follow-up)

- Begin retiring the per-block-frame heuristic layer in `vvp/vthread.cc` (owner/refcount maps, scoped chain search, sanitize/recovery paths) where the collapsed model makes it dead, keeping the retain-on-detach mechanism that supports detached forks in automatic scopes.

Note: this supersedes part of the rationale of #78 (fork-scope elision for unnamed blocking forks) — collapse generalizes elision.

## Validation (all four gates, before each commit)

| Gate | Baseline | Step 1 | Step 2 |
|---|---|---|---|
| ivtest `vvp_reg.pl` | 2962 pass / 131 fail | identical failure set | 2968 pass / 128 fail — **zero new**, 6 net improvements |
| UVM sweep | 179 / 0 / 1 skip | 180 / 0 / 1 | 180 / 0 / 1 |
| bundled VPI | 81/81 | 81/81 | 81/81 |
| negative | 32/32 | 32/32 | 32/32 |

CI: step-1 commit was green on all 6 jobs (2×Ubuntu, macOS, 3×MSYS2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rw99VxJiHE4VesM8qucMHk